### PR TITLE
Update changelog template

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -12,6 +12,8 @@ EMPTY_CHANGELOG = """# CodeQL Action and CodeQL Runner Changelog
 
 ## [UNRELEASED]
 
+No user facing changes.
+
 """
 
 # The branch being merged from.

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -101,7 +101,7 @@ jobs:
           PR_BODY="Updates version and changelog."
 
           # Update the changelog
-          perl -i -pe 's/^/## \[UNRELEASED\]\n\n/ if($.==3)' CHANGELOG.md
+          perl -i -pe 's/^/## \[UNRELEASED\]\n\nNo user facing changes.\n\n/ if($.==3)' CHANGELOG.md
           git add .
           git commit -m "Update changelog and version after $VERSION"
           npm version patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+No user facing changes.
+
 ## 1.0.2 - 17 Jun 2021
 
 - Fix out of memory in hash computation. [#550](https://github.com/github/codeql-action/pull/550)


### PR DESCRIPTION
The changelog for an empty version will now be:

```
No user facing changes.
```

And this will appear in the final changelog when there is an actual release.
The benefits are that users will see regular release cycles and know
how old versions are even if there's no changes for a particular version

If we find that we are going months without any user facing changes, but
we have non-visible changes, then we can rethink this strategy.
But I think this is nicer than having empty sections for a version.

Fixes #579.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
