### PR TITLE
Add a check to ensure expected CodeQL release files exist.

### DIFF
--- a/.github/workflows/check-expected-release-files.yml
+++ b/.github/workflows/check-expected-release-files.yml
@@ -1,0 +1,22 @@
+name: Check Expected Release Files
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/check-expected-release-files.yml
+      - src/defaults.json
+
+jobs:
+  check-expected-release-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout CodeQL Action
+        uses: actions/checkout@v2
+      - name: Check Expected Release Files
+        run: |
+          bundle_version="$(cat "./src/defaults.json" | jq -r ".bundleVersion")"
+          set -x
+          for expected_file in "codeql-bundle.tar.gz" "codeql-bundle-linux64.tar.gz" "codeql-bundle-osx64.tar.gz" "codeql-bundle-win64.tar.gz" "codeql-runner-linux" "codeql-runner-macos" "codeql-runner-win.exe"; do
+            curl --location --fail --head --request GET "https://github.com/github/codeql-action/releases/download/$bundle_version/$expected_file" > /dev/null
+          done


### PR DESCRIPTION
This adds a check to make sure all the expected files on the CodeQL bundle release exist, including the runner and the CodeQL complete bundle, neither of which are covered by other checks.

(Adding this because I initially forgot to rename the `codeql-bundle-all.zip` file to `codeql-bundle.zip`.)

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
