### PR TITLE
Don't use ::set-env in python-setup

### DIFF
--- a/python-setup/auto_install_packages.py
+++ b/python-setup/auto_install_packages.py
@@ -142,5 +142,8 @@ if __name__ == "__main__":
     python_executable_path = install_packages(codeql_base_dir)
 
     if python_executable_path is not None:
+        # see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+        env_file = open(os.environ["GITHUB_ENV"], mode="at")
+
         print("Setting CODEQL_PYTHON={}".format(python_executable_path))
-        print("::set-env name=CODEQL_PYTHON::{}".format(python_executable_path))
+        print("CODEQL_PYTHON={}".format(python_executable_path), file=env_file)

--- a/python-setup/tests/from_python_exe.py
+++ b/python-setup/tests/from_python_exe.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import os
 import subprocess
 from typing import Tuple
 
@@ -24,8 +25,11 @@ def get_details(path_to_python_exe: str) -> Tuple[str, str]:
 if __name__ == "__main__":
     version, import_path = get_details(sys.argv[1])
 
+    # see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+    env_file = open(os.environ["GITHUB_ENV"], mode="at")
+
     print("Setting LGTM_PYTHON_SETUP_VERSION={}".format(version))
-    print("::set-env name=LGTM_PYTHON_SETUP_VERSION::{}".format(version))
+    print("LGTM_PYTHON_SETUP_VERSION={}".format(version), file=env_file)
 
     print("Setting LGTM_INDEX_IMPORT_PATH={}".format(import_path))
-    print("::set-env name=LGTM_INDEX_IMPORT_PATH::{}".format(import_path))
+    print("LGTM_INDEX_IMPORT_PATH={}".format(import_path), file=env_file)


### PR DESCRIPTION
Is now deprecated as described in https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

@Daverlo I don't know how this plays together with version compatibility, just spotted the warning on an action run, and thought I could fix it up.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
