### PR TITLE
Suggestion: merge main and update lib/ in PR on dispatch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,8 +19,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Check that building works
-      run: npm run-script build
+    - name: Check generated JavaScript
+      run: |
+        # Sanity check that repo is clean to start with
+        if [ ! -z "$(git status --porcelain)" ]; then
+          # If we get a fail here then this workflow needs attention...
+          >&2 echo "Failed: Repo should be clean before testing!"
+          exit 1
+        fi
+        # Wipe the lib directory incase there are extra unnecessary files in there
+        rm -rf lib
+        # Generate the JavaScript files
+        npm run-script build
+        # Check that repo is still clean
+        if [ ! -z "$(git status --porcelain)" ]; then
+          # If we get a fail here then the PR needs attention
+          >&2 echo "Failed: JavaScript files are not up to date. Run 'npm run-script build' to update"
+          git status
+          exit 1
+        fi
+        echo "Success: JavaScript files are up to date"
 
   check-node-modules:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,26 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Check generated JavaScript
-      run: |
-        # Sanity check that repo is clean to start with
-        if [ ! -z "$(git status --porcelain)" ]; then
-          # If we get a fail here then this workflow needs attention...
-          >&2 echo "Failed: Repo should be clean before testing!"
-          exit 1
-        fi
-        # Wipe the lib directory incase there are extra unnecessary files in there
-        rm -rf lib
-        # Generate the JavaScript files
-        npm run-script build
-        # Check that repo is still clean
-        if [ ! -z "$(git status --porcelain)" ]; then
-          # If we get a fail here then the PR needs attention
-          >&2 echo "Failed: JavaScript files are not up to date. Run 'npm run-script build' to update"
-          git status
-          exit 1
-        fi
-        echo "Success: JavaScript files are up to date"
+    - name: Check that building works
+      run: npm run-script build
 
   check-node-modules:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-lib.yml
+++ b/.github/workflows/update-lib.yml
@@ -1,0 +1,18 @@
+name: "Update lib/"
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build lib/
+      run: npm run-script build
+    - name: Push updates
+      uses: stefanzweifel/git-auto-commit-action@v4.7.2
+      with:
+        commit_message: "Auto-update lib/"

--- a/.github/workflows/update-lib.yml
+++ b/.github/workflows/update-lib.yml
@@ -2,13 +2,20 @@ name: "Update lib/"
 
 on:
   workflow_dispatch:
+    # Example of how to trigger this:
+    # curl -X POST \
+    #      -H "Authorization: Bearer <token>" \
+    #      https://api.github.com/repos/github/codeql-action/actions/workflows/update-lib.yml/dispatches \
+    #      -d '{"ref":"main","inputs":{"pr":"<pr-number>"}}'
+    # Replace <token> with a personal access token from this page: https://github.com/settings/tokens
+    # Replace <pr-number> by the number of the pull request to update
     inputs:
       pr:
         description: 'The number of the PR to update'
         required: true
 
 jobs:
-  build:
+  update-lib:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-lib.yml
+++ b/.github/workflows/update-lib.yml
@@ -1,18 +1,30 @@
 name: "Update lib/"
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'The number of the PR to update'
+        required: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build lib/
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Checkout PR
+      uses: dawidd6/action-checkout-pr@v1
+      with:
+        pr: ${{ github.event.inputs.pr }}
+    - name: Merge main branch
+      run: git merge main --no-ff
+    - name: Remove lib/ directory
+      run: rm -rf lib
+    - name: Update lib/ directory
       run: npm run-script build
     - name: Push updates
-      uses: stefanzweifel/git-auto-commit-action@v4.7.2
+      uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: "Auto-update lib/"


### PR DESCRIPTION
### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.

* * *

This is a suggestion to change the way contributing to this project works. Currently, when a PR is submitted the submitter has to run `npm run build` and include the changes to the `lib/` directory in the PR. With the changes in this PR, including the changes to `lib/` is no longer necessary (*). This should avoid a bunch of merge conflicts with regards to the `lib/` directory - even though they're simple to fix it is annoying you have to.

To me, it seems these changes don't require any changes to [the Contributing Guidelines](https://github.com/github/codeql-action/blob/378f1f95d77928be059077e8fb39f1fd2529f45d/CONTRIBUTING.md), but if desired I wouldn't mind adding a note about this new workflow to [the "Submitting a pull request" section](https://github.com/github/codeql-action/blob/378f1f95d77928be059077e8fb39f1fd2529f45d/CONTRIBUTING.md#submitting-a-pull-request).

<sup>(*): It is still possible though, and if a PR is merged with updates to lib/ included, the changes in this PR won't have any effect.</sup>