### PR TITLE
Enable dependabot automatic updates

### DIFF
--- a/.github/depandabot.yml
+++ b/.github/depandabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday" # Gives us a working day to merge this before our typical release
+    labels:
+      - "Update dependencies"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,7 +27,7 @@ jobs:
       run: .github/workflows/script/check-js.sh
 
   check-node-modules:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/script/check-node-modules.sh
+++ b/.github/workflows/script/check-node-modules.sh
@@ -7,6 +7,7 @@ if [ ! -z "$(git status --porcelain)" ]; then
     >&2 echo "Failed: Repo should be clean before testing!"
     exit 1
 fi
+sudo npm install --force -g npm@latest
 # Reinstall modules and then clean to remove absolute paths
 # Use 'npm ci' instead of 'npm install' as this is intended to be reproducible
 npm ci

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,6 +1,7 @@
 name: Update dependencies
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   update:
@@ -32,6 +33,9 @@ jobs:
         git config --global user.email "github-actions@github.com"
         git config --global user.name "github-actions[bot]"
         git add node_modules
-        git commit -am "Update checked-in dependencies"
-        git push
+        if ! git commit -am "Update checked-in dependencies" ; then
+          echo "No changes detected, skipping pushing..."
+          exit 0
+        fi
+        git push origin "$BRANCH"
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,37 @@
+name: Update dependencies
+on:
+  pull_request:
+
+jobs:
+  update:
+    name: Update dependencies
+    runs-on: macos-latest
+    if: contains(github.event.pull_request.labels.*.name, 'Update dependencies')
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Remove PR label
+      env:
+        REPOSITORY: '${{ github.repository }}'
+        PR_NUMBER: '${{ github.event.pull_request.number }}'
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      run: |
+        gh api "repos/$REPOSITORY/issues/$PR_NUMBER/labels/Update%20dependencies" -X DELETE
+
+    - name: Push updated dependencies
+      env:
+        BRANCH: '${{ github.head_ref }}'
+      run: |
+        git fetch
+        git checkout $BRANCH
+        sudo npm install --force -g npm@latest
+        npm install
+        npm ci
+        npm run removeNPMAbsolutePaths
+        git config --global user.email "github-actions@github.com"
+        git config --global user.name "github-actions[bot]"
+        git add node_modules
+        git commit -am "Update checked-in dependencies"
+        git push
+

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,12 +30,10 @@ jobs:
         npm install
         npm ci
         npm run removeNPMAbsolutePaths
-        git config --global user.email "github-actions@github.com"
-        git config --global user.name "github-actions[bot]"
-        git add node_modules
-        if ! git commit -am "Update checked-in dependencies" ; then
-          echo "No changes detected, skipping pushing..."
-          exit 0
+        if [ ! -z "$(git status --porcelain)" ]; then
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions[bot]"
+          git add node_modules
+          git commit -am "Update checked-in dependencies"
+          git push origin "$BRANCH"
         fi
-        git push origin "$BRANCH"
-

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -1243,7 +1243,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3220,9 +3219,6 @@
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "codeql",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^0.5.1",
@@ -1297,7 +1297,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3274,9 +3273,6 @@
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }


### PR DESCRIPTION
Closes https://github.com/github/codeql-coreql-team/issues/1344

This adds a new workflow (triggered by a label) that updates the checked-in dependencies on a PR branch. It also enables Dependabot and has it apply the relevant label to have the checked-in dependencies updated. Unfortunately, the workflow will not work on forks due to missing the permissions to push to other user's forks, so we can't use it on our own PRs. It should work on Dependabot's PRs, though, since it creates its PRs from the main repo.