### PR TITLE
Disable default queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The CodeQL action should be run on `push` events, and on a `schedule`. `Push` ev
 ### Configuration 
 You may optionally specify additional queries for CodeQL to execute by using a config file. The queries must belong to a [QL pack](https://help.semmle.com/codeql/codeql-cli/reference/qlpack-overview.html) and can be in your repository or any public repository. You can choose a single .ql file, a folder containing multiple .ql files, a .qls [query suite](https://help.semmle.com/codeql/codeql-cli/procedures/query-suites.html) file, or any combination of the above. To use queries from other repositories use the same syntax as when [using an action](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
+You can disable the default queries using `ignore-default-queries: true`.
+
 You can choose to ignore some files or folders from the analysis, or include additional files/folders for analysis. This *only* works for Javascript and Python analysis.
 Identifying potential files for extraction:
 - Scans each folder that's defined as `paths` in turn, traversing subfolders and looking for relevant files.
@@ -97,6 +99,8 @@ A config file looks like this:
 
 ```yaml
 name: "My CodeQL config"
+
+ignore-default-queries: true
 
 queries:
   - name: In-repo queries (Runs the queries located in the my-queries folder of the repo)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A config file looks like this:
 ```yaml
 name: "My CodeQL config"
 
-ignore-default-queries: true
+disable-default-queries: true
 
 queries:
   - name: In-repo queries (Runs the queries located in the my-queries folder of the repo)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The CodeQL action should be run on `push` events, and on a `schedule`. `Push` ev
 ### Configuration 
 You may optionally specify additional queries for CodeQL to execute by using a config file. The queries must belong to a [QL pack](https://help.semmle.com/codeql/codeql-cli/reference/qlpack-overview.html) and can be in your repository or any public repository. You can choose a single .ql file, a folder containing multiple .ql files, a .qls [query suite](https://help.semmle.com/codeql/codeql-cli/procedures/query-suites.html) file, or any combination of the above. To use queries from other repositories use the same syntax as when [using an action](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses).
 
-You can disable the default queries using `ignore-default-queries: true`.
+You can disable the default queries using `disable-default-queries: true`.
 
 You can choose to ignore some files or folders from the analysis, or include additional files/folders for analysis. This *only* works for Javascript and Python analysis.
 Identifying potential files for extraction:

--- a/lib/config-utils.js
+++ b/lib/config-utils.js
@@ -23,7 +23,7 @@ exports.ExternalQuery = ExternalQuery;
 class Config {
     constructor() {
         this.name = "";
-        this.ignoreDefaultQueries = false;
+        this.disableDefaultQueries = false;
         this.additionalQueries = [];
         this.externalQueries = [];
         this.pathsIgnore = [];
@@ -76,8 +76,8 @@ function initConfig() {
         if (parsedYAML.name && typeof parsedYAML.name === "string") {
             config.name = parsedYAML.name;
         }
-        if (parsedYAML['ignore-default-queries'] && typeof parsedYAML['ignore-default-queries'] === "boolean") {
-            config.ignoreDefaultQueries = parsedYAML['ignore-default-queries'];
+        if (parsedYAML['disable-default-queries'] && typeof parsedYAML['disable-default-queries'] === "boolean") {
+            config.disableDefaultQueries = parsedYAML['disable-default-queries'];
         }
         const queries = parsedYAML.queries;
         if (queries && queries instanceof Array) {

--- a/lib/config-utils.js
+++ b/lib/config-utils.js
@@ -23,6 +23,7 @@ exports.ExternalQuery = ExternalQuery;
 class Config {
     constructor() {
         this.name = "";
+        this.ignoreDefaultQueries = false;
         this.additionalQueries = [];
         this.externalQueries = [];
         this.pathsIgnore = [];
@@ -74,6 +75,9 @@ function initConfig() {
         const parsedYAML = yaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
         if (parsedYAML.name && typeof parsedYAML.name === "string") {
             config.name = parsedYAML.name;
+        }
+        if (parsedYAML['ignore-default-queries'] && typeof parsedYAML['ignore-default-queries'] === "boolean") {
+            config.ignoreDefaultQueries = parsedYAML['ignore-default-queries'];
         }
         const queries = parsedYAML.queries;
         if (queries && queries instanceof Array) {

--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -92,7 +92,7 @@ async function runQueries(codeqlCmd, databaseFolder, sarifFolder, config) {
         if (!config.disableDefaultQueries) {
             queries.push(database + '-code-scanning.qls');
         }
-        queries.push(...queriesPerLanguage[database]);
+        queries.push(...(queriesPerLanguage[database] || []));
         const sarifFile = path.join(sarifFolder, database + '.sarif');
         await exec.exec(codeqlCmd, [
             'database',

--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -88,7 +88,11 @@ async function runQueries(codeqlCmd, databaseFolder, sarifFolder, config) {
     const queriesPerLanguage = await resolveQueryLanguages(codeqlCmd, config);
     for (let database of fs.readdirSync(databaseFolder)) {
         core.startGroup('Analyzing ' + database);
-        const additionalQueries = queriesPerLanguage[database] || [];
+        const queries = [];
+        if (!config.ignoreDefaultQueries) {
+            queries.push(database + '-code-scanning.qls');
+        }
+        queries.push(...queriesPerLanguage[database]);
         const sarifFile = path.join(sarifFolder, database + '.sarif');
         await exec.exec(codeqlCmd, [
             'database',
@@ -97,8 +101,7 @@ async function runQueries(codeqlCmd, databaseFolder, sarifFolder, config) {
             '--format=sarif-latest',
             '--output=' + sarifFile,
             '--no-sarif-add-snippets',
-            database + '-code-scanning.qls',
-            ...additionalQueries,
+            ...queries
         ]);
         core.debug('SARIF results for database ' + database + ' created at "' + sarifFile + '"');
         core.endGroup();

--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -89,7 +89,7 @@ async function runQueries(codeqlCmd, databaseFolder, sarifFolder, config) {
     for (let database of fs.readdirSync(databaseFolder)) {
         core.startGroup('Analyzing ' + database);
         const queries = [];
-        if (!config.ignoreDefaultQueries) {
+        if (!config.disableDefaultQueries) {
             queries.push(database + '-code-scanning.qls');
         }
         queries.push(...queriesPerLanguage[database]);

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -17,6 +17,7 @@ export class ExternalQuery {
 
 export class Config {
     public name = "";
+    public ignoreDefaultQueries = false;
     public additionalQueries: string[] = [];
     public externalQueries: ExternalQuery[] = [];
     public pathsIgnore: string[] = [];
@@ -79,6 +80,10 @@ function initConfig(): Config {
 
         if (parsedYAML.name && typeof parsedYAML.name === "string") {
             config.name = parsedYAML.name;
+        }
+
+        if (parsedYAML['ignore-default-queries'] && typeof parsedYAML['ignore-default-queries'] === "boolean") {
+            config.ignoreDefaultQueries = parsedYAML['ignore-default-queries'];
         }
 
         const queries = parsedYAML.queries;

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -17,7 +17,7 @@ export class ExternalQuery {
 
 export class Config {
     public name = "";
-    public ignoreDefaultQueries = false;
+    public disableDefaultQueries = false;
     public additionalQueries: string[] = [];
     public externalQueries: ExternalQuery[] = [];
     public pathsIgnore: string[] = [];
@@ -82,8 +82,8 @@ function initConfig(): Config {
             config.name = parsedYAML.name;
         }
 
-        if (parsedYAML['ignore-default-queries'] && typeof parsedYAML['ignore-default-queries'] === "boolean") {
-            config.ignoreDefaultQueries = parsedYAML['ignore-default-queries'];
+        if (parsedYAML['disable-default-queries'] && typeof parsedYAML['disable-default-queries'] === "boolean") {
+            config.disableDefaultQueries = parsedYAML['disable-default-queries'];
         }
 
         const queries = parsedYAML.queries;

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -102,7 +102,12 @@ async function runQueries(codeqlCmd: string, databaseFolder: string, sarifFolder
   for (let database of fs.readdirSync(databaseFolder)) {
     core.startGroup('Analyzing ' + database);
 
-    const additionalQueries = queriesPerLanguage[database] || [];
+    const queries: string[] = [];
+    if (!config.ignoreDefaultQueries) {
+      queries.push(database + '-code-scanning.qls');
+    }
+    queries.push(...queriesPerLanguage[database]);
+
     const sarifFile = path.join(sarifFolder, database + '.sarif');
 
     await exec.exec(codeqlCmd, [
@@ -112,8 +117,7 @@ async function runQueries(codeqlCmd: string, databaseFolder: string, sarifFolder
       '--format=sarif-latest',
       '--output=' + sarifFile,
       '--no-sarif-add-snippets',
-      database + '-code-scanning.qls',
-      ...additionalQueries,
+      ...queries
     ]);
 
     core.debug('SARIF results for database ' + database + ' created at "' + sarifFile + '"');

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -103,7 +103,7 @@ async function runQueries(codeqlCmd: string, databaseFolder: string, sarifFolder
     core.startGroup('Analyzing ' + database);
 
     const queries: string[] = [];
-    if (!config.ignoreDefaultQueries) {
+    if (!config.disableDefaultQueries) {
       queries.push(database + '-code-scanning.qls');
     }
     queries.push(...queriesPerLanguage[database]);

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -106,7 +106,7 @@ async function runQueries(codeqlCmd: string, databaseFolder: string, sarifFolder
     if (!config.disableDefaultQueries) {
       queries.push(database + '-code-scanning.qls');
     }
-    queries.push(...queriesPerLanguage[database]);
+    queries.push(...(queriesPerLanguage[database] || []));
 
     const sarifFile = path.join(sarifFolder, database + '.sarif');
 


### PR DESCRIPTION
This PR adds an option for disabling the queries we run default.

A run without the `ignore-default-queries` set, it runs all the queries: https://github.com/github/codeql-action/runs/629305743?check_suite_focus=true
A run with `ignore-default-queries: false`, it runs all the queries: https://github.com/github/codeql-action/runs/629307092?check_suite_focus=true
A run with `ignore-default-queries: true` it only runs the custom queries: https://github.com/github/codeql-action/runs/629310667?check_suite_focus=true

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in otehr repos!
  - [x] CodeQL using init/finish actions
  - [x] 3rd party tool using upload action
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.