### PR TITLE
Fix Python CI jobs.

### DIFF
--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
+        tools: latest
         languages: python
 
     - name: Test Auto Package Installation
@@ -60,7 +61,8 @@ jobs:
         esac
         echo ${basePath}
 
-        find ${basePath}/hostedtoolcache/CodeQL -path "*x64/codeql" -exec $GITHUB_WORKSPACE/python-setup/auto_install_packages.py {} \;
+        codeql_version="0.0.0-$(cat "$GITHUB_WORKSPACE/src/defaults.json" | jq -r .bundleVersion | rev | cut -d - -f 1 | rev)"
+        $GITHUB_WORKSPACE/python-setup/auto_install_packages.py "${basePath}/hostedtoolcache/CodeQL/$codeql_version/x64/codeql"
     - name: Setup for extractor
       run: |
         echo $CODEQL_PYTHON
@@ -105,7 +107,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20200826/codeql-bundle.tar.gz
+        tools: latest
         languages: python
 
     - name: Test Auto Package Installation
@@ -114,12 +116,15 @@ jobs:
         powershell -File $cmd
 
         cd $Env:GITHUB_WORKSPACE\\${{ matrix.test_dir }}
-        py -3 $Env:GITHUB_WORKSPACE\\python-setup\\auto_install_packages.py C:\\hostedtoolcache\\windows\\CodeQL\\0.0.0-20200826\\x64\\codeql
+        $DefaultsPath = Join-Path (Join-Path $Env:GITHUB_WORKSPACE "src") "defaults.json"
+        $CodeQLBundleName = (Get-Content -Raw -Path $DefaultsPath | ConvertFrom-Json).bundleVersion
+        $CodeQLVersion = "0.0.0-" + $CodeQLBundleName.split("-")[-1]
+        py -3 $Env:GITHUB_WORKSPACE\\python-setup\\auto_install_packages.py C:\\hostedtoolcache\\windows\\CodeQL\\$CodeQLVersion\\x64\\codeql
     - name: Setup for extractor
       run: |
         echo $Env:CODEQL_PYTHON
 
-        py -3 $Env:GITHUB_WORKSPACE\\python-setup\\tests\\from_python_exe.py $Env:CODEQL_PYTHON 
+        py -3 $Env:GITHUB_WORKSPACE\\python-setup\\tests\\from_python_exe.py $Env:CODEQL_PYTHON
     - name: Verify packages installed
       run: |
         $cmd = $Env:GITHUB_WORKSPACE + "\\python-setup\\tests\\check_requests_123.ps1"

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -105,6 +105,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
+        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20200826/codeql-bundle.tar.gz
         languages: python
 
     - name: Test Auto Package Installation


### PR DESCRIPTION
The current Python CI jobs seem to assume the bundle will never be updated by referencing the bundle by exact version. They don't specify a static bundle to actually download though, so every time the bundle updates the CI will break.

I've fixed this by specifying the expected bundle as the one to download under the assumption that is what we want to test. We could also test the latest version, but that seems like it could break unexpectedly if there are changes to the Python extractor.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
