### PR TITLE
Improve feedback about what files are being uploaded in the upload-sarif Action.

### DIFF
--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -85,7 +85,7 @@ async function uploadFiles(sarifFiles) {
         const ref = util.getRequiredEnvParam('GITHUB_REF'); // it's in the form "refs/heads/master"
         const analysisName = util.getRequiredEnvParam('GITHUB_WORKFLOW');
         const startedAt = process.env[sharedEnv.CODEQL_ACTION_STARTED_AT];
-        core.debug("Uploading sarif files: " + JSON.stringify(sarifFiles));
+        core.info("Uploading sarif files: " + JSON.stringify(sarifFiles));
         let sarifPayload = combineSarifFiles(sarifFiles);
         sarifPayload = fingerprints.addFingerprints(sarifPayload);
         const zipped_sarif = zlib_1.default.gzipSync(sarifPayload).toString('base64');

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -61,6 +61,9 @@ async function upload(input) {
         const sarifFiles = fs.readdirSync(input)
             .filter(f => f.endsWith(".sarif"))
             .map(f => path.resolve(input, f));
+        if (sarifFiles.length === 0) {
+            core.setFailed("No SARIF files found to upload in \"" + input + "\".");
+        }
         await uploadFiles(sarifFiles);
     }
     else {

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -63,6 +63,7 @@ async function upload(input) {
             .map(f => path.resolve(input, f));
         if (sarifFiles.length === 0) {
             core.setFailed("No SARIF files found to upload in \"" + input + "\".");
+            return;
         }
         await uploadFiles(sarifFiles);
     }

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -56,6 +56,7 @@ export async function upload(input: string) {
             .map(f => path.resolve(input, f));
         if (sarifFiles.length === 0) {
             core.setFailed("No SARIF files found to upload in \"" + input + "\".");
+            return;
         }
         await uploadFiles(sarifFiles);
     } else {

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -54,6 +54,9 @@ export async function upload(input: string) {
         const sarifFiles = fs.readdirSync(input)
             .filter(f => f.endsWith(".sarif"))
             .map(f => path.resolve(input, f));
+        if (sarifFiles.length === 0) {
+            core.setFailed("No SARIF files found to upload in \"" + input + "\".");
+        }
         await uploadFiles(sarifFiles);
     } else {
         await uploadFiles([input]);

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -79,7 +79,7 @@ async function uploadFiles(sarifFiles: string[]) {
         const analysisName = util.getRequiredEnvParam('GITHUB_WORKFLOW');
         const startedAt = process.env[sharedEnv.CODEQL_ACTION_STARTED_AT];
 
-        core.debug("Uploading sarif files: " + JSON.stringify(sarifFiles));
+        core.info("Uploading sarif files: " + JSON.stringify(sarifFiles));
         let sarifPayload = combineSarifFiles(sarifFiles);
         sarifPayload = fingerprints.addFingerprints(sarifPayload);
 


### PR DESCRIPTION
This pull request makes two changes designed to assist debugging the upload action. Firstly it increases the log level of the message listing which SARIF files are being uploaded, which is a very useful piece of information.

Secondly it fails the action if an attempt is made to upload a folder with no SARIF files in, since this is very likely to be a mistake.

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - [x] CodeQL using init/analyze actions (N/A)
  - [x] 3rd party tool using upload action
    - Successful upload here: https://github.com/Anthophila/chrisgavin/runs/636104360?check_suite_focus=true
    - Failed upload here: https://github.com/Anthophila/chrisgavin/actions/runs/92977473
- [x] Confirm this change is backwards compatible with existing workflows. (Yes, though workflows that try to upload an empty directory will now fail.)
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary. (N/A)
