### PR TITLE
Create undeclared-action-input.ql

### DIFF
--- a/queries/undeclared-action-input.ql
+++ b/queries/undeclared-action-input.ql
@@ -36,7 +36,7 @@ class ActionDeclaration extends File {
 }
 
 Expr getAFunctionChildExpr(Function f) {
-  result = f.getBody().getAChildStmt*().getAChildExpr*()
+  result.getContainer() = f
 }
 
 /*
@@ -44,6 +44,8 @@ Expr getAFunctionChildExpr(Function f) {
  */
 Function calledBy(Function f) {
   result = getAFunctionChildExpr(f).(InvokeExpr).getResolvedCallee()
+  or
+  result.getEnclosingContainer() = f // assume outer function causes inner function to be called
 }
 
 class GetInputMethodCallExpr extends MethodCallExpr {

--- a/queries/undeclared-action-input.ql
+++ b/queries/undeclared-action-input.ql
@@ -1,0 +1,63 @@
+/**
+ * @name Undeclared action input
+ * @description Code tries to use an input parameter that is not defined for this action.
+   Perhaps this code is shared by multiple actions.
+ * @kind problem
+ * @problem.severity error
+ * @id javascript/codeql-action/undeclared-action-input
+ */
+
+import javascript
+
+class ActionDeclaration extends File {
+  ActionDeclaration() {
+    getRelativePath().matches("%/action.yml")
+  }
+
+  string getName() {
+    result = getRelativePath().regexpCapture("(.*)/action.yml", 1)
+  }
+
+  YAMLDocument getRootNode() {
+    result.getFile() = this
+  }
+
+  string getAnInput() {
+    result = getRootNode().(YAMLMapping).lookup("inputs").(YAMLMapping).getKey(_).(YAMLString).getValue()
+  }
+
+  FunctionDeclStmt getEntrypoint() {
+    result.getFile().getRelativePath() = getRootNode().
+      (YAMLMapping).lookup("runs").
+      (YAMLMapping).lookup("main").
+      (YAMLString).getValue().regexpReplaceAll("\\.\\./lib/(.*)\\.js", "src/$1.ts") and
+    result.getName() = "run"
+  }
+}
+
+Expr getAFunctionChildExpr(Function f) {
+  result = f.getBody().getAChildStmt*().getAChildExpr*()
+}
+
+/*
+ * Result is a function that is called from the body of the given function `f`
+ */
+Function calledBy(Function f) {
+  result = getAFunctionChildExpr(f).(InvokeExpr).getResolvedCallee()
+}
+
+class GetInputMethodCallExpr extends MethodCallExpr {
+  GetInputMethodCallExpr() {
+    getMethodName() = "getInput"
+  }
+
+  string getInputName() {
+    result = getArgument(0).(StringLiteral).getValue()
+  }
+}
+
+from ActionDeclaration action, GetInputMethodCallExpr getInputCall, string inputName
+where getAFunctionChildExpr(calledBy*(action.getEntrypoint())) = getInputCall and
+  inputName = getInputCall.getInputName() and
+  not inputName = action.getAnInput()
+select getInputCall, "The $@ input is not defined for the $@ action", inputName, inputName, action, action.getName()


### PR DESCRIPTION
Adds a new CodeQL query for detecting when we are referencing action input parameters (by `core.getInput(...)`) from actions where those inputs are not defined. This can easily happen when code is reused between actions, and affects us more than most people because we have multiple actions in the same repo.

The alerts are visible at https://github.com/github/codeql-action/security/code-scanning?query=ref%3Arefs%2Fheads%2Fundeclared-action-input

All the alerts appear to be true positives to me and it's found all the alerts I expected it to find.

(Here's a screenshot for posterity)
![results2](https://user-images.githubusercontent.com/3749000/80970929-dd819000-8e13-11ea-8d88-0eee4bdd66e5.png)
