### PR TITLE
Fix undeclared action inputs

### DIFF
--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: The number of threads to be used by CodeQL.
     required: false
     default: "1"
+  checkout_path:
+    description: "The path at which the analyzed repository was checked out. Used to relativeize any absolute paths in the uploaded SARIF file."
+    required: false
+    default: ${{ github.workspace }}
   token:
     default: ${{ github.token }}
   matrix:

--- a/queries/undeclared-action-input.ql
+++ b/queries/undeclared-action-input.ql
@@ -9,11 +9,17 @@
 
 import javascript
 
+/**
+ * A declaration of a github action, including its inputs and entrypoint.
+ */
 class ActionDeclaration extends File {
   ActionDeclaration() {
     getRelativePath().matches("%/action.yml")
   }
 
+  /**
+   * The name of the action.
+   */
   string getName() {
     result = getRelativePath().regexpCapture("(.*)/action.yml", 1)
   }
@@ -22,10 +28,16 @@ class ActionDeclaration extends File {
     result.getFile() = this
   }
 
+  /**
+   * The name of any input to this action.
+   */
   string getAnInput() {
     result = getRootNode().(YAMLMapping).lookup("inputs").(YAMLMapping).getKey(_).(YAMLString).getValue()
   }
 
+  /**
+   * The function that is the entrypoint to this action.
+   */
   FunctionDeclStmt getEntrypoint() {
     result.getFile().getRelativePath() = getRootNode().
       (YAMLMapping).lookup("runs").
@@ -35,6 +47,21 @@ class ActionDeclaration extends File {
   }
 }
 
+/**
+ * A function declared on CodeQL interface from codeql.ts
+ */
+class CodeQLFunction extends Function {
+  CodeQLFunction() {
+    exists(Function getCodeQLForCmd, ObjectExpr obj |
+      getCodeQLForCmd.getName() = "getCodeQLForCmd" and
+      obj = getCodeQLForCmd.getAStmt().(ReturnStmt).getExpr() and
+      obj.getAProperty().getInit() = this)
+  }
+}
+
+/**
+ * Any expr that is a transitive child of the given function.
+ */
 Expr getAFunctionChildExpr(Function f) {
   result.getContainer() = f
 }
@@ -45,14 +72,25 @@ Expr getAFunctionChildExpr(Function f) {
 Function calledBy(Function f) {
   result = getAFunctionChildExpr(f).(InvokeExpr).getResolvedCallee()
   or
-  result.getEnclosingContainer() = f // assume outer function causes inner function to be called
+  // Assume outer function causes inner function to be called,
+  // except for the special case of the CodeQL functions.
+  (result.getEnclosingContainer() = f and not result instanceof CodeQLFunction)
+  or
+  // Handle calls to CodeQL functions by name
+  getAFunctionChildExpr(f).(InvokeExpr).getCalleeName() = result.(CodeQLFunction).getName()
 }
 
+/**
+ * A call to the core.getInput method.
+ */
 class GetInputMethodCallExpr extends MethodCallExpr {
   GetInputMethodCallExpr() {
     getMethodName() = "getInput"
   }
 
+  /**
+   * The name of the input being accessed.
+   */
   string getInputName() {
     result = getArgument(0).(StringLiteral).getValue()
   }


### PR DESCRIPTION
If this works the same as it did locally then this will fix all of the alerts from https://github.com/github/codeql-action/security/code-scanning

Some of them were false positives because our analysis was mistakenly determining that all of the methods from the CodeQL object were called, when actually they were just defined. I fixed this by giving the analysis knowledge of the CodeQL object and how it is defined. I'm a little worried the knowledge is too specific, so for example we'll have to adjust the query if we rename the method, but since it's all in one repository at least this would be easy to do. Resolving the codeql functions is then just done by name, which hopefully will be good enough. Again I think this is a case of make the analysis good enough and if it's a bit of an over-approximation then we'll fix it in the future when it becomes a problem.

There was one true positive too that I have also fixed in this PR. I think we do still need this `checkout_path` input for the `analyze` action. I'm not sure we can rely on just always using the workspace directory for this action while allowing the user to specify another directory for the `upload-sarif` action. The user could have checked out their src to some subdirectory, though I do see this as an unlikely situation. I don't think there's any harm in adding the input in, when we have it for the `upload-sarif` action already.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
