### PR TITLE
Add retrying to the upload

### DIFF
--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -83,6 +83,12 @@ async function uploadPayload(payload) {
             // Sleep for the backoff period
             await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
         }
+        else if (res.message.statusCode === 500) {
+            // If the upload fails with 500 then we assume it is a temporary problem
+            // with turbo-scan and not an error that the user has caused or can fix.
+            // We avoid marking the job as failed to avoid breaking CI workflows.
+            core.error('Upload failed (' + requestID + '): ' + await res.readBody());
+        }
         else {
             core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
         }

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -55,7 +55,7 @@ function combineSarifFiles(sarifFiles) {
 }
 exports.combineSarifFiles = combineSarifFiles;
 // Upload the given payload.
-// If the request fails then this will be retry a small number of times.
+// If the request fails then this will retry a small number of times.
 async function uploadPayload(payload) {
     core.info('Uploading results');
     const githubToken = core.getInput('token');

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -93,7 +93,7 @@ async function uploadPayload(payload) {
         }
         else {
             // If the upload fails with 5xx then we assume it is a temporary problem
-            // with turbo-scan and not an error that the user has caused or can fix.
+            // and not an error that the user has caused or can fix.
             // We avoid marking the job as failed to avoid breaking CI workflows.
             core.error('Upload failed (' + requestID + '): (' + statusCode + ') ' + await res.readBody());
             return;

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -78,15 +78,15 @@ async function uploadPayload(payload) {
         const requestID = res.message.headers["x-github-request-id"];
         // On any other status code that's not 5xx mark the upload as failed
         if (!statusCode || statusCode < 500 || statusCode >= 600) {
-            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+            core.setFailed('Upload failed (' + requestID + '): (' + statusCode + ') ' + await res.readBody());
             return;
         }
         // On a 5xx status code we may retry the request
         if (attempt < backoffPeriods.length) {
             // Log the failure as a warning but don't mark the action as failed yet
             core.warning('Upload attempt (' + (attempt + 1) + ' of ' + (backoffPeriods.length + 1) +
-                ') failed (' + requestID + '). Retrying in ' + backoffPeriods[attempt] + ' seconds: ' +
-                await res.readBody());
+                ') failed (' + requestID + '). Retrying in ' + backoffPeriods[attempt] +
+                ' seconds: (' + statusCode + ') ' + await res.readBody());
             // Sleep for the backoff period
             await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
             continue;
@@ -95,7 +95,7 @@ async function uploadPayload(payload) {
             // If the upload fails with 5xx then we assume it is a temporary problem
             // with turbo-scan and not an error that the user has caused or can fix.
             // We avoid marking the job as failed to avoid breaking CI workflows.
-            core.error('Upload failed (' + requestID + '): ' + await res.readBody());
+            core.error('Upload failed (' + requestID + '): (' + statusCode + ') ' + await res.readBody());
             return;
         }
     }

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -70,11 +70,18 @@ async function uploadPayload(payload) {
     for (let attempt = 0; attempt <= backoffPeriods.length; attempt++) {
         const res = await client.put(url, payload);
         core.debug('response status: ' + res.message.statusCode);
-        if (res.message.statusCode === 202) {
+        const statusCode = res.message.statusCode;
+        if (statusCode === 202) {
             core.info("Successfully uploaded results");
             return;
         }
         const requestID = res.message.headers["x-github-request-id"];
+        // On any other status code that's not 5xx mark the upload as failed
+        if (!statusCode || statusCode < 500 || statusCode >= 600) {
+            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+            return;
+        }
+        // On a 5xx status code we may retry the request
         if (attempt < backoffPeriods.length) {
             // Log the failure as a warning but don't mark the action as failed yet
             core.warning('Upload attempt (' + (attempt + 1) + ' of ' + (backoffPeriods.length + 1) +
@@ -82,15 +89,14 @@ async function uploadPayload(payload) {
                 await res.readBody());
             // Sleep for the backoff period
             await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
+            continue;
         }
-        else if (res.message.statusCode === 500) {
-            // If the upload fails with 500 then we assume it is a temporary problem
+        else {
+            // If the upload fails with 5xx then we assume it is a temporary problem
             // with turbo-scan and not an error that the user has caused or can fix.
             // We avoid marking the job as failed to avoid breaking CI workflows.
             core.error('Upload failed (' + requestID + '): ' + await res.readBody());
-        }
-        else {
-            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+            return;
         }
     }
 }

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -54,6 +54,40 @@ function combineSarifFiles(sarifFiles) {
     return JSON.stringify(combinedSarif);
 }
 exports.combineSarifFiles = combineSarifFiles;
+// Upload the given payload.
+// If the request fails then this will be retry a small number of times.
+async function uploadPayload(payload) {
+    core.info('Uploading results');
+    const githubToken = core.getInput('token');
+    const ph = new auth.BearerCredentialHandler(githubToken);
+    const client = new http.HttpClient('Code Scanning : Upload SARIF', [ph]);
+    const url = 'https://api.github.com/repos/' + process.env['GITHUB_REPOSITORY'] + '/code-scanning/analysis';
+    // Make up to 4 attempts to upload, and sleep for these
+    // number of seconds between each attempt.
+    // We don't want to backoff too much to avoid wasting action
+    // minutes, but just waiting a little bit could maybe help.
+    const backoffPeriods = [1, 5, 15];
+    for (let attempt = 0; attempt <= backoffPeriods.length; attempt++) {
+        const res = await client.put(url, payload);
+        core.debug('response status: ' + res.message.statusCode);
+        if (res.message.statusCode === 202) {
+            core.info("Successfully uploaded results");
+            return;
+        }
+        const requestID = res.message.headers["x-github-request-id"];
+        if (attempt < backoffPeriods.length) {
+            // Log the failure as a warning but don't mark the action as failed yet
+            core.warning('Upload attempt (' + (attempt + 1) + ' of ' + (backoffPeriods.length + 1) +
+                ') failed (' + requestID + '). Retrying in ' + backoffPeriods[attempt] + ' seconds: ' +
+                await res.readBody());
+            // Sleep for the backoff period
+            await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
+        }
+        else {
+            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+        }
+    }
+}
 // Uploads a single sarif file or a directory of sarif files
 // depending on what the path happens to refer to.
 async function upload(input) {
@@ -112,26 +146,8 @@ async function uploadFiles(sarifFiles) {
             "started_at": startedAt,
             "tool_names": toolNames,
         });
-        core.info('Uploading results');
-        const githubToken = core.getInput('token');
-        const ph = new auth.BearerCredentialHandler(githubToken);
-        const client = new http.HttpClient('Code Scanning : Upload SARIF', [ph]);
-        const url = 'https://api.github.com/repos/' + process.env['GITHUB_REPOSITORY'] + '/code-scanning/analysis';
-        const res = await client.put(url, payload);
-        const requestID = res.message.headers["x-github-request-id"];
-        core.debug('response status: ' + res.message.statusCode);
-        if (res.message.statusCode === 500) {
-            // If the upload fails with 500 then we assume it is a temporary problem
-            // with turbo-scan and not an error that the user has caused or can fix.
-            // We avoid marking the job as failed to avoid breaking CI workflows.
-            core.error('Upload failed (' + requestID + '): ' + await res.readBody());
-        }
-        else if (res.message.statusCode !== 202) {
-            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
-        }
-        else {
-            core.info("Successfully uploaded results");
-        }
+        // Make the upload
+        await uploadPayload(payload);
         // Mark that we have made an upload
         fs.writeFileSync(sentinelFile, '');
     }

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -94,7 +94,7 @@ async function uploadPayload(payload) {
 
         } else {
             // If the upload fails with 5xx then we assume it is a temporary problem
-            // with turbo-scan and not an error that the user has caused or can fix.
+            // and not an error that the user has caused or can fix.
             // We avoid marking the job as failed to avoid breaking CI workflows.
             core.error('Upload failed (' + requestID + '): (' + statusCode + ') ' + await res.readBody());
             return;

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -48,7 +48,7 @@ export function combineSarifFiles(sarifFiles: string[]): string {
 }
 
 // Upload the given payload.
-// If the request fails then this will be retry a small number of times.
+// If the request fails then this will retry a small number of times.
 async function uploadPayload(payload) {
     core.info('Uploading results');
 

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -78,7 +78,7 @@ async function uploadPayload(payload) {
 
         // On any other status code that's not 5xx mark the upload as failed
         if (!statusCode || statusCode < 500 || statusCode >= 600) {
-            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+            core.setFailed('Upload failed (' + requestID + '): (' + statusCode + ') ' + await res.readBody());
             return;
         }
 
@@ -86,8 +86,8 @@ async function uploadPayload(payload) {
         if (attempt < backoffPeriods.length) {
             // Log the failure as a warning but don't mark the action as failed yet
             core.warning('Upload attempt (' + (attempt + 1) + ' of ' + (backoffPeriods.length + 1) +
-              ') failed (' + requestID + '). Retrying in ' + backoffPeriods[attempt] + ' seconds: ' +
-              await res.readBody());
+              ') failed (' + requestID + '). Retrying in ' + backoffPeriods[attempt] +
+              ' seconds: (' + statusCode + ') ' + await res.readBody());
             // Sleep for the backoff period
             await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
             continue;
@@ -96,7 +96,7 @@ async function uploadPayload(payload) {
             // If the upload fails with 5xx then we assume it is a temporary problem
             // with turbo-scan and not an error that the user has caused or can fix.
             // We avoid marking the job as failed to avoid breaking CI workflows.
-            core.error('Upload failed (' + requestID + '): ' + await res.readBody());
+            core.error('Upload failed (' + requestID + '): (' + statusCode + ') ' + await res.readBody());
             return;
         }
     }

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -83,6 +83,12 @@ async function uploadPayload(payload) {
             // Sleep for the backoff period
             await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
 
+        } else if (res.message.statusCode === 500) {
+            // If the upload fails with 500 then we assume it is a temporary problem
+            // with turbo-scan and not an error that the user has caused or can fix.
+            // We avoid marking the job as failed to avoid breaking CI workflows.
+            core.error('Upload failed (' + requestID + '): ' + await res.readBody());
+
         } else {
             core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
         }

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -47,6 +47,48 @@ export function combineSarifFiles(sarifFiles: string[]): string {
     return JSON.stringify(combinedSarif);
 }
 
+// Upload the given payload.
+// If the request fails then this will be retry a small number of times.
+async function uploadPayload(payload) {
+    core.info('Uploading results');
+
+    const githubToken = core.getInput('token');
+    const ph: auth.BearerCredentialHandler = new auth.BearerCredentialHandler(githubToken);
+    const client = new http.HttpClient('Code Scanning : Upload SARIF', [ph]);
+    const url = 'https://api.github.com/repos/' + process.env['GITHUB_REPOSITORY'] + '/code-scanning/analysis';
+
+    // Make up to 4 attempts to upload, and sleep for these
+    // number of seconds between each attempt.
+    // We don't want to backoff too much to avoid wasting action
+    // minutes, but just waiting a little bit could maybe help.
+    const backoffPeriods = [1, 5, 15];
+
+    for (let attempt = 0; attempt <= backoffPeriods.length; attempt++) {
+
+        const res: http.HttpClientResponse = await client.put(url, payload);
+        core.debug('response status: ' + res.message.statusCode);
+
+        if (res.message.statusCode === 202) {
+            core.info("Successfully uploaded results");
+            return;
+        }
+
+        const requestID = res.message.headers["x-github-request-id"];
+
+        if (attempt < backoffPeriods.length) {
+            // Log the failure as a warning but don't mark the action as failed yet
+            core.warning('Upload attempt (' + (attempt + 1) + ' of ' + (backoffPeriods.length + 1) +
+              ') failed (' + requestID + '). Retrying in ' + backoffPeriods[attempt] + ' seconds: ' +
+              await res.readBody());
+            // Sleep for the backoff period
+            await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
+
+        } else {
+            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+        }
+    }
+}
+
 // Uploads a single sarif file or a directory of sarif files
 // depending on what the path happens to refer to.
 export async function upload(input: string) {
@@ -112,25 +154,8 @@ async function uploadFiles(sarifFiles: string[]) {
             "tool_names": toolNames,
         });
 
-        core.info('Uploading results');
-        const githubToken = core.getInput('token');
-        const ph: auth.BearerCredentialHandler = new auth.BearerCredentialHandler(githubToken);
-        const client = new http.HttpClient('Code Scanning : Upload SARIF', [ph]);
-        const url = 'https://api.github.com/repos/' + process.env['GITHUB_REPOSITORY'] + '/code-scanning/analysis';
-        const res: http.HttpClientResponse = await client.put(url, payload);
-        const requestID = res.message.headers["x-github-request-id"];
-
-        core.debug('response status: ' + res.message.statusCode);
-        if (res.message.statusCode === 500) {
-            // If the upload fails with 500 then we assume it is a temporary problem
-            // with turbo-scan and not an error that the user has caused or can fix.
-            // We avoid marking the job as failed to avoid breaking CI workflows.
-            core.error('Upload failed (' + requestID + '): ' + await res.readBody());
-        } else if (res.message.statusCode !== 202) {
-            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
-        } else {
-            core.info("Successfully uploaded results");
-        }
+        // Make the upload
+        await uploadPayload(payload);
 
         // Mark that we have made an upload
         fs.writeFileSync(sentinelFile, '');

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -68,13 +68,21 @@ async function uploadPayload(payload) {
         const res: http.HttpClientResponse = await client.put(url, payload);
         core.debug('response status: ' + res.message.statusCode);
 
-        if (res.message.statusCode === 202) {
+        const statusCode = res.message.statusCode;
+        if (statusCode === 202) {
             core.info("Successfully uploaded results");
             return;
         }
 
         const requestID = res.message.headers["x-github-request-id"];
 
+        // On any other status code that's not 5xx mark the upload as failed
+        if (!statusCode || statusCode < 500 || statusCode >= 600) {
+            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+            return;
+        }
+
+        // On a 5xx status code we may retry the request
         if (attempt < backoffPeriods.length) {
             // Log the failure as a warning but don't mark the action as failed yet
             core.warning('Upload attempt (' + (attempt + 1) + ' of ' + (backoffPeriods.length + 1) +
@@ -82,15 +90,14 @@ async function uploadPayload(payload) {
               await res.readBody());
             // Sleep for the backoff period
             await new Promise(r => setTimeout(r, backoffPeriods[attempt] * 1000));
+            continue;
 
-        } else if (res.message.statusCode === 500) {
-            // If the upload fails with 500 then we assume it is a temporary problem
+        } else {
+            // If the upload fails with 5xx then we assume it is a temporary problem
             // with turbo-scan and not an error that the user has caused or can fix.
             // We avoid marking the job as failed to avoid breaking CI workflows.
             core.error('Upload failed (' + requestID + '): ' + await res.readBody());
-
-        } else {
-            core.setFailed('Upload failed (' + requestID + '): ' + await res.readBody());
+            return;
         }
     }
 }


### PR DESCRIPTION
This should make the upload retry a few times and with a small amount of delay between attempts. Hopefully this will help get over very minor issues, though if there's a larger outage of github lasting more than a few seconds then it won't be able to help.

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - I created branches to simulate various failure methods.
    - `upload_retry` where everything is normal
      - [x] CodeQL using init/analyze actions - https://github.com/Anthophila/test-electron/actions/runs/92974577
      - [x] 3rd party tool using upload action - https://github.com/Anthophila/test-electron/actions/runs/92974579
    - `upload_retry_error` where all attempts fail
      - In the logs you can see the final error message and that it retries with the expected delays.
      - [x] CodeQL using init/analyze actions - https://github.com/Anthophila/test-electron/actions/runs/92961566
      - [x] 3rd party tool using upload action - https://github.com/Anthophila/test-electron/actions/runs/92961572
    - `upload_retry_partial_error` where the first attempt fails
      - [x] CodeQL using init/analyze actions - https://github.com/Anthophila/test-electron/actions/runs/92971009
      - [x] 3rd party tool using upload action - https://github.com/Anthophila/test-electron/actions/runs/92971012
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
