### PR TITLE
Disable snippets by default

### DIFF
--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -19,7 +19,7 @@ inputs:
   add-snippets:
     description: Specify whether or not to add code snippets to the output sarif file.
     required: false
-    default: "true"
+    default: "false"
   threads:
     description: The number of threads to be used by CodeQL.
     required: false


### PR DESCRIPTION
Hotfix to the `v1` branch.

The snippets are larger than expected in a few cases. This PR disables them by default so we have time to investigate further.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
