### PR TITLE
Apply "Disable snippets by default" to main 

### DIFF
--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -19,7 +19,7 @@ inputs:
   add-snippets:
     description: Specify whether or not to add code snippets to the output sarif file.
     required: false
-    default: "true"
+    default: "false"
   threads:
     description: The number of threads to be used by CodeQL.
     required: false


### PR DESCRIPTION
Apply #210 to main, as it does not seem that a quick fix will be available to enable this for everyone. In this way, we keep `main` "ahead or in-par" with `v1`.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
