### PR TITLE
Exclude lib directory from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -11,3 +11,4 @@ queries:
   - uses: security-and-quality
 paths-ignore:
   - tests
+  - lib


### PR DESCRIPTION
I don't think we want to be analyzing the `lib` directory as that's all generated code and we're currently getting some duplicate alerts showing up.

It'll theoretically also show up alerts from dependencies, although I can't actually see any such alerts right now. Although this could be informative, it's not the way that codeql is meant to be used. It'll be more useful to rely on things like CVEs and dependabot to find out about vulnerabilities in dependencies.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
