### PR TITLE
Enable Dependabot on runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
       day: "thursday" # Gives us a working day to merge this before our typical release
     labels:
       - "Update dependencies"
+  - package-ecosystem: "npm"
+    directory: "/runner"
+    schedule:
+      interval: "weekly"
+      day: "thursday" # Gives us a working day to merge this before our typical release


### PR DESCRIPTION
This PR enables Dependabot on the dependencies for building the CodeQL runner, which have their own `package.json` and `package-lock.json` in a subfolder. Note we don't need the new "Update dependencies" label for these PRs as the dependencies there are not checked in.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
