### PR TITLE
Remove quotes around `$DRAFT` argument

### DIFF
--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -124,4 +124,4 @@ jobs:
             --base "$BASE_BRANCH" \
             --title "$PR_TITLE" \
             --body "$PR_BODY" \
-            "$DRAFT"
+            ${DRAFT:+"$DRAFT"} # no quotes around $DRAFT. gh will error out if there is an empty ""


### PR DESCRIPTION
gh will complain if there is an empty `""`, which is the case if
`$DRAFT` is unset.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
