### PR TITLE
Create PRs as drafts to prompt maintainers to trigger PR checks

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -93,7 +93,9 @@ def open_pr(repo, all_commits, short_main_sha, branch_name):
   title = 'Merge ' + MAIN_BRANCH + ' into ' + LATEST_RELEASE_BRANCH
 
   # Create the pull request
-  pr = repo.create_pull(title=title, body='\n'.join(body), head=branch_name, base=LATEST_RELEASE_BRANCH)
+  # PR checks won't be triggered on PRs created by Actions. Therefore mark the PR as draft so that
+  # a maintainer can take the PR out of draft, thereby triggering the PR checks.
+  pr = repo.create_pull(title=title, body='\n'.join(body), head=branch_name, base=LATEST_RELEASE_BRANCH, draft=True)
   print('Created PR #' + str(pr.number))
 
   # Assign the conductor

--- a/.github/workflows/check-expected-release-files.yml
+++ b/.github/workflows/check-expected-release-files.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - .github/workflows/check-expected-release-files.yml
       - src/defaults.json
+    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
+    # by other workflows.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   check-expected-release-files:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, v1]
   pull_request:
     branches: [main, v1]
+    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
+    # by other workflows.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   # Identify the CodeQL tool versions to use in the analysis job.

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -106,19 +106,14 @@ jobs:
           git commit -m "Update changelog and version after $VERSION"
           npm version patch
 
-          # when running this workflow on a PR, this is just a test.
-          # so put into draft mode.
-          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-            DRAFT="--draft"
-          else
-            DRAFT=""
-          fi
-
           git push origin "$NEW_BRANCH"
+
+          # PR checks won't be triggered on PRs created by Actions. Therefore mark the PR as draft
+          # so that a maintainer can take the PR out of draft, thereby triggering the PR checks.
           gh pr create \
             --head "$NEW_BRANCH" \
             --base "$BASE_BRANCH" \
             --title "$PR_TITLE" \
             --label "Update dependencies" \
             --body "$PR_BODY" \
-            ${DRAFT:+"$DRAFT"} # no quotes around $DRAFT. gh will error out if there is an empty ""
+            --draft

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main, v1]
   pull_request:
+    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
+    # by other workflows.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main, v1]
   pull_request:
+    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
+    # by other workflows.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test-setup-python-scripts:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,7 +1,7 @@
 name: Update dependencies
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 jobs:
   update:

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install PyGithub==1.51 requests
+        pip install PyGithub==1.55 requests
 
     - name: Update git config
       run: |


### PR DESCRIPTION
PR checks aren't triggered on PRs created by Actions workflows.  This change marks PRs created by workflows as draft to prompt maintainers to take the PR out of draft, thereby triggering PR checks.

Update release branch workflow:

- Test workflow run: https://github.com/github/codeql-action/actions/runs/1095021129
- Test PR: https://github.com/github/codeql-action/pull/680

Post-release mergeback workflow:

- Test workflow run: https://github.com/github/codeql-action/actions/runs/1095020479
- Test PR: https://github.com/github/codeql-action/pull/681

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
