### PR TITLE
Actions: Run enterprise versions workflow only on the parent repo

### DIFF
--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   update-supported-enterprise-server-versions:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'github/codeql-action' }}
 
     steps:
       - name: Setup Python


### PR DESCRIPTION
Don't run the cron workflow on forks, since they lack the necessary secrets.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
