### PR TITLE
Move .github/workflows back where it was

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,6 +54,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
     - uses: ./../action/init
     - name: Build code
       shell: bash
@@ -93,6 +94,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
     - uses: ./../action/init
       with:
         tools: ${{ matrix.tools }}
@@ -126,6 +128,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
     - uses: ./../action/init
       with:
         languages: go
@@ -159,6 +162,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
     - uses: ./../action/init
       with:
         languages: go
@@ -185,6 +189,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
     - uses: ./../action/init
       with:
         languages: go
@@ -205,6 +210,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -246,6 +252,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
     - uses: ./../action/init
       with:
         languages: javascript
@@ -339,6 +346,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
 
     - name: Build runner
       run: |
@@ -374,6 +382,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
 
     - name: Build runner
       run: |
@@ -410,6 +419,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
 
     - name: Build runner
       run: |
@@ -447,6 +457,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
 
     - name: Build runner
       run: |
@@ -481,6 +492,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
 
     - name: Build runner
       run: |
@@ -516,6 +528,7 @@ jobs:
         mkdir ../action
         mv * .github ../action/
         mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
 
     - name: Build runner
       run: |


### PR DESCRIPTION
We're getting a lot of "Could not read workflow" errors on the pr-checks because they move the repository files out of the way in order to move some test files back in. We can avoid the error by making sure we don't move the workflow file that's executing, or at least we move it back to where it was.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
