### PR TITLE
Error on queries with missing/multiple languages

### DIFF
--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -73,12 +73,12 @@ async function resolveQueryLanguages(codeqlCmd, config) {
         const noDeclaredLanguage = resolveQueriesOutputObject.noDeclaredLanguage;
         const noDeclaredLanguageQueries = Object.keys(noDeclaredLanguage);
         if (noDeclaredLanguageQueries.length !== 0) {
-            core.warning('Some queries do not declare a language:\n' + noDeclaredLanguageQueries.join('\n'));
+            throw new Error('Some queries do not declare a language, their qlpack.yml file is missing or is invalid');
         }
         const multipleDeclaredLanguages = resolveQueriesOutputObject.multipleDeclaredLanguages;
         const multipleDeclaredLanguagesQueries = Object.keys(multipleDeclaredLanguages);
         if (multipleDeclaredLanguagesQueries.length !== 0) {
-            core.warning('Some queries declare multiple languages:\n' + multipleDeclaredLanguagesQueries.join('\n'));
+            throw new Error('Some queries declare multiple languages, their qlpack.yml file is missing or is invalid');
         }
     }
     return res;

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -82,13 +82,13 @@ async function resolveQueryLanguages(codeqlCmd: string, config: configUtils.Conf
     const noDeclaredLanguage = resolveQueriesOutputObject.noDeclaredLanguage;
     const noDeclaredLanguageQueries = Object.keys(noDeclaredLanguage);
     if (noDeclaredLanguageQueries.length !== 0) {
-      core.warning('Some queries do not declare a language:\n' + noDeclaredLanguageQueries.join('\n'));
+      throw new Error('Some queries do not declare a language, their qlpack.yml file is missing or is invalid');
     }
 
     const multipleDeclaredLanguages = resolveQueriesOutputObject.multipleDeclaredLanguages;
     const multipleDeclaredLanguagesQueries = Object.keys(multipleDeclaredLanguages);
     if (multipleDeclaredLanguagesQueries.length !== 0) {
-      core.warning('Some queries declare multiple languages:\n' + multipleDeclaredLanguagesQueries.join('\n'));
+      throw new Error('Some queries declare multiple languages, their qlpack.yml file is missing or is invalid');
     }
   }
 


### PR DESCRIPTION
This PR improves the error message for custom queries that don't have a qlpack.yml or one that is invalid, and aborts the execution instead of continuing with analysis and upload.

Here is a workflow run with a missing qlpack: https://github.com/github/codeql-action/actions/runs/91020742
Here is a successful workflow run: https://github.com/github/codeql-action/actions/runs/91018560

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in otehr repos!
  - [x] CodeQL using init/finish actions
  - [ ] 3rd party tool using upload action
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.