### PR TITLE
Fixing sorting of PRs

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -45,8 +45,8 @@ def open_pr(repo, all_commits, short_master_sha, branch_name):
   print('Found ' + str(len(commits_without_pull_requests)) + ' commits not in a pull request')
 
   # Sort PRs and commits by age
-  sorted(pull_requests, key=lambda pr: pr.number)
-  sorted(commits_without_pull_requests, key=lambda c: c.commit.author.date)
+  pull_requests = sorted(pull_requests, key=lambda pr: pr.number)
+  commits_without_pull_requests = sorted(commits_without_pull_requests, key=lambda c: c.commit.author.date)
   
   # Start constructing the body text
   body = 'Merging ' + short_master_sha + ' into ' + LATEST_RELEASE_BRANCH


### PR DESCRIPTION
I made a mistake here as I thought `sorted` updated the list in-place, but that's not true. So the PRs in https://github.com/github/codeql-action/pull/71 weren't sorted as they were inteneded to have been.

I got suspicious as to why I was the conductor, when I think it should have been @alexkappa 

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - [x] CodeQL using init/analyze actions
  - [x] 3rd party tool using upload action
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
