### PR TITLE
upload ref in status report

### DIFF
--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -141,7 +141,7 @@ async function uploadFiles(sarifFiles) {
         }
         const commitOid = util.getRequiredEnvParam('GITHUB_SHA');
         const workflowRunIDStr = util.getRequiredEnvParam('GITHUB_RUN_ID');
-        const ref = util.getRequiredEnvParam('GITHUB_REF'); // it's in the form "refs/heads/master"
+        const ref = util.getRef();
         const analysisKey = await util.getAnalysisKey();
         const analysisName = util.getRequiredEnvParam('GITHUB_WORKFLOW');
         const startedAt = process.env[sharedEnv.CODEQL_ACTION_STARTED_AT];

--- a/lib/util.js
+++ b/lib/util.js
@@ -193,6 +193,14 @@ async function getAnalysisKey() {
 }
 exports.getAnalysisKey = getAnalysisKey;
 /**
+ * Get the ref currently being analyzed.
+ */
+function getRef() {
+    // it's in the form "refs/heads/master"
+    return getRequiredEnvParam('GITHUB_REF');
+}
+exports.getRef = getRef;
+/**
  * Compose a StatusReport.
  *
  * @param actionName The name of the action, e.g. 'init', 'finish', 'upload-sarif'
@@ -202,6 +210,7 @@ exports.getAnalysisKey = getAnalysisKey;
  */
 async function createStatusReport(actionName, status, cause, exception) {
     const commitOid = process.env['GITHUB_SHA'] || '';
+    const ref = getRef();
     const workflowRunIDStr = process.env['GITHUB_RUN_ID'];
     let workflowRunID = -1;
     if (workflowRunIDStr) {
@@ -218,6 +227,7 @@ async function createStatusReport(actionName, status, cause, exception) {
         job_name: jobName,
         languages: languages,
         commit_oid: commitOid,
+        ref: ref,
         action_name: actionName,
         action_oid: "unknown",
         started_at: startedAt,

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -145,7 +145,7 @@ async function uploadFiles(sarifFiles: string[]): Promise<boolean> {
 
         const commitOid = util.getRequiredEnvParam('GITHUB_SHA');
         const workflowRunIDStr = util.getRequiredEnvParam('GITHUB_RUN_ID');
-        const ref = util.getRequiredEnvParam('GITHUB_REF'); // it's in the form "refs/heads/master"
+        const ref = util.getRef();
         const analysisKey = await util.getAnalysisKey();
         const analysisName = util.getRequiredEnvParam('GITHUB_WORKFLOW');
         const startedAt = process.env[sharedEnv.CODEQL_ACTION_STARTED_AT];

--- a/src/util.ts
+++ b/src/util.ts
@@ -200,6 +200,14 @@ export async function getAnalysisKey(): Promise<string> {
     return analysisKey;
 }
 
+/**
+ * Get the ref currently being analyzed.
+ */
+export function getRef(): string {
+    // it's in the form "refs/heads/master"
+    return getRequiredEnvParam('GITHUB_REF');
+}
+
 interface StatusReport {
     "workflow_run_id": number;
     "workflow_name": string;
@@ -207,6 +215,7 @@ interface StatusReport {
     "matrix_vars"?: string;
     "languages": string;
     "commit_oid": string;
+    "ref": string;
     "action_name": string;
     "action_oid": string;
     "started_at": string;
@@ -232,6 +241,7 @@ async function createStatusReport(
     Promise<StatusReport> {
 
     const commitOid = process.env['GITHUB_SHA'] || '';
+    const ref = getRef();
     const workflowRunIDStr = process.env['GITHUB_RUN_ID'];
     let workflowRunID = -1;
     if (workflowRunIDStr) {
@@ -249,6 +259,7 @@ async function createStatusReport(
         job_name: jobName,
         languages: languages,
         commit_oid: commitOid,
+        ref: ref,
         action_name: actionName,
         action_oid: "unknown", // TODO decide if it's possible to fill this in
         started_at: startedAt,


### PR DESCRIPTION
Uploads the current ref in the status reports. We are including this in the final upload already, but we'd also like to have it in the status reports during execution.

Moved the calculation of the ref to a function so it'll be easier to change when we have to add support for pull requests.

@marcogario, @daverlo

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - [x] CodeQL using init/analyze actions
  - [x] 3rd party tool using upload action
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
