### PR TITLE
 Updates the permissions block to be minimal

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,8 +17,6 @@ jobs:
       versions: ${{ steps.compare.outputs.versions }}
 
     permissions:
-      actions: read
-      contents: read
       security-events: write
 
     steps:
@@ -68,8 +66,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     permissions:
-      actions: read
-      contents: read
       security-events: write
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-No user facing changes.
+- Update README to include a sample permissions block. [#689](https://github.com/github/codeql-action/pull/689)
 
 ## 1.0.10 - 03 Aug 2021
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ jobs:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
 
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
 And adds a permissions block to the README.

Fixes #464.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
