### PR TITLE
Prevent accidental analysis of the `get-pip.py` script.

### DIFF
--- a/python-setup/install_tools.sh
+++ b/python-setup/install_tools.sh
@@ -31,8 +31,7 @@ python3 -m pip install --user pipenv
 if command -v python2 &> /dev/null; then
 	# Setup Python 2 dependency installation tools.
 	# The Ubuntu 20.04 GHA environment does not come with a Python 2 pip
-	curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
-	python2 get-pip.py
+	curl --location --fail https://bootstrap.pypa.io/get-pip.py | python2
 
 	python2 -m pip install --user --upgrade pip setuptools wheel
 


### PR DESCRIPTION
It seems like in some cases this script gets analyzed. We can either remove it after running it, or just not save it at all.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
