### PR TITLE
Update unguarded-action-lib.ql to catch uses of actions-util.ts

### DIFF
--- a/queries/unguarded-action-lib.ql
+++ b/queries/unguarded-action-lib.ql
@@ -43,7 +43,7 @@ class ActionsLibImport extends ImportDeclaration {
   ActionsLibImport() {
     getImportedPath().getValue().matches("@actions/%") and
     not isSafeActionLib(getImportedPath().getValue()) or
-    getImportedPath().getValue().matches("/actions-util$")
+    getImportedPath().getValue().matches("%/actions-util$")
   }
 
   string getName() {


### PR DESCRIPTION
I'm not 100% sure this change is correct but the PR checks should tell us as this should introduce at least one alert because it'll now spot accesses of `actions-util.ts`. Because it's using `matches` but then with a string with no wildcards in it I'm assuming this must be a mistake.

Alternatively we could probably just use `getImportedPath().getValue() = "./actions-util")` since we currently have all our source in one directory. Is that better? Using `matches` lets us catch this potential future edge case.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
