### PR TITLE
Fix "Using a custom configuration" link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Use the `config-file` parameter of the `init` action to enable the configuration
     config-file: ./.github/codeql/codeql-config.yml
 ```
 
-The configuration file must be located within the local repository. For information on how to write a configuration file, see "[Using a custom configuration](https://help.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#using-a-custom-configuration)."
+The configuration file must be located within the local repository. For information on how to write a configuration file, see "[Using a custom configuration file](https://help.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#using-a-custom-configuration-file)."
 
 If you only want to customise the queries used, you can specify them in your workflow instead of creating a config file, using the `queries` property of the `init` action:
 


### PR DESCRIPTION
### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.

### Description

Fix the "Using a custom configuration" link the README. The actual ID of the header on the page is `#using-a-custom-configuration-file`, so I updated both the link and the link title to match. (as far as I can tell all other links in the README work as expected.)

---

As an aside (not sure where best to report this), the snippet for [Specifying directories to scan](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#specifying-directories-to-scan) in the docs seems to be outdated. `paths-ignore` and `paths` can no longer be specified in the `with:` statement, according to [this error message](https://github.com/ericcornelissen/svgo-action/runs/1097787080#step:3:1):

```
##[warning]Unexpected input(s) 'paths-ignore', valid inputs are ['tools', 'languages', 'token', 'matrix', 'config-file', 'queries']
```