### PR TITLE
Make sure a Python 2 pip is installed

### DIFF
--- a/python-setup/install_tools.sh
+++ b/python-setup/install_tools.sh
@@ -10,6 +10,10 @@ set -e
 # subsequent actions in the current job, and not the current action.
 export PATH="$HOME/.local/bin:$PATH"
 
+# The Ubuntu 20.04 GHA environment does not come with a Python 2 pip
+curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+python2 get-pip.py
+
 python2 -m pip install --user --upgrade pip setuptools wheel
 python3 -m pip install --user --upgrade pip setuptools wheel
 


### PR DESCRIPTION
In the README of this repo, it's suggested to use the `ubuntu-latest` environment.
That environment will soon be upgraded to Ubuntu 20.04: https://github.com/actions/virtual-environments/issues/1816

As pointed out in that issue, the updated image comes without a Python 2 pip preinstalled:

    Setup Python dependencies
    /home/runner/work/_actions/github/codeql-action/v1/python-setup/install_tools.sh
    [...]
      + python2 -m pip install --user --upgrade pip setuptools wheel
      /usr/bin/python2: No module named pip
    Warning: Unable to download and extract the tools needed for installing the python dependecies. You can call this action with 'setup-python-dependencies: false' to disable this process.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
