### PR TITLE
Only analyze PRs against main and v1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, v1]
   pull_request:
+    branches: [main, v1]
 
 jobs:
   build:


### PR DESCRIPTION
We can only analyze PRs against those branches we are analyzing on push.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
