### PR TITLE
Run all tests on latest tools

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,4 +18,5 @@ jobs:
       with:
         languages: javascript
         config-file: ./.github/codeql/codeql-config.yml
+        tools: latest
     - uses: ./analyze

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -18,6 +18,8 @@ jobs:
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
     - uses: ./../action/init
+      with:
+        tools: latest
     - name: Build code
       shell: bash
       run: ./build.sh
@@ -44,6 +46,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        # Run with latest and default tools to test both paths.
+        # Only need to do this for a sigle test.
         tools: [~, latest]
     runs-on: ${{ matrix.os }}
 
@@ -91,6 +95,7 @@ jobs:
       with:
         languages: go
         config-file: ./.github/codeql/custom-queries.yml
+        tools: latest
     - name: Build code
       shell: bash
       run: ./build.sh
@@ -152,6 +157,7 @@ jobs:
     - uses: ./../action/init
       with:
         languages: javascript
+        tools: latest
     - uses: ./../action/analyze
       env:
         TEST_MODE: true


### PR DESCRIPTION
Makes all integration tests use the latest bundle version by default. There is one test that already runs on latest and the version in the environment, to test that code path as well.

By running on the latest version of the tools we'll get better confidence when we upgrade the bundle. Currently the CI checks when updating the bundle are basically useless because it uses the tools from the environment.

I also run into this with #222 but I realise that PR is held up by the virtual environment being updated anyway. So if anything using the latest version in our tests would have actually masked the error on that PR and made it more dangerous. It's dangerous if our testing environment is different from the environment that users see.

I guess the ultimate option would be to run all tests on both tools versions, but that is probably prohibitively expensive given the number of checks we already have.

So there are pros and cons of making this change. What do people think?

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
