### PR TITLE
Add workflow_dispatch event

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -7,6 +7,7 @@ on:
     # curl -H "Authorization: Bearer <token>" -X POST https://api.github.com/repos/github/codeql-action/dispatches -d '{"event_type":"update-release-branch"}'
     # Replace <token> with a personal access token from this page: https://github.com/settings/tokens
     types: [update-release-branch]
+  workflow_dispatch:
 
 jobs:
   update:


### PR DESCRIPTION
Adding this new event will allow us to trigger the workflow through the UI, instead of having to use the API.

Unfortunately we can't test it until it's on the default branch, but it seems to work. I did a test a t https://github.com/robertbrignull/workflow-test/actions?query=workflow%3Adispatch

@chrisgavin 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
