### PR TITLE
Update description to include limit on number of results

### DIFF
--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -3,7 +3,7 @@ description: 'Upload the analysis results'
 author: 'GitHub'
 inputs:
   sarif_file:
-    description: The SARIF file or directory of SARIF files to be uploaded.
+    description: The SARIF file or directory of SARIF files to be uploaded. Each SARIF file should contain a maximum of 1000 results, any additional results are ignored.
     required: false
     default: '../results'
   checkout_path:

--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -3,7 +3,7 @@ description: 'Upload the analysis results'
 author: 'GitHub'
 inputs:
   sarif_file:
-    description: The SARIF file or directory of SARIF files to be uploaded. Each SARIF file should contain a maximum of 1000 results, any additional results are ignored.
+    description: The SARIF file or directory of SARIF files to be uploaded. Each upload should contain a maximum of 1000 results, any additional results are ignored.
     required: false
     default: '../results'
   checkout_path:


### PR DESCRIPTION
👋🏻 I'm proposing this change alongside some similar changes to the documentation. We want to make sure that people are aware of the limit on the number of results that will be processed per SARIF file. This is rarely a problem for results generated by CodeQL but a few people have encountered it when running 3rd party tools that may be "noisy".

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
