### PR TITLE
Move and extend licence info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This action runs GitHub's industry-leading static analysis engine, CodeQL, against a repository's source code to find security vulnerabilities. It then automatically uploads the results to GitHub so they can be displayed in the repository's security tab. CodeQL runs an extensible set of [queries](https://github.com/semmle/ql), which have been developed by the community and the [GitHub Security Lab](https://securitylab.github.com/) to find common vulnerabilities in your code.
 
+## License
+
+This project is released under the [MIT License](LICENSE).
+
+The underlying CodeQL CLI, used in this action, is licensed under the [GitHub CodeQL Terms and Conditions](https://securitylab.github.com/tools/codeql/license). As such, this action may be used on open source projects hosted on GitHub, and on  private repositories that are owned by an organisation with GitHub Advanced Security enabled.
+
 ## Usage
 
 To get code scanning results from CodeQL analysis on your repo you can use the following workflow as a template:
@@ -162,7 +168,3 @@ dotnet build /p:UseSharedCompilation=false
 ```
 
 Version 3 does not require the additional flag.
-
-## License
-
-This project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
https://github.slack.com/archives/CP9GMKJCE/p1588758186095600

> We should communicate that the action is free for use on open source, but using CodeQL on private repositories requires GitHub Advanced Security