### PR TITLE
Fixes a regex for language and locale recognition

### DIFF
--- a/src/sarif_v2.1.0_schema.json
+++ b/src/sarif_v2.1.0_schema.json
@@ -2339,9 +2339,8 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
-
         "versionControlProvenance": {
           "description": "Specifies the revision in version control of the artifacts that were scanned.",
           "type": "array",
@@ -3040,7 +3039,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "contents": {


### PR DESCRIPTION
See https://github.com/oasis-tcs/sarif-spec/pull/490
See #418

Note that this changes the sarif spec file. Unless this
change is actually merged in the sarif spec repo, the
version used by the action will be slightly different.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/master/README.md) has been updated if necessary.
