### PR TITLE
Send tool names to upload endpoint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Merge / deployment checklist
 
-- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in otehr repos!
+- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
   - [ ] CodeQL using init/finish actions
   - [ ] 3rd party tool using upload action
 - [ ] Confirm this change is backwards compatible with existing workflows.

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -100,6 +100,7 @@ async function uploadFiles(sarifFiles) {
         if (matrix === "null" || matrix === "") {
             matrix = undefined;
         }
+        const toolNames = util.getToolNames(sarifPayload);
         const payload = JSON.stringify({
             "commit_oid": commitOid,
             "ref": ref,
@@ -108,7 +109,8 @@ async function uploadFiles(sarifFiles) {
             "workflow_run_id": workflowRunID,
             "checkout_uri": checkoutURI,
             "environment": matrix,
-            "started_at": startedAt
+            "started_at": startedAt,
+            "tool_names": toolNames,
         });
         core.info('Uploading results');
         const githubToken = core.getInput('token');

--- a/lib/util.js
+++ b/lib/util.js
@@ -262,3 +262,21 @@ async function reportActionSucceeded(action) {
     await sendStatusReport(await createStatusReport(action, 'success'));
 }
 exports.reportActionSucceeded = reportActionSucceeded;
+/**
+ * Get the array of all the tool names contained in the given sarif contents.
+ *
+ * Returns an array of unique string tool names.
+ */
+function getToolNames(sarifContents) {
+    const sarif = JSON.parse(sarifContents);
+    const toolNames = {};
+    for (const run of sarif.runs || []) {
+        const tool = run.tool || {};
+        const driver = tool.driver || {};
+        if (typeof driver.name === "string" && driver.name.length > 0) {
+            toolNames[driver.name] = true;
+        }
+    }
+    return Object.keys(toolNames);
+}
+exports.getToolNames = getToolNames;

--- a/src/testdata/tool-names.sarif
+++ b/src/testdata/tool-names.sarif
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeQL command-line toolchain"
+        }
+      }
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeQL command-line toolchain"
+        }
+      }
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "ESLint"
+        }
+      }
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": ""
+        }
+      }
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": null
+        }
+      }
+    }
+  ]
+}

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -98,6 +98,8 @@ async function uploadFiles(sarifFiles: string[]) {
             matrix = undefined;
         }
 
+        const toolNames = util.getToolNames(sarifPayload);
+
         const payload = JSON.stringify({
             "commit_oid": commitOid,
             "ref": ref,
@@ -106,7 +108,8 @@ async function uploadFiles(sarifFiles: string[]) {
             "workflow_run_id": workflowRunID,
             "checkout_uri": checkoutURI,
             "environment": matrix,
-            "started_at": startedAt
+            "started_at": startedAt,
+            "tool_names": toolNames,
         });
 
         core.info('Uploading results');

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,0 +1,9 @@
+import * as fs from 'fs';
+
+import * as util from './util';
+
+test('getToolNames', () => {
+  const input = fs.readFileSync(__dirname + '/testdata/tool-names.sarif', 'utf8')
+  const toolNames = util.getToolNames(input);
+  expect(toolNames).toStrictEqual(["CodeQL command-line toolchain", "ESLint"])
+})

--- a/src/util.ts
+++ b/src/util.ts
@@ -293,3 +293,23 @@ export async function reportActionFailed(action: string, cause?: string, excepti
 export async function reportActionSucceeded(action: string) {
     await sendStatusReport(await createStatusReport(action, 'success'));
 }
+
+/**
+ * Get the array of all the tool names contained in the given sarif contents.
+ *
+ * Returns an array of unique string tool names.
+ */
+export function getToolNames(sarifContents: string): string[] {
+    const sarif = JSON.parse(sarifContents);
+    const toolNames = {};
+
+    for (const run of sarif.runs || []) {
+        const tool = run.tool || {};
+        const driver = tool.driver || {};
+        if (typeof driver.name === "string" && driver.name.length > 0) {
+            toolNames[driver.name] = true;
+        }
+    }
+
+    return Object.keys(toolNames);
+}


### PR DESCRIPTION
This pull request sends an array of all the tool names included in the sarif files to the upload endpoint.

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in otehr repos!
  - [ ] CodeQL using init/finish actions
  - [ ] 3rd party tool using upload action
- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.