### PR TITLE
Use tmp dir for external queries test

### DIFF
--- a/lib/external-queries.js
+++ b/lib/external-queries.js
@@ -11,8 +11,9 @@ const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
+const util = __importStar(require("./util"));
 async function checkoutExternalQueries(config) {
-    const folder = process.env['RUNNER_WORKSPACE'] || '/tmp/codeql-action';
+    const folder = util.getRequiredEnvParam('RUNNER_WORKSPACE');
     for (const externalQuery of config.externalQueries) {
         core.info('Checking out ' + externalQuery.repository);
         const checkoutLocation = path.join(folder, externalQuery.repository);

--- a/lib/util.js
+++ b/lib/util.js
@@ -15,6 +15,8 @@ const http = __importStar(require("@actions/http-client"));
 const auth = __importStar(require("@actions/http-client/auth"));
 const octokit = __importStar(require("@octokit/rest"));
 const console_log_level_1 = __importDefault(require("console-log-level"));
+const fs = __importStar(require("fs"));
+const os = __importStar(require("os"));
 const path = __importStar(require("path"));
 const sharedEnv = __importStar(require("./shared-environment"));
 /**
@@ -280,3 +282,11 @@ function getToolNames(sarifContents) {
     return Object.keys(toolNames);
 }
 exports.getToolNames = getToolNames;
+// Creates a random temporary directory, runs the given body, and then deletes the directory.
+// Mostly intended for use within tests.
+async function withTmpDir(body) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeql-action-'));
+    await body(tmpDir);
+    fs.rmdirSync(tmpDir, { recursive: true });
+}
+exports.withTmpDir = withTmpDir;

--- a/src/external-queries.test.ts
+++ b/src/external-queries.test.ts
@@ -3,15 +3,19 @@ import * as path from "path";
 
 import * as configUtils from "./config-utils";
 import * as externalQueries from "./external-queries";
+import * as util from "./util";
 
 test("checkoutExternalQueries", async () => {
     let config = new configUtils.Config();
     config.externalQueries = [
         new configUtils.ExternalQuery("github/codeql-go", "df4c6869212341b601005567381944ed90906b6b"),
     ];
-    await externalQueries.checkoutExternalQueries(config);
 
-    let destination = process.env["RUNNER_WORKSPACE"] || "/tmp/codeql-action/";
-    // COPYRIGHT file existed in df4c6869212341b601005567381944ed90906b6b but not in master
-    expect(fs.existsSync(path.join(destination, "github", "codeql-go", "COPYRIGHT"))).toBeTruthy();
+    await util.withTmpDir(async tmpDir => {
+        process.env["RUNNER_WORKSPACE"] = tmpDir;
+        await externalQueries.checkoutExternalQueries(config);
+
+        // COPYRIGHT file existed in df4c6869212341b601005567381944ed90906b6b but not in master
+        expect(fs.existsSync(path.join(tmpDir, "github", "codeql-go", "COPYRIGHT"))).toBeTruthy();
+    });
 });

--- a/src/external-queries.ts
+++ b/src/external-queries.ts
@@ -4,9 +4,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import * as configUtils from './config-utils';
+import * as util from './util';
 
 export async function checkoutExternalQueries(config: configUtils.Config) {
-  const folder = process.env['RUNNER_WORKSPACE'] || '/tmp/codeql-action';
+  const folder = util.getRequiredEnvParam('RUNNER_WORKSPACE');
 
   for (const externalQuery of config.externalQueries) {
     core.info('Checking out ' + externalQuery.repository);

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,8 @@ import * as http from '@actions/http-client';
 import * as auth from '@actions/http-client/auth';
 import * as octokit from '@octokit/rest';
 import consoleLogLevel from 'console-log-level';
+import * as fs from "fs";
+import * as os from 'os';
 import * as path from 'path';
 
 import * as sharedEnv from './shared-environment';
@@ -312,4 +314,12 @@ export function getToolNames(sarifContents: string): string[] {
     }
 
     return Object.keys(toolNames);
+}
+
+// Creates a random temporary directory, runs the given body, and then deletes the directory.
+// Mostly intended for use within tests.
+export async function withTmpDir(body: (tmpDir: string) => Promise<void>) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeql-action-'));
+    await body(tmpDir);
+    fs.rmdirSync(tmpDir, { recursive: true });
 }


### PR DESCRIPTION
The external queries tests run in a fixed directory. This is arguably fine when run as part of CI, but if the tests are run multiple times locally then they start to interfere with each other.

To see it's working, you can see in the [test logs](https://github.com/github/codeql-action/runs/645786593)
```
Cloning into '/tmp/codeql-action-1XUxpg/github/codeql-go'
```

This PR creates a random tmp dir for each test run and deletes it when the test is done. I created a shared function for this because I intend to start using it for other tests as well.

Also by populating the `RUNNER_WORKSPACE` env var we can make it required in `checkoutExternalQueries` and this avoids the hardcoded alternative path.

@Daverlo

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - [x] CodeQL using init/analyze actions - https://github.com/Anthophila/test-electron/actions/runs/96083423
  - [x] 3rd party tool using upload action - https://github.com/Anthophila/test-electron/actions/runs/96083425
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
