### PR TITLE
Improve errors & warnings in autobuild

### DIFF
--- a/lib/autobuild.js
+++ b/lib/autobuild.js
@@ -48,13 +48,13 @@ async function run() {
         core.endGroup();
     }
     catch (error) {
-        core.setFailed(error.message);
+        core.setFailed("We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps.  " + error.message);
         await util.reportActionFailed('autobuild', error.message, error.stack);
         return;
     }
     await util.reportActionSucceeded('autobuild');
 }
 run().catch(e => {
-    core.setFailed("We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. codeql/autobuild action failed.  " + e);
+    core.setFailed("autobuild action failed.  " + e);
     console.log(e);
 });

--- a/lib/autobuild.js
+++ b/lib/autobuild.js
@@ -22,12 +22,16 @@ async function run() {
         // We want pick the dominant language in the repo from the ones we're able to build
         // The languages are sorted in order specified by user or by lines of code if we got
         // them from the GitHub API, so try to build the first language on the list.
-        const language = (_a = process.env[sharedEnv.CODEQL_ACTION_TRACED_LANGUAGES]) === null || _a === void 0 ? void 0 : _a.split(',')[0];
+        const autobuildLanguages = ((_a = process.env[sharedEnv.CODEQL_ACTION_TRACED_LANGUAGES]) === null || _a === void 0 ? void 0 : _a.split(',')) || [];
+        const language = autobuildLanguages[0];
         if (!language) {
             core.info("None of the languages in this project require extra build steps");
             return;
         }
         core.debug(`Detected dominant traced language: ${language}`);
+        if (autobuildLanguages.length > 1) {
+            core.warning(`We will only automatically build ${language} code. If you wish to scan ${autobuildLanguages.slice(1).join(' and ')}, you must replace this block with custom build steps.`);
+        }
         core.startGroup(`Attempting to automatically build ${language} code`);
         // TODO: share config accross actions better via env variables
         const codeqlCmd = util.getRequiredEnvParam(sharedEnv.CODEQL_ACTION_CMD);
@@ -51,6 +55,6 @@ async function run() {
     await util.reportActionSucceeded('autobuild');
 }
 run().catch(e => {
-    core.setFailed("autobuild action failed: " + e);
+    core.setFailed("We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. codeql/autobuild action failed.  " + e);
     console.log(e);
 });

--- a/src/autobuild.ts
+++ b/src/autobuild.ts
@@ -49,7 +49,7 @@ async function run() {
     core.endGroup();
 
   } catch (error) {
-    core.setFailed(error.message);
+    core.setFailed("We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps.  " + error.message);
     await util.reportActionFailed('autobuild', error.message, error.stack);
     return;
   }
@@ -58,6 +58,6 @@ async function run() {
 }
 
 run().catch(e => {
-  core.setFailed("We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. codeql/autobuild action failed.  " + e);
+  core.setFailed("autobuild action failed.  " + e);
   console.log(e);
 });

--- a/src/autobuild.ts
+++ b/src/autobuild.ts
@@ -15,7 +15,8 @@ async function run() {
     // We want pick the dominant language in the repo from the ones we're able to build
     // The languages are sorted in order specified by user or by lines of code if we got
     // them from the GitHub API, so try to build the first language on the list.
-    const language = process.env[sharedEnv.CODEQL_ACTION_TRACED_LANGUAGES]?.split(',')[0];
+    const autobuildLanguages = process.env[sharedEnv.CODEQL_ACTION_TRACED_LANGUAGES]?.split(',') || [];
+    const language = autobuildLanguages[0];
 
     if (!language) {
       core.info("None of the languages in this project require extra build steps");
@@ -23,6 +24,10 @@ async function run() {
     }
 
     core.debug(`Detected dominant traced language: ${language}`);
+
+    if (autobuildLanguages.length > 1) {
+      core.warning(`We will only automatically build ${language} code. If you wish to scan ${autobuildLanguages.slice(1).join(' and ')}, you must replace this block with custom build steps.`);
+    }
 
     core.startGroup(`Attempting to automatically build ${language} code`);
     // TODO: share config accross actions better via env variables
@@ -53,6 +58,6 @@ async function run() {
 }
 
 run().catch(e => {
-  core.setFailed("autobuild action failed: " + e);
+  core.setFailed("We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. codeql/autobuild action failed.  " + e);
   console.log(e);
 });


### PR DESCRIPTION
This adds better messaging to tell the user what languages we aren't autobuilding and prompts them to replace this action with custom build steps if we do fail.

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - [ ] CodeQL using init/finish actions
  - [ ] 3rd party tool using upload action
- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
