### PR TITLE
Always report exceptions

### DIFF
--- a/lib/config-utils.js
+++ b/lib/config-utils.js
@@ -71,41 +71,36 @@ function initConfig() {
         core.debug('No configuration file was provided');
         return config;
     }
-    try {
-        const parsedYAML = yaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
-        if (parsedYAML.name && typeof parsedYAML.name === "string") {
-            config.name = parsedYAML.name;
-        }
-        if (parsedYAML['disable-default-queries'] && typeof parsedYAML['disable-default-queries'] === "boolean") {
-            config.disableDefaultQueries = parsedYAML['disable-default-queries'];
-        }
-        const queries = parsedYAML.queries;
-        if (queries && queries instanceof Array) {
-            queries.forEach(query => {
-                if (query.uses && typeof query.uses === "string") {
-                    config.addQuery(query.uses);
-                }
-            });
-        }
-        const pathsIgnore = parsedYAML['paths-ignore'];
-        if (pathsIgnore && pathsIgnore instanceof Array) {
-            pathsIgnore.forEach(path => {
-                if (typeof path === "string") {
-                    config.pathsIgnore.push(path);
-                }
-            });
-        }
-        const paths = parsedYAML.paths;
-        if (paths && paths instanceof Array) {
-            paths.forEach(path => {
-                if (typeof path === "string") {
-                    config.paths.push(path);
-                }
-            });
-        }
+    const parsedYAML = yaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
+    if (parsedYAML.name && typeof parsedYAML.name === "string") {
+        config.name = parsedYAML.name;
     }
-    catch (err) {
-        core.setFailed(err);
+    if (parsedYAML['disable-default-queries'] && typeof parsedYAML['disable-default-queries'] === "boolean") {
+        config.disableDefaultQueries = parsedYAML['disable-default-queries'];
+    }
+    const queries = parsedYAML.queries;
+    if (queries && queries instanceof Array) {
+        queries.forEach(query => {
+            if (query.uses && typeof query.uses === "string") {
+                config.addQuery(query.uses);
+            }
+        });
+    }
+    const pathsIgnore = parsedYAML['paths-ignore'];
+    if (pathsIgnore && pathsIgnore instanceof Array) {
+        pathsIgnore.forEach(path => {
+            if (typeof path === "string") {
+                config.pathsIgnore.push(path);
+            }
+        });
+    }
+    const paths = parsedYAML.paths;
+    if (paths && paths instanceof Array) {
+        paths.forEach(path => {
+            if (typeof path === "string") {
+                config.paths.push(path);
+            }
+        });
     }
     return config;
 }

--- a/lib/finalize-db.js
+++ b/lib/finalize-db.js
@@ -126,7 +126,7 @@ async function run() {
         await runQueries(codeqlCmd, databaseFolder, sarifFolder, config);
         if ('true' === core.getInput('upload')) {
             if (!await upload_lib.upload(sarifFolder)) {
-                await util.reportActionFailed('failed', 'upload');
+                await util.reportActionFailed('finish', 'upload');
                 return;
             }
         }

--- a/lib/setup-tracer.js
+++ b/lib/setup-tracer.js
@@ -205,8 +205,8 @@ async function run() {
         await util.reportActionFailed('init', error.message, error.stack);
         return;
     }
-    core.exportVariable(sharedEnv.CODEQL_ACTION_INIT_COMPLETED, 'true');
     await util.reportActionSucceeded('init');
+    core.exportVariable(sharedEnv.CODEQL_ACTION_INIT_COMPLETED, 'true');
 }
 run().catch(e => {
     core.setFailed("init action failed: " + e);

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -125,55 +125,50 @@ exports.upload = upload;
 async function uploadFiles(sarifFiles) {
     core.startGroup("Uploading results");
     let succeeded = false;
-    try {
-        // Check if an upload has happened before. If so then abort.
-        // This is intended to catch when the finish and upload-sarif actions
-        // are used together, and then the upload-sarif action is invoked twice.
-        const sentinelFile = await getSentinelFilePath();
-        if (fs.existsSync(sentinelFile)) {
-            core.info("Aborting as an upload has already happened from this job");
-            return false;
-        }
-        const commitOid = util.getRequiredEnvParam('GITHUB_SHA');
-        const workflowRunIDStr = util.getRequiredEnvParam('GITHUB_RUN_ID');
-        const ref = util.getRequiredEnvParam('GITHUB_REF'); // it's in the form "refs/heads/master"
-        const analysisName = util.getRequiredEnvParam('GITHUB_WORKFLOW');
-        const startedAt = process.env[sharedEnv.CODEQL_ACTION_STARTED_AT];
-        core.info("Uploading sarif files: " + JSON.stringify(sarifFiles));
-        let sarifPayload = combineSarifFiles(sarifFiles);
-        sarifPayload = fingerprints.addFingerprints(sarifPayload);
-        const zipped_sarif = zlib_1.default.gzipSync(sarifPayload).toString('base64');
-        let checkoutPath = core.getInput('checkout_path');
-        let checkoutURI = file_url_1.default(checkoutPath);
-        const workflowRunID = parseInt(workflowRunIDStr, 10);
-        if (Number.isNaN(workflowRunID)) {
-            core.setFailed('GITHUB_RUN_ID must define a non NaN workflow run ID');
-            return false;
-        }
-        let matrix = core.getInput('matrix');
-        if (matrix === "null" || matrix === "") {
-            matrix = undefined;
-        }
-        const toolNames = util.getToolNames(sarifPayload);
-        const payload = JSON.stringify({
-            "commit_oid": commitOid,
-            "ref": ref,
-            "analysis_name": analysisName,
-            "sarif": zipped_sarif,
-            "workflow_run_id": workflowRunID,
-            "checkout_uri": checkoutURI,
-            "environment": matrix,
-            "started_at": startedAt,
-            "tool_names": toolNames,
-        });
-        // Make the upload
-        succeeded = await uploadPayload(payload);
-        // Mark that we have made an upload
-        fs.writeFileSync(sentinelFile, '');
+    // Check if an upload has happened before. If so then abort.
+    // This is intended to catch when the finish and upload-sarif actions
+    // are used together, and then the upload-sarif action is invoked twice.
+    const sentinelFile = await getSentinelFilePath();
+    if (fs.existsSync(sentinelFile)) {
+        core.info("Aborting as an upload has already happened from this job");
+        return false;
     }
-    catch (error) {
-        core.setFailed(error.message);
+    const commitOid = util.getRequiredEnvParam('GITHUB_SHA');
+    const workflowRunIDStr = util.getRequiredEnvParam('GITHUB_RUN_ID');
+    const ref = util.getRequiredEnvParam('GITHUB_REF'); // it's in the form "refs/heads/master"
+    const analysisName = util.getRequiredEnvParam('GITHUB_WORKFLOW');
+    const startedAt = process.env[sharedEnv.CODEQL_ACTION_STARTED_AT];
+    core.info("Uploading sarif files: " + JSON.stringify(sarifFiles));
+    let sarifPayload = combineSarifFiles(sarifFiles);
+    sarifPayload = fingerprints.addFingerprints(sarifPayload);
+    const zipped_sarif = zlib_1.default.gzipSync(sarifPayload).toString('base64');
+    let checkoutPath = core.getInput('checkout_path');
+    let checkoutURI = file_url_1.default(checkoutPath);
+    const workflowRunID = parseInt(workflowRunIDStr, 10);
+    if (Number.isNaN(workflowRunID)) {
+        core.setFailed('GITHUB_RUN_ID must define a non NaN workflow run ID');
+        return false;
     }
+    let matrix = core.getInput('matrix');
+    if (matrix === "null" || matrix === "") {
+        matrix = undefined;
+    }
+    const toolNames = util.getToolNames(sarifPayload);
+    const payload = JSON.stringify({
+        "commit_oid": commitOid,
+        "ref": ref,
+        "analysis_name": analysisName,
+        "sarif": zipped_sarif,
+        "workflow_run_id": workflowRunID,
+        "checkout_uri": checkoutURI,
+        "environment": matrix,
+        "started_at": startedAt,
+        "tool_names": toolNames,
+    });
+    // Make the upload
+    succeeded = await uploadPayload(payload);
+    // Mark that we have made an upload
+    fs.writeFileSync(sentinelFile, '');
     core.endGroup();
     return succeeded;
 }

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -75,45 +75,41 @@ function initConfig(): Config {
         return config;
     }
 
-    try {
-        const parsedYAML = yaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
+    const parsedYAML = yaml.safeLoad(fs.readFileSync(configFile, 'utf8'));
 
-        if (parsedYAML.name && typeof parsedYAML.name === "string") {
-            config.name = parsedYAML.name;
-        }
+    if (parsedYAML.name && typeof parsedYAML.name === "string") {
+        config.name = parsedYAML.name;
+    }
 
-        if (parsedYAML['disable-default-queries'] && typeof parsedYAML['disable-default-queries'] === "boolean") {
-            config.disableDefaultQueries = parsedYAML['disable-default-queries'];
-        }
+    if (parsedYAML['disable-default-queries'] && typeof parsedYAML['disable-default-queries'] === "boolean") {
+        config.disableDefaultQueries = parsedYAML['disable-default-queries'];
+    }
 
-        const queries = parsedYAML.queries;
-        if (queries && queries instanceof Array) {
-            queries.forEach(query => {
-                if (query.uses && typeof query.uses === "string") {
-                    config.addQuery(query.uses);
-                }
-            });
-        }
+    const queries = parsedYAML.queries;
+    if (queries && queries instanceof Array) {
+        queries.forEach(query => {
+            if (query.uses && typeof query.uses === "string") {
+                config.addQuery(query.uses);
+            }
+        });
+    }
 
-        const pathsIgnore = parsedYAML['paths-ignore'];
-        if (pathsIgnore && pathsIgnore instanceof Array) {
-            pathsIgnore.forEach(path => {
-                if (typeof path === "string") {
-                    config.pathsIgnore.push(path);
-                }
-            });
-        }
+    const pathsIgnore = parsedYAML['paths-ignore'];
+    if (pathsIgnore && pathsIgnore instanceof Array) {
+        pathsIgnore.forEach(path => {
+            if (typeof path === "string") {
+                config.pathsIgnore.push(path);
+            }
+        });
+    }
 
-        const paths = parsedYAML.paths;
-        if (paths && paths instanceof Array) {
-            paths.forEach(path => {
-                if (typeof path === "string") {
-                    config.paths.push(path);
-                }
-            });
-        }
-    } catch (err) {
-        core.setFailed(err);
+    const paths = parsedYAML.paths;
+    if (paths && paths instanceof Array) {
+        paths.forEach(path => {
+            if (typeof path === "string") {
+                config.paths.push(path);
+            }
+        });
     }
 
     return config;

--- a/src/finalize-db.ts
+++ b/src/finalize-db.ts
@@ -151,7 +151,7 @@ async function run() {
 
     if ('true' === core.getInput('upload')) {
       if (!await upload_lib.upload(sarifFolder)) {
-        await util.reportActionFailed('failed', 'upload');
+        await util.reportActionFailed('finish', 'upload');
         return;
       }
     }

--- a/src/setup-tracer.ts
+++ b/src/setup-tracer.ts
@@ -238,8 +238,8 @@ async function run() {
         await util.reportActionFailed('init', error.message, error.stack);
         return;
     }
-    core.exportVariable(sharedEnv.CODEQL_ACTION_INIT_COMPLETED, 'true');
     await util.reportActionSucceeded('init');
+    core.exportVariable(sharedEnv.CODEQL_ACTION_INIT_COMPLETED, 'true');
 }
 
 run().catch(e => {


### PR DESCRIPTION
We currently catch exceptions in a couple of places where it would be better to let them reach the top level where they would be included in the status report from the action.

* Don't catch exceptions during upload lower than the top level
* Don't catch exceptions during config initialization lower than the top level
* Correct the action name passed from the `analyze` action

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - [x] CodeQL using init/analyze actions [action run](https://github.com/Anthophila/test-electron/actions/runs/97180916) :heavy_check_mark: 
  - [x] 3rd party tool using upload action [action run](https://github.com/Anthophila/test-electron/runs/649610588) :heavy_check_mark: 
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
