### PR TITLE
Add support for debugging from VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug AVA test file",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/ava",
+      "runtimeArgs": [
+        "${file}",
+        "--break",
+        "--serial",
+        "--timeout=20m"
+      ],
+      "port": 9229,
+      "outputCapture": "std",
+      "skipFiles": [
+        "<node_internals>/**/*.js"
+      ]
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Before you start, ensure that you have a recent version of node installed. You c
 * Run tests: `npm run test`.  You’ll need to ensure that the JavaScript files are up-to-date first by running the command above.
 * Run the linter: `npm run lint`.
 
+This project also includes configuration to run tests from VSCode (with support for breakpoints) - open the test file you wish to run and choose "Debug AVA test file" from the Run menu in the Run panel.
+
 ### Running the action
 
 To see the effect of your changes and to test them, push your changes in a branch and then look at the [Actions output](https://github.com/github/codeql-action/actions) for that branch.  You can also exercise the code locally by running the automated tests.


### PR DESCRIPTION
https://github.com/avajs/ava/blob/master/docs/recipes/debugging-with-vscode.md recommends passing the `debug` option to Ava.  However, in my experience Ava waits indefinitely when this option is used, without actually running any tests.

The increased timeout setting is so that tests won't fail prematurely because you're slowly stepping through code.

### Merge / deployment checklist

- **N/A** Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
