### PR TITLE
Remove `strategy: fail-fast`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ on:
 
 jobs:
   CodeQL-Build:
-
-    strategy:
-      fail-fast: false
-
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Setting `strategy: fail-fast` has no effect unless the workflow is run as part of a matrix build. It controls whether one matrix build failing causes other builds in that same matrix to be aborted. It has no effect within an individual run.

See https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast for more info.

I'm removing this from the suggested usage example because it is unnecessary and misleading.

### Merge / deployment checklist

- Run test builds as necessary. Can be on this repository or elsewhere as needed in order to test the change - please include links to tests in other repos!
  - [x] CodeQL using init/analyze actions
  - [x] 3rd party tool using upload action
- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
