### PR TITLE
don't fail-fast on integration tests

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   multi-language-repo_test-autodetect-languages:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -28,6 +29,7 @@ jobs:
 
   multi-language-repo_test-custom-queries:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -55,6 +57,7 @@ jobs:
   # Currently is not possible to analyze Go in conjunction with other languages in macos
   multi-language-repo_test-go-custom-queries:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -1,6 +1,6 @@
 name: "Integration Testing"
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   multi-language-repo_test-autodetect-languages:


### PR DESCRIPTION
Aborting the other jobs is unhelpful for determining if the issue is limited to only one operating system. Since the jobs are done mostly in parallel it shouldn't take significantly longer. This will make it use more actions minutes but at our level I think that is acceptable.
