### PR TITLE
Update lockfile in mergeback

### DIFF
--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -119,5 +119,6 @@ jobs:
             --head "$NEW_BRANCH" \
             --base "$BASE_BRANCH" \
             --title "$PR_TITLE" \
+            --label "Update dependencies" \
             --body "$PR_BODY" \
             ${DRAFT:+"$DRAFT"} # no quotes around $DRAFT. gh will error out if there is an empty ""


### PR DESCRIPTION
The first mergeback workflow after https://github.com/github/codeql-action/pull/630 failed (https://github.com/github/codeql-action/pull/634) because the lockfile did not have the new version ([this commit](https://github.com/github/codeql-action/pull/634/commits/fb190722374162e20bbea5ef72a467e66d531efe) fixed it after I manually added the label). Adding the label on the PR should make sure that commit gets made automatically.