### PR TITLE
Fix the mergeback workflow

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -8,8 +8,7 @@ import json
 import datetime
 import os
 
-EMPTY_CHANGELOG = """
-# CodeQL Action and CodeQL Runner Changelog
+EMPTY_CHANGELOG = """# CodeQL Action and CodeQL Runner Changelog
 
 ## [UNRELEASED]
 

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -74,9 +74,11 @@ jobs:
           set +e # don't fail on an errored command
           git ls-remote --tags origin | grep "$VERSION"
           EXISTS="$?"
-          if [ "$EXISTS" -ne 0 ]; then
-             echo "::set-output name=exists::true"
-             echo "Tag $TAG exists. Not going to re-release."
+          if [ "$EXISTS" -eq 0 ]; then
+            echo "Tag $TAG exists. Not going to re-release."
+            echo "::set-output name=exists::true"
+          else
+            echo "Tag $TAG does not exist yet."
           fi
 
       # we didn't tag the release during the update-release-branch workflow because the
@@ -88,6 +90,7 @@ jobs:
           VERSION: ${{ steps.getVersion.outputs.version }}
         run: |
           git tag -a "$VERSION" -m "$VERSION"
+          git fetch --unshallow  # unshallow the repo in order to allow pushes
           git push origin --follow-tags "$VERSION"
 
       - name: Create mergeback branch

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -83,7 +83,7 @@ jobs:
       # commit that actually makes it to the release branch is a merge commit,
       # and not yet known during the first workflow. We tag now because we know the correct commit.
       - name: Tag release
-        if: steps.check.outputs.exists == 'true'
+        if: steps.check.outputs.exists != 'true'
         env:
           VERSION: ${{ steps.getVersion.outputs.version }}
         run: |
@@ -91,7 +91,7 @@ jobs:
           git push origin --follow-tags "$VERSION"
 
       - name: Create mergeback branch
-        if: steps.check.outputs.exists == 'true'
+        if: steps.check.outputs.exists != 'true'
         env:
           VERSION: "${{ steps.getVersion.outputs.version }}"
           NEW_BRANCH: "${{ steps.getVersion.outputs.newBranch }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CodeQL Action and CodeQL Runner Changelog
 
-## [UNRELEASED]
+## 1.0.0 - 31 May 2021
 
 - Add this changelog file. [#507](https://github.com/github/codeql-action/pull/507)
 - Improve grouping of analysis logs. Add a new log group containing a summary of metrics and diagnostics, if they were produced by CodeQL builtin queries. [#515](https://github.com/github/codeql-action/pull/515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CodeQL Action and CodeQL Runner Changelog
 
+## [UNRELEASED]
+
 ## 1.0.0 - 31 May 2021
 
 - Add this changelog file. [#507](https://github.com/github/codeql-action/pull/507)
 - Improve grouping of analysis logs. Add a new log group containing a summary of metrics and diagnostics, if they were produced by CodeQL builtin queries. [#515](https://github.com/github/codeql-action/pull/515)
-- Add metrics and diagnostics summaries from custom query suites to the analysis summary log group. [#532](https://github.com/github/codeql-action/pull/532) 
+- Add metrics and diagnostics summaries from custom query suites to the analysis summary log group. [#532](https://github.com/github/codeql-action/pull/532)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeql",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codeql",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "CodeQL action",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint --report-unused-disable-directives --max-warnings=0 . --ext .js,.ts",
     "lint-fix": "eslint --report-unused-disable-directives --max-warnings=0 . --ext .js,.ts --fix",
     "removeNPMAbsolutePaths": "removeNPMAbsolutePaths . --force",
-    "version": "cd runner && npm version patch && git add ."
+    "version": "cd runner && npm version patch && cd .. && npm run removeNPMAbsolutePaths && git add runner"
   },
   "ava": {
     "typescript": {

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql-runner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql-runner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "CodeQL runner",
   "scripts": {


### PR DESCRIPTION
And manually mergeback v1 into main.

Needed to do a few fixes here:

- Fix the logic in `post-release-mergeback.yml` workflow
- Unshallow before pushing a tag
- Fix the `version` script so that newlines are correctly stripped to keep `removeNPMAbsolutePaths` happy
- Manually updated the changelog.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
