### PR TITLE
Add PR check job for Ruby beta

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -497,6 +497,47 @@ jobs:
           exit 1
         fi
 
+  # Ruby is in beta, so test it separately for now.
+  multi-language-repo_test-ruby:
+    needs: [check-js, check-node-modules, check-codeql-versions]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        tools:
+          - latest
+          # TODO: Uncomment when nightly builds also support Ruby in beta.
+          # - ${{ needs.check-codeql-versions.outputs.nightly-url }}
+    runs-on: ${{ matrix.os }}
+    env:
+      CODEQL_ENABLE_EXPERIMENTAL_FEATURES: true
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Move codeql-action
+      shell: bash
+      run: |
+        mkdir ../action
+        mv * .github ../action/
+        mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
+    - uses: ./../action/init
+      with:
+        languages: ruby
+        tools: ${{ matrix.tools }}
+    - uses: ./../action/analyze
+      id: analysis
+      env:
+        TEST_MODE: true
+    - name: Check database
+      shell: bash
+      run: |
+        RUBY_DB="${{ fromJson(steps.analysis.outputs.db-locations).ruby }}"
+        if [[ ! -d "$RUBY_DB" ]]; then
+          echo "Did not create a database for Ruby."
+          exit 1
+        fi
+
   multi-language-repo_rubocop:
     needs: [check-js, check-node-modules]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a separate job that analyses the multilanguage test repo's Ruby code.
For now, run this only with the latest released build of CodeQL pointed to in `defaults.json`.
The nightly build and the cached builds don't support Ruby yet.

In future, we can update this and other PR checks to test a wider range of cases.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
