### PR TITLE
Fix update-release-branch-fix.py

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -122,7 +122,7 @@ def get_commit_difference(repo):
 
 # Is the given commit the automatic merge commit from when merging a PR
 def is_pr_merge_commit(commit):
-  return commit.committer.login == 'web-flow' and len(commit.parents) > 1
+  return commit.committer is not None and commit.committer.login == 'web-flow' and len(commit.parents) > 1
 
 # Gets a copy of the commit message that should display nicely
 def get_truncated_commit_message(commit):

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -118,8 +118,8 @@ jobs:
       with:
         config-file: ".github/codeql/codeql-config-packaging.yml"
         languages: javascript
-        # TODO: this is temporary until we have a release that includes the latest packaging work.
-        tools: https://github.com/dsp-testing/aeisenberg-codeql-action-packaging/releases/download/codeql-bundle-20210606/codeql-bundle-linux64.tar.gz
+        # TODO: this can be removed when cli v2.5.6 is released and available in the tool cache
+        tools: https://github.com/dsp-testing/aeisenberg-codeql-action-packaging/releases/download/codeql-bundle-20210615/codeql-bundle-linux64.tar.gz
 
     - name: Build code
       shell: bash

--- a/tests/multi-language-repo/.github/codeql/codeql-config-packaging.yml
+++ b/tests/multi-language-repo/.github/codeql/codeql-config-packaging.yml
@@ -3,7 +3,7 @@ name: Pack testing in the CodeQL Action
 disable-default-queries: true
 packs:
   javascript:
-    - dsp-testing/codeql-pack1@0.0.3
+    - dsp-testing/codeql-pack1@0.0.4
     - dsp-testing/codeql-pack2 # latest
 paths-ignore:
   - tests


### PR DESCRIPTION
This change ensures that the the script can handle
commits with no committer in them. This will happen
for some commits that are auto-generated during
PRs.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
