### PR TITLE
Refactor PR checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 lib/*.js linguist-generated=true
+.github/workflows/__* linguist-generated=true
 
 # Reduce incidence of needless merge conflicts on CHANGELOG.md
 # The man page at

--- a/.github/prepare-test/action.yml
+++ b/.github/prepare-test/action.yml
@@ -1,0 +1,39 @@
+name: "Prepare test"
+description: Performs some preparation to run tests
+inputs:
+  version:
+    required: true
+outputs:
+  tools-url:
+    value: ${{ steps.get-url.outputs.tools-url }}
+runs:
+  using: composite
+  steps:
+    - name: Move codeql-action
+      shell: bash
+      run: |
+        mkdir ../action
+        mv * .github ../action/
+        mv ../action/tests/multi-language-repo/{*,.github} .
+        mv ../action/.github/workflows .github
+    - id: get-url
+      name: Determine URL
+      shell: bash
+      run: |
+        if [[ ${{ inputs.version }} == "nightly-latest" ]]; then
+          export LATEST=`gh release list --repo dsp-testing/codeql-cli-nightlies -L 1 | cut -f 3`
+          echo "::set-output name=tools-url::https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/$LATEST/codeql-bundle.tar.gz"
+        elif [[ ${{ inputs.version }} == *"nightly"* ]]; then
+          export VERSION=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
+          echo "::set-output name=tools-url::https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-$VERSION-manual/codeql-bundle.tar.gz"
+        elif [[ ${{ inputs.version }} == *"stable"* ]]; then
+          export VERSION=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
+          echo "Hello $VERSION"
+          echo "::set-output name=tools-url::https://github.com/github/codeql-action/releases/download/codeql-bundle-$VERSION/codeql-bundle.tar.gz"
+        elif [[ ${{ inputs.version }} == "latest" ]]; then
+          echo "::set-output name=tools-url::latest"
+        elif [[ ${{ inputs.version }} == "cached" ]]; then
+          echo "::set-output name=tools-url::"
+        else
+          echo "::error Unrecognized version specified!"
+        fi

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -1,0 +1,60 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: 'PR Check - Go: Custom queries'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  go-custom-queries:
+    strategy:
+      matrix:
+        version:
+        - stable-20201028
+        - stable-20210319
+        - stable-20210809
+        - cached
+        - latest
+        - nightly-latest
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+    name: 'Go: Custom queries'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13.1
+    - uses: ./../action/init
+      with:
+        languages: go
+        config-file: ./.github/codeql/custom-queries.yml
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      env:
+        TEST_MODE: true

--- a/.github/workflows/__go-custom-tracing-autobuild.yml
+++ b/.github/workflows/__go-custom-tracing-autobuild.yml
@@ -1,0 +1,63 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: 'PR Check - Go: Autobuild custom tracing'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  go-custom-tracing-autobuild:
+    strategy:
+      matrix:
+        version:
+        - stable-20201028
+        - stable-20210319
+        - stable-20210809
+        - cached
+        - latest
+        - nightly-latest
+        os: [ubuntu-latest, macos-latest]
+    name: 'Go: Autobuild custom tracing'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13.1
+    - uses: ./../action/init
+      with:
+        languages: go
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - uses: ./../action/autobuild
+    - uses: ./../action/analyze
+      env:
+        TEST_MODE: true
+    - shell: bash
+      run: |
+        cd "$RUNNER_TEMP/codeql_databases"
+        if [[ ! -d go ]]; then
+          echo "Did not find a Go database"
+          exit 1
+        fi
+    env:
+      CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'true'

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -1,0 +1,61 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: 'PR Check - Go: Custom tracing'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  go-custom-tracing:
+    strategy:
+      matrix:
+        version:
+        - stable-20201028
+        - stable-20210319
+        - stable-20210809
+        - cached
+        - latest
+        - nightly-latest
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+    name: 'Go: Custom tracing'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13.1
+    - uses: ./../action/init
+      with:
+        languages: go
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Build code
+      shell: bash
+      run: go build main.go
+    - uses: ./../action/analyze
+      env:
+        TEST_MODE: true
+    env:
+      CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'true'

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -1,0 +1,59 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - Custom source root
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  javascript-source-root:
+    strategy:
+      matrix:
+        version: [latest, cached, nightly-latest] # This feature is not compatible with old CLIs
+        os: [ubuntu-latest]
+    name: Custom source root
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - name: Move codeql-action
+      shell: bash
+      run: |
+        mkdir ../new-source-root
+        mv * ../new-source-root
+    - uses: ./../action/init
+      with:
+        languages: javascript
+        source-root: ../new-source-root
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - uses: ./../action/analyze
+      with:
+        skip-queries: true
+        upload: false
+    - name: Assert database exists
+      shell: bash
+      run: |
+        cd "$RUNNER_TEMP/codeql_databases"
+        if [[ ! -d javascript ]]; then
+          echo "Did not find a JavaScript database"
+          exit 1
+        fi

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -1,0 +1,86 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - Multi-language repository
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  multi-language-autodetect:
+    strategy:
+      matrix:
+        version:
+        - stable-20201028
+        - stable-20210319
+        - stable-20210809
+        - cached
+        - latest
+        - nightly-latest
+        os: [ubuntu-latest, macos-latest]
+    name: Multi-language repository
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        db-location: ${{ runner.temp }}/customDbLocation
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      id: analysis
+      env:
+        TEST_MODE: true
+    - shell: bash
+      run: |
+        CPP_DB=${{ fromJson(steps.analysis.outputs.db-locations).cpp }}
+        if [[ ! -d $CPP_DB ]] || [[ ! $CPP_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+          echo "Did not create a database for CPP, or created it in the wrong location."
+          exit 1
+        fi
+        CSHARP_DB=${{ fromJson(steps.analysis.outputs.db-locations).csharp }}
+        if [[ ! -d $CSHARP_DB ]] || [[ ! $CSHARP_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+          echo "Did not create a database for C Sharp, or created it in the wrong location."
+          exit 1
+        fi
+        GO_DB=${{ fromJson(steps.analysis.outputs.db-locations).go }}
+        if [[ ! -d $GO_DB ]] || [[ ! $GO_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+          echo "Did not create a database for Go, or created it in the wrong location."
+          exit 1
+        fi
+        JAVA_DB=${{ fromJson(steps.analysis.outputs.db-locations).java }}
+        if [[ ! -d $JAVA_DB ]] || [[ ! $JAVA_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+          echo "Did not create a database for Java, or created it in the wrong location."
+          exit 1
+        fi
+        JAVASCRIPT_DB=${{ fromJson(steps.analysis.outputs.db-locations).javascript }}
+        if [[ ! -d $JAVASCRIPT_DB ]] || [[ ! $JAVASCRIPT_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+          echo "Did not create a database for Javascript, or created it in the wrong location."
+          exit 1
+        fi
+        PYTHON_DB=${{ fromJson(steps.analysis.outputs.db-locations).python }}
+        if [[ ! -d $PYTHON_DB ]] || [[ ! $PYTHON_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+          echo "Did not create a database for Python, or created it in the wrong location."
+          exit 1
+        fi

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -1,0 +1,65 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: 'PR Check - Packaging: Config and input'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  packaging-config-inputs-js:
+    strategy:
+      matrix:
+        version: [nightly-20210831] # This CLI version is known to work with package used in this test
+        os: [ubuntu-latest, macos-latest]
+    name: 'Packaging: Config and input'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        config-file: .github/codeql/codeql-config-packaging3.yml
+        packs: +dsp-testing/codeql-pack1@0.1.0
+        languages: javascript
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      with:
+        output: ${{ runner.temp }}/results
+      env:
+        TEST_MODE: true
+    - name: Assert Results
+      shell: bash
+      run: |
+        cd "$RUNNER_TEMP/results"
+        # We should have 3 hits from these rules
+        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+        echo "Found matching rules '$RULES'"
+        if [ "$RULES" != "$EXPECTED_RULES" ]; then
+          echo "Did not match expected rules '$EXPECTED_RULES'."
+          exit 1
+        fi

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -1,0 +1,64 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: 'PR Check - Packaging: Config file'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  packaging-config-js:
+    strategy:
+      matrix:
+        version: [nightly-20210831] # This CLI version is known to work with package used in this test
+        os: [ubuntu-latest, macos-latest]
+    name: 'Packaging: Config file'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        config-file: .github/codeql/codeql-config-packaging.yml
+        languages: javascript
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      with:
+        output: ${{ runner.temp }}/results
+      env:
+        TEST_MODE: true
+    - name: Assert Results
+      shell: bash
+      run: |
+        cd "$RUNNER_TEMP/results"
+        # We should have 3 hits from these rules
+        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+        echo "Found matching rules '$RULES'"
+        if [ "$RULES" != "$EXPECTED_RULES" ]; then
+          echo "Did not match expected rules '$EXPECTED_RULES'."
+          exit 1
+        fi

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -1,0 +1,65 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: 'PR Check - Packaging: Action input'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  packaging-inputs-js:
+    strategy:
+      matrix:
+        version: [nightly-20210831] # This CLI version is known to work with package used in this test
+        os: [ubuntu-latest, macos-latest]
+    name: 'Packaging: Action input'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        config-file: .github/codeql/codeql-config-packaging2.yml
+        languages: javascript
+        packs: dsp-testing/codeql-pack1@0.1.0, dsp-testing/codeql-pack2
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      with:
+        output: ${{ runner.temp }}/results
+      env:
+        TEST_MODE: true
+    - name: Assert Results
+      shell: bash
+      run: |
+        cd "$RUNNER_TEMP/results"
+        # We should have 3 hits from these rules
+        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+        echo "Found matching rules '$RULES'"
+        if [ "$RULES" != "$EXPECTED_RULES" ]; then
+          echo "Did not match expected rules '$EXPECTED_RULES'."
+          exit 1
+        fi

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -1,0 +1,58 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - Remote config file
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  remote-config:
+    strategy:
+      matrix:
+        version:
+        - stable-20201028
+        - stable-20210319
+        - stable-20210809
+        - cached
+        - latest
+        - nightly-latest
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+    name: Remote config file
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+        languages: cpp,csharp,java,javascript,python
+        config-file: github/codeql-action/tests/multi-language-repo/.github/codeql/custom-queries.yml@${{
+          github.sha }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      env:
+        TEST_MODE: true

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -1,0 +1,65 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - RuboCop multi-language
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  rubocop-multi-language:
+    strategy:
+      matrix:
+        version:
+        - stable-20201028
+        - stable-20210319
+        - stable-20210809
+        - cached
+        - latest
+        - nightly-latest
+        os: [ubuntu-latest]
+    name: RuboCop multi-language
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - name: Install Code Scanning integration
+      shell: bash
+      run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
+    - name: Install dependencies
+      shell: bash
+      run: bundle install
+    - name: RuboCop run
+      shell: bash
+      run: |
+        bash -c "
+          bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
+          [[ $? -ne 2 ]]
+        "
+    - uses: ./../action/upload-sarif
+      with:
+        sarif_file: rubocop.sarif
+      env:
+        TEST_MODE: true

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -1,0 +1,78 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - Split workflow
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  split-workflow:
+    strategy:
+      matrix:
+        version: [nightly-20210831] # This CLI version is known to work with package used in this test
+        os: [ubuntu-latest, macos-latest]
+    name: Split workflow
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        config-file: .github/codeql/codeql-config-packaging3.yml
+        packs: +dsp-testing/codeql-pack1@0.1.0
+        languages: javascript
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      with:
+        skip-queries: true
+        output: ${{ runner.temp }}/results
+      env:
+        TEST_MODE: true
+    - name: Assert No Results
+      shell: bash
+      run: |
+        if [ "$(ls -A $RUNNER_TEMP/results)" ]; then
+          echo "Expected results directory to be empty after skipping query execution!"
+          exit 1
+        fi
+    - uses: ./../action/analyze
+      with:
+        output: ${{ runner.temp }}/results
+      env:
+        TEST_MODE: true
+    - name: Assert Results
+      shell: bash
+      run: |
+        cd "$RUNNER_TEMP/results"
+        # We should have 3 hits from these rules
+        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+        echo "Found matching rules '$RULES'"
+        if [ "$RULES" != "$EXPECTED_RULES" ]; then
+          echo "Did not match expected rules '$EXPECTED_RULES'."
+          exit 1
+        fi

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -1,0 +1,52 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - Local CodeQL bundle
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  test-local-codeql:
+    strategy:
+      matrix:
+        version: [nightly-latest]
+        os: [ubuntu-latest]
+    name: Local CodeQL bundle
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - name: Fetch a CodeQL bundle
+      shell: bash
+      env:
+        CODEQL_URL: ${{ steps.prepare-test.outputs.tools-url }}
+      run: |
+        wget "$CODEQL_URL"
+    - uses: ./../action/init
+      with:
+        tools: ./codeql-bundle.tar.gz
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      env:
+        TEST_MODE: true

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -1,0 +1,54 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - Proxy test
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  test-proxy:
+    strategy:
+      matrix:
+        version: [latest]
+        os: [ubuntu-latest]
+    name: Proxy test
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        languages: javascript
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - uses: ./../action/analyze
+      env:
+        TEST_MODE: true
+    env:
+      https_proxy: http://squid-proxy:3128
+    container:
+      image: ubuntu:18.04
+      options: --dns 127.0.0.1
+    services:
+      squid-proxy:
+        image: datadog/squid:latest
+        ports:
+        - 3128:3128

--- a/.github/workflows/__test-ruby.yml
+++ b/.github/workflows/__test-ruby.yml
@@ -1,0 +1,55 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+name: PR Check - Ruby analysis
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+    - main
+    - v1
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  test-ruby:
+    strategy:
+      matrix:
+        version: [latest, cached, nightly-latest]
+        os: [ubuntu-latest, macos-latest]
+    name: Ruby analysis
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}
+    - uses: ./../action/init
+      with:
+        languages: ruby
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - uses: ./../action/analyze
+      id: analysis
+      env:
+        TEST_MODE: true
+    - name: Check database
+      shell: bash
+      run: |
+        RUBY_DB="${{ fromJson(steps.analysis.outputs.db-locations).ruby }}"
+        if [[ ! -d "$RUBY_DB" ]]; then
+          echo "Did not create a database for Ruby."
+          exit 1
+        fi
+    env:
+      CODEQL_ENABLE_EXPERIMENTAL_FEATURES: 'true'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,7 +1,4 @@
-name: PR checks
-
-env:
-  GO111MODULE: auto
+name: PR Checks (Basic Checks and Runner)
 
 on:
   push:
@@ -18,637 +15,56 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Run Lint
-      run: npm run-script lint
+      - uses: actions/checkout@v2
+      - name: Run Lint
+        run: npm run-script lint
 
   check-js:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Check generated JS
-      run: .github/workflows/script/check-js.sh
+      - uses: actions/checkout@v2
+      - name: Check generated JS
+        run: .github/workflows/script/check-js.sh
 
   check-node-modules:
     name: Check modules up to date
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Check node modules up to date
-      run: .github/workflows/script/check-node-modules.sh
+      - uses: actions/checkout@v2
+      - name: Check node modules up to date
+        run: .github/workflows/script/check-node-modules.sh
+
+  verify-pr-checks:
+    name: Verify PR checks up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruamel.yaml
+      - name: Verify PR checks up to date
+        run: .github/workflows/script/verify-pr-checks.sh
 
   npm-test:
     name: Unit Test
     needs: [check-js, check-node-modules]
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: npm run-script test
-      run: npm run-script test
-
-  multi-language-repo_test-autodetect-languages:
-    name: Autodetect language (multi)
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        db-location: "${{ runner.temp }}/customDbLocation"
-    - name: Build code
-      shell: bash
-      run: ./build.sh
-    - uses: ./../action/analyze
-      id: analysis
-      env:
-        TEST_MODE: true
-    - run: |
-        CPP_DB=${{ fromJson(steps.analysis.outputs.db-locations).cpp }}
-        if [[ ! -d $CPP_DB ]] || [[ ! $CPP_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
-          echo "Did not create a database for CPP, or created it in the wrong location."
-          exit 1
-        fi
-        CSHARP_DB=${{ fromJson(steps.analysis.outputs.db-locations).csharp }}
-        if [[ ! -d $CSHARP_DB ]] || [[ ! $CSHARP_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
-          echo "Did not create a database for C Sharp, or created it in the wrong location."
-          exit 1
-        fi
-        GO_DB=${{ fromJson(steps.analysis.outputs.db-locations).go }}
-        if [[ ! -d $GO_DB ]] || [[ ! $GO_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
-          echo "Did not create a database for Go, or created it in the wrong location."
-          exit 1
-        fi
-        JAVA_DB=${{ fromJson(steps.analysis.outputs.db-locations).java }}
-        if [[ ! -d $JAVA_DB ]] || [[ ! $JAVA_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
-          echo "Did not create a database for Java, or created it in the wrong location."
-          exit 1
-        fi
-        JAVASCRIPT_DB=${{ fromJson(steps.analysis.outputs.db-locations).javascript }}
-        if [[ ! -d $JAVASCRIPT_DB ]] || [[ ! $JAVASCRIPT_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
-          echo "Did not create a database for Javascript, or created it in the wrong location."
-          exit 1
-        fi
-        PYTHON_DB=${{ fromJson(steps.analysis.outputs.db-locations).python }}
-        if [[ ! -d $PYTHON_DB ]] || [[ ! $PYTHON_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
-          echo "Did not create a database for Python, or created it in the wrong location."
-          exit 1
-        fi
-
-  # Packaging test that runs against a javascript database
-  # Specifying packs in the config file.
-  test-packaging-javascript-config:
-    name: Packaging Config JS
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        config-file: ".github/codeql/codeql-config-packaging.yml"
-        languages: javascript
-        # This version is known to worl with 0.1.0
-        tools: https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-20210831-manual/codeql-bundle.tar.gz
-    - name: Build code
-      shell: bash
-      run: ./build.sh
-    - uses: ./../action/analyze
-      with:
-        output: "${{ runner.temp }}/results"
-      env:
-        TEST_MODE: true
-    - name: Assert Results
-      run: |
-        cd "$RUNNER_TEMP/results"
-        # We should have 3 hits from these rules
-        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
-
-        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
-        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
-        echo "Found matching rules '$RULES'"
-        if [ "$RULES" != "$EXPECTED_RULES" ]; then
-          echo "Did not match expected rules '$EXPECTED_RULES'."
-          exit 1
-        fi
-
-  # Packaging test that runs against a javascript database
-  # Specifying packs as an input.
-  test-packaging-javascript-inputs:
-    name: Packaging Inputs JS
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        config-file: ".github/codeql/codeql-config-packaging2.yml"
-        languages: javascript
-        packs: dsp-testing/codeql-pack1@0.1.0, dsp-testing/codeql-pack2
-        # This version is known to worl with 0.1.0
-        tools: https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-20210831-manual/codeql-bundle.tar.gz
-
-    - name: Build code
-      shell: bash
-      run: ./build.sh
-    - uses: ./../action/analyze
-      with:
-        output: "${{ runner.temp }}/results"
-      env:
-        TEST_MODE: true
-    - name: Assert Results
-      run: |
-        cd "$RUNNER_TEMP/results"
-        # We should have 3 hits from these rules
-        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
-
-        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
-        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
-        echo "Found matching rules '$RULES'"
-        if [ "$RULES" != "$EXPECTED_RULES" ]; then
-          echo "Did not match expected rules '$EXPECTED_RULES'."
-          exit 1
-        fi
-
-  # Packaging test that runs against a javascript database
-  # Specifying packs in the config file and inputs.
-  test-packaging-javascript-config-and-inputs:
-    name: Packaging Inputs and Config JS
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        config-file: ".github/codeql/codeql-config-packaging3.yml"
-        packs: +dsp-testing/codeql-pack1@0.1.0
-        languages: javascript
-        # This version is known to worl with 0.1.0
-        tools: https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-20210831-manual/codeql-bundle.tar.gz
-
-    - name: Build code
-      shell: bash
-      run: ./build.sh
-    - uses: ./../action/analyze
-      with:
-        output: "${{ runner.temp }}/results"
-      env:
-        TEST_MODE: true
-    - name: Assert Results
-      run: |
-        cd "$RUNNER_TEMP/results"
-        # We should have 3 hits from these rules
-        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
-
-        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
-        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
-        echo "Found matching rules '$RULES'"
-        if [ "$RULES" != "$EXPECTED_RULES" ]; then
-          echo "Did not match expected rules '$EXPECTED_RULES'."
-          exit 1
-        fi
-
-  # Tests a split workflow where database construction and query execution happen in different steps
-  test-split-workflow:
-    name: Split workflow
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        config-file: ".github/codeql/codeql-config-packaging3.yml"
-        packs: +dsp-testing/codeql-pack1@0.1.0
-        languages: javascript
-        # This version is known to worl with 0.1.0
-        tools: https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-20210831-manual/codeql-bundle.tar.gz
-    - name: Build code
-      shell: bash
-      run: ./build.sh
-    - uses: ./../action/analyze
-      with:
-        skip-queries: true
-        output: "${{ runner.temp }}/results"
-      env:
-        TEST_MODE: true
-    - name: Assert No Results
-      run: |
-        if [ "$(ls -A $RUNNER_TEMP/results)" ]; then
-          echo "Expected results directory to be empty after skipping query execution!"
-          exit 1
-        fi
-    - uses: ./../action/analyze
-      with:
-        output: "${{ runner.temp }}/results"
-      env:
-        TEST_MODE: true
-    - name: Assert Results
-      run: |
-        cd "$RUNNER_TEMP/results"
-        # We should have 3 hits from these rules
-        EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
-
-        # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
-        RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
-        echo "Found matching rules '$RULES'"
-        if [ "$RULES" != "$EXPECTED_RULES" ]; then
-          echo "Did not match expected rules '$EXPECTED_RULES'."
-          exit 1
-        fi
-
-  # Identify the CodeQL tool versions to integration test against.
-  check-codeql-versions:
-    name: Check CodeQL Versions
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-    outputs:
-      versions: ${{ steps.compare.outputs.versions }}
-      nightly-url: ${{ steps.get-url.outputs.nightly-url }}
-    env:
-      # URL of the oldest release that we support, if this is being bumped then the constant
-      # CODEQL_MINIMUM_VERSION in the file codeql.ts should also be bumped to match this.
-      OLDEST_URL: https://github.com/github/codeql-action/releases/download/codeql-bundle-20201028/codeql-bundle.tar.gz
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - name: Init with default CodeQL bundle from the VM image
-      id: init-default
-      uses: ./../action/init
-      with:
-        languages: javascript
-    - name: Remove empty database
-      # allows us to run init a second time
-      run: |
-        rm -rf "$RUNNER_TEMP/codeql_databases"
-    - name: Init with latest CodeQL bundle
-      id: init-latest
-      uses: ./../action/init
-      with:
-        tools: latest
-        languages: javascript
-    - name: Remove empty database
-      # allows us to run init a third time
-      run: |
-        rm -rf "$RUNNER_TEMP/codeql_databases"
-    - name: Get nightly release URL
-      id: get-url
-      env:
-        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      shell: bash
-      # This workflow step gets an unstable testing version of the CodeQL CLI. It should not be used outside of these tests.
-      run: |
-        export LATEST=`gh release list --repo dsp-testing/codeql-cli-nightlies -L 1 | cut -f 3`
-        echo "::set-output name=nightly-url::https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/$LATEST/codeql-bundle.tar.gz"
-    - name: Init with a CodeQL bundle from a nightly release
-      id: init-nightly
-      uses: ./../action/init
-      with:
-        tools: ${{ steps.get-url.outputs.nightly-url }}
-        languages: javascript
-    - name: Remove empty database
-      # allows us to run init a fourth time
-      run: |
-        rm -rf "$RUNNER_TEMP/codeql_databases"
-    - name: Init with a CodeQL bundle from the oldest supported release
-      id: init-oldest
-      uses: ./../action/init
-      with:
-        tools: ${{ env.OLDEST_URL }}
-        languages: javascript
-    - name: Compare CodeQL bundle versions
-      id: compare
-      env:
-        CODEQL_DEFAULT: ${{ steps.init-default.outputs.codeql-path }}
-        CODEQL_LATEST: ${{ steps.init-latest.outputs.codeql-path }}
-        CODEQL_NIGHTLY: ${{ steps.init-nightly.outputs.codeql-path }}
-        CODEQL_OLDEST: ${{ steps.init-oldest.outputs.codeql-path }}
-        NIGHTLY_URL: ${{ steps.get-url.outputs.nightly-url }}
-      run: |
-        CODEQL_VERSION_DEFAULT="$("$CODEQL_DEFAULT" version --format terse)"
-        CODEQL_VERSION_LATEST="$("$CODEQL_LATEST" version --format terse)"
-        CODEQL_VERSION_NIGHTLY="$("$CODEQL_NIGHTLY" version --format terse)"
-        CODEQL_VERSION_OLDEST="$("$CODEQL_OLDEST" version --format terse)"
-        echo "Default CodeQL bundle version is $CODEQL_VERSION_DEFAULT"
-        echo "Latest CodeQL bundle version is $CODEQL_VERSION_LATEST"
-        echo "Nightly CodeQL bundle version is $CODEQL_VERSION_NIGHTLY"
-        echo "Oldest supported CodeQL bundle version is $CODEQL_VERSION_OLDEST"
-
-        # If we're running on a pull request, run each integration test with all four bundles, even
-        # if `tools: latest` would be the same as `tools: null`. This allows us to make the
-        # integration test job for each of the four bundles a required status check.
-        #
-        # If we're running on push, then we can skip running with `tools: latest` when it would be
-        # the same as running with `tools: null`.
-        if [[ "$GITHUB_EVENT_NAME" != "pull_request" && "$CODEQL_VERSION_DEFAULT" == "$CODEQL_VERSION_LATEST" ]]; then
-          VERSIONS_JSON="[null, \"$NIGHTLY_URL\", \"$OLDEST_URL\"]"
-        else
-          VERSIONS_JSON="[null, \"$NIGHTLY_URL\", \"$OLDEST_URL\", \"latest\"]"
-        fi
-
-        # Output a JSON-encoded list with the distinct versions to test against.
-        echo "Suggested matrix config for integration tests: $VERSIONS_JSON"
-        echo "::set-output name=versions::${VERSIONS_JSON}"
-
-  multi-language-repo_test-custom-queries-and-remote-config:
-    name: Remote Config Custom Queries multi-language repo
-    needs: [check-js, check-node-modules, check-codeql-versions]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        tools: ${{ fromJson(needs.check-codeql-versions.outputs.versions) }}
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        tools: ${{ matrix.tools }}
-        languages: cpp,csharp,java,javascript,python
-        config-file: github/codeql-action/tests/multi-language-repo/.github/codeql/custom-queries.yml@${{ github.sha }}
-    - name: Build code
-      shell: bash
-      run: ./build.sh
-    - uses: ./../action/analyze
-      env:
-        TEST_MODE: true
-
-  # Currently is not possible to analyze Go in conjunction with other languages in macos
-  multi-language-repo_test-go-custom-queries:
-    name: Go custom queries multi-language repo
-    needs: [check-js, check-node-modules, check-codeql-versions]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        tools: ${{ fromJson(needs.check-codeql-versions.outputs.versions) }}
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - uses: actions/setup-go@v2
-      if: ${{ matrix.os ==  'macos-latest' }}
-      with:
-        go-version: '^1.13.1'
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        languages: go
-        config-file: ./.github/codeql/custom-queries.yml
-        tools: ${{ matrix.tools }}
-    - name: Build code
-      shell: bash
-      run: ./build.sh
-    - uses: ./../action/analyze
-      env:
-        TEST_MODE: true
-
-  go-custom-tracing:
-    name: Go custom tracing
-    needs: [check-js, check-node-modules, check-codeql-versions]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        tools: ${{ fromJson(needs.check-codeql-versions.outputs.versions) }}
-    runs-on: ${{ matrix.os }}
-    env:
-      CODEQL_EXTRACTOR_GO_BUILD_TRACING: "on"
-
-    steps:
-    - uses: actions/setup-go@v2
-      if: ${{ matrix.os ==  'macos-latest' }}
-      with:
-        go-version: '^1.13.1'
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        languages: go
-        tools: ${{ matrix.tools }}
-    - name: Build code
-      shell: bash
-      run: go build main.go
-    - uses: ./../action/analyze
-      env:
-        TEST_MODE: true
-
-  go-custom-tracing-autobuild:
-    name: Go autobuild custom tracing
-    needs: [check-js, check-node-modules, check-codeql-versions]
-    strategy:
-      fail-fast: false
-      matrix:
-        tools: ${{ fromJson(needs.check-codeql-versions.outputs.versions) }}
-    # No need to test Go autobuild on multiple OSes since
-    # we're testing Go custom tracing with a manual build on all OSes.
-    runs-on: ubuntu-latest
-    env:
-      CODEQL_EXTRACTOR_GO_BUILD_TRACING: "on"
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        languages: go
-        tools: ${{ matrix.tools }}
-    - uses: ./../action/autobuild
-    - uses: ./../action/analyze
-      env:
-        TEST_MODE: true
-    - run: |
-        cd "$RUNNER_TEMP/codeql_databases"
-        if [[ ! -d go ]]; then
-          echo "Did not find a Go database"
-          exit 1
-        fi
-
-  # Ruby is in beta, so test it separately for now.
-  multi-language-repo_test-ruby:
-    name: Ruby multi-language
-    needs: [check-js, check-node-modules, check-codeql-versions]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        tools:
-          - latest
-          # TODO: Uncomment when nightly builds also support Ruby in beta.
-          # - ${{ needs.check-codeql-versions.outputs.nightly-url }}
-    runs-on: ${{ matrix.os }}
-    env:
-      CODEQL_ENABLE_EXPERIMENTAL_FEATURES: true
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        languages: ruby
-        tools: ${{ matrix.tools }}
-    - uses: ./../action/analyze
-      id: analysis
-      env:
-        TEST_MODE: true
-    - name: Check database
-      shell: bash
-      run: |
-        RUBY_DB="${{ fromJson(steps.analysis.outputs.db-locations).ruby }}"
-        if [[ ! -d "$RUBY_DB" ]]; then
-          echo "Did not create a database for Ruby."
-          exit 1
-        fi
-
-  multi-language-repo_rubocop:
-    name: Rubocop multi-language
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.6
-    - name: Install Code Scanning integration
-      run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
-    - name: Install dependencies
-      run: bundle install
-    - name: Rubocop run
-      run: |
-        bash -c "
-          bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
-          [[ $? -ne 2 ]]
-        "
-    - uses: ./../action/upload-sarif
-      with:
-        sarif_file: rubocop.sarif
-      env:
-        TEST_MODE: true
-
-  test-proxy:
-    name: Proxy
-    needs: [check-js, check-node-modules, check-codeql-versions]
-    strategy:
-      fail-fast: false
-      matrix:
-        tools: ${{ fromJson(needs.check-codeql-versions.outputs.versions) }}
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:18.04
-      options: --dns 127.0.0.1
-    services:
-      squid-proxy:
-        image: datadog/squid:latest
-        ports:
-          - 3128:3128
-    env:
-      https_proxy: http://squid-proxy:3128
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        languages: javascript
-        tools: ${{ matrix.tools }}
-    - uses: ./../action/analyze
-      env:
-        TEST_MODE: true
+      - uses: actions/checkout@v2
+      - name: npm run-script test
+        run: npm run-script test
 
   runner-analyze-javascript-ubuntu:
     name: Runner ubuntu JS analyze
@@ -656,27 +72,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build runner
-      run: |
-        cd runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        # Pass --config-file here, but not for other jobs in this workflow.
-        # This means we're testing the config file parsing in the runner
-        # but not slowing down all jobs unnecessarily as it doesn't add much
-        # testing the parsing on different operating systems and languages.
-        runner/dist/codeql-runner-linux init --repository $GITHUB_REPOSITORY --languages javascript --config-file ./.github/codeql/codeql-config.yml --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          # Pass --config-file here, but not for other jobs in this workflow.
+          # This means we're testing the config file parsing in the runner
+          # but not slowing down all jobs unnecessarily as it doesn't add much
+          # testing the parsing on different operating systems and languages.
+          runner/dist/codeql-runner-linux init --repository $GITHUB_REPOSITORY --languages javascript --config-file ./.github/codeql/codeql-config.yml --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Run analyze
-      run: |
-        runner/dist/codeql-runner-linux analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          runner/dist/codeql-runner-linux analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-javascript-windows:
     name: Runner windows JS analyze
@@ -684,23 +100,23 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build runner
-      run: |
-        cd runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        runner/dist/codeql-runner-win.exe init --repository $Env:GITHUB_REPOSITORY --languages javascript --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          runner/dist/codeql-runner-win.exe init --repository $Env:GITHUB_REPOSITORY --languages javascript --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Run analyze
-      run: |
-        runner/dist/codeql-runner-win.exe analyze --repository $Env:GITHUB_REPOSITORY --commit $Env:GITHUB_SHA --ref $Env:GITHUB_REF --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          runner/dist/codeql-runner-win.exe analyze --repository $Env:GITHUB_REPOSITORY --commit $Env:GITHUB_SHA --ref $Env:GITHUB_REF --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-javascript-macos:
     name: Runner macos JS analyze
@@ -708,23 +124,23 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build runner
-      run: |
-        cd runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        runner/dist/codeql-runner-macos init --repository $GITHUB_REPOSITORY --languages javascript --config-file ./.github/codeql/codeql-config.yml --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          runner/dist/codeql-runner-macos init --repository $GITHUB_REPOSITORY --languages javascript --config-file ./.github/codeql/codeql-config.yml --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Run analyze
-      run: |
-        runner/dist/codeql-runner-macos analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          runner/dist/codeql-runner-macos analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-csharp-ubuntu:
     name: Runner ubuntu C# analyze
@@ -732,36 +148,36 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
+      - name: Move codeql-action
+        shell: bash
+        run: |
+          mkdir ../action
+          mv * .github ../action/
+          mv ../action/tests/multi-language-repo/{*,.github} .
+          mv ../action/.github/workflows .github
 
-    - name: Build runner
-      run: |
-        cd ../action/runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd ../action/runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        ../action/runner/dist/codeql-runner-linux init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          ../action/runner/dist/codeql-runner-linux init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Build code
-      run: |
-        . ./codeql-runner/codeql-env.sh
-        $CODEQL_RUNNER dotnet build
+      - name: Build code
+        run: |
+          . ./codeql-runner/codeql-env.sh
+          $CODEQL_RUNNER dotnet build
 
-    - name: Run analyze
-      run: |
-        ../action/runner/dist/codeql-runner-linux analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          ../action/runner/dist/codeql-runner-linux analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-csharp-windows:
     name: Runner windows C# analyze
@@ -769,39 +185,39 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
+      - name: Move codeql-action
+        shell: bash
+        run: |
+          mkdir ../action
+          mv * .github ../action/
+          mv ../action/tests/multi-language-repo/{*,.github} .
+          mv ../action/.github/workflows .github
 
-    - name: Build runner
-      run: |
-        cd ../action/runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd ../action/runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        ../action/runner/dist/codeql-runner-win.exe init --repository $Env:GITHUB_REPOSITORY --languages csharp --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          ../action/runner/dist/codeql-runner-win.exe init --repository $Env:GITHUB_REPOSITORY --languages csharp --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Build code
-      shell: powershell
-      # Note we want to make sure that the .win32env file is read correctly, so we unset the CODEQL_EXTRACTOR_CSHARP_ROOT from the .sh file.
-      run: |
-        cat ./codeql-runner/codeql-env.sh | Invoke-Expression
-        $Env:CODEQL_EXTRACTOR_CSHARP_ROOT = ""
-        & $Env:CODEQL_RUNNER dotnet build
+      - name: Build code
+        shell: powershell
+        # Note we want to make sure that the .win32env file is read correctly, so we unset the CODEQL_EXTRACTOR_CSHARP_ROOT from the .sh file.
+        run: |
+          cat ./codeql-runner/codeql-env.sh | Invoke-Expression
+          $Env:CODEQL_EXTRACTOR_CSHARP_ROOT = ""
+          & $Env:CODEQL_RUNNER dotnet build
 
-    - name: Run analyze
-      run: |
-        ../action/runner/dist/codeql-runner-win.exe analyze --repository $Env:GITHUB_REPOSITORY --commit $Env:GITHUB_SHA --ref $Env:GITHUB_REF --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          ../action/runner/dist/codeql-runner-win.exe analyze --repository $Env:GITHUB_REPOSITORY --commit $Env:GITHUB_SHA --ref $Env:GITHUB_REF --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-csharp-macos:
     name: Runner macos C# analyze
@@ -809,38 +225,37 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
+      - name: Move codeql-action
+        shell: bash
+        run: |
+          mkdir ../action
+          mv * .github ../action/
+          mv ../action/tests/multi-language-repo/{*,.github} .
+          mv ../action/.github/workflows .github
 
-    - name: Build runner
-      run: |
-        cd ../action/runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd ../action/runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        ../action/runner/dist/codeql-runner-macos init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          ../action/runner/dist/codeql-runner-macos init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Build code
-      shell: bash
-      run: |
-        . ./codeql-runner/codeql-env.sh
-        $CODEQL_RUNNER dotnet build
+      - name: Build code
+        shell: bash
+        run: |
+          . ./codeql-runner/codeql-env.sh
+          $CODEQL_RUNNER dotnet build
 
-    - name: Run analyze
-      run: |
-        ../action/runner/dist/codeql-runner-macos analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
-
+      - name: Run analyze
+        run: |
+          ../action/runner/dist/codeql-runner-macos analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-csharp-autobuild-ubuntu:
     name: Runner ubuntu autobuild C# analyze
@@ -848,35 +263,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
+      - name: Move codeql-action
+        shell: bash
+        run: |
+          mkdir ../action
+          mv * .github ../action/
+          mv ../action/tests/multi-language-repo/{*,.github} .
+          mv ../action/.github/workflows .github
 
-    - name: Build runner
-      run: |
-        cd ../action/runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd ../action/runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        ../action/runner/dist/codeql-runner-linux init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          ../action/runner/dist/codeql-runner-linux init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Build code
-      run: |
-        ../action/runner/dist/codeql-runner-linux autobuild
+      - name: Build code
+        run: |
+          ../action/runner/dist/codeql-runner-linux autobuild
 
-    - name: Run analyze
-      run: |
-        ../action/runner/dist/codeql-runner-linux analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          ../action/runner/dist/codeql-runner-linux analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-csharp-autobuild-windows:
     name: Runner windows autobuild C# analyze
@@ -884,36 +299,36 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
+      - name: Move codeql-action
+        shell: bash
+        run: |
+          mkdir ../action
+          mv * .github ../action/
+          mv ../action/tests/multi-language-repo/{*,.github} .
+          mv ../action/.github/workflows .github
 
-    - name: Build runner
-      run: |
-        cd ../action/runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd ../action/runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        ../action/runner/dist/codeql-runner-win.exe init --repository $Env:GITHUB_REPOSITORY --languages csharp --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          ../action/runner/dist/codeql-runner-win.exe init --repository $Env:GITHUB_REPOSITORY --languages csharp --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Build code
-      shell: powershell
-      run: |
-        ../action/runner/dist/codeql-runner-win.exe autobuild
+      - name: Build code
+        shell: powershell
+        run: |
+          ../action/runner/dist/codeql-runner-win.exe autobuild
 
-    - name: Run analyze
-      run: |
-        ../action/runner/dist/codeql-runner-win.exe analyze --repository $Env:GITHUB_REPOSITORY --commit $Env:GITHUB_SHA --ref $Env:GITHUB_REF --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          ../action/runner/dist/codeql-runner-win.exe analyze --repository $Env:GITHUB_REPOSITORY --commit $Env:GITHUB_SHA --ref $Env:GITHUB_REF --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-analyze-csharp-autobuild-macos:
     name: Runner macos autobuild C# analyze
@@ -921,36 +336,36 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Move codeql-action
-      shell: bash
-      run: |
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
+      - name: Move codeql-action
+        shell: bash
+        run: |
+          mkdir ../action
+          mv * .github ../action/
+          mv ../action/tests/multi-language-repo/{*,.github} .
+          mv ../action/.github/workflows .github
 
-    - name: Build runner
-      run: |
-        cd ../action/runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd ../action/runner
+          npm install
+          npm run build-runner
 
-    - name: Run init
-      run: |
-        ../action/runner/dist/codeql-runner-macos init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+      - name: Run init
+        run: |
+          ../action/runner/dist/codeql-runner-macos init --repository $GITHUB_REPOSITORY --languages csharp --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
 
-    - name: Build code
-      shell: bash
-      run: |
-        ../action/runner/dist/codeql-runner-macos autobuild
+      - name: Build code
+        shell: bash
+        run: |
+          ../action/runner/dist/codeql-runner-macos autobuild
 
-    - name: Run analyze
-      run: |
-        ../action/runner/dist/codeql-runner-macos analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
-      env:
-        TEST_MODE: true
+      - name: Run analyze
+        run: |
+          ../action/runner/dist/codeql-runner-macos analyze --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
+        env:
+          TEST_MODE: true
 
   runner-upload-sarif:
     name: Runner upload sarif
@@ -960,60 +375,16 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build runner
-      run: |
-        cd runner
-        npm install
-        npm run build-runner
+      - name: Build runner
+        run: |
+          cd runner
+          npm install
+          npm run build-runner
 
-    - name: Upload with runner
-      run: |
-        # Deliberately don't use TEST_MODE here. This is specifically testing
-        # the compatibility with the API.
-        runner/dist/codeql-runner-linux upload --sarif-file src/testdata/empty-sarif.sarif --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}
-
-  multi-language-repo_test-local-codeql:
-    name: Local codeql multi-language repo
-    needs: [check-js, check-node-modules, check-codeql-versions]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Move codeql-action
-      run: |
-        wget ${{ needs.check-codeql-versions.outputs.nightly-url }}
-        mkdir ../action
-        mv * .github ../action/
-        mv ../action/tests/multi-language-repo/{*,.github} .
-        mv ../action/.github/workflows .github
-    - uses: ./../action/init
-      with:
-        tools: ../action/codeql-bundle.tar.gz
-    - name: Build code
-      run: ./build.sh
-    - uses: ./../action/analyze
-
-  test-javascript-source-root:
-    name: JS source root
-    needs: [check-js, check-node-modules]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./init
-      with:
-        languages: javascript
-        source-root: tests/multi-language-repo
-    - uses: ./analyze
-      with:
-        skip-queries: true
-        upload: false
-    - name: Assert database exists
-      run: |
-        cd "$RUNNER_TEMP/codeql_databases"
-        if [[ ! -d javascript ]]; then
-          echo "Did not find a JavaScript database"
-          exit 1
-        fi
+      - name: Upload with runner
+        run: |
+          # Deliberately don't use TEST_MODE here. This is specifically testing
+          # the compatibility with the API.
+          runner/dist/codeql-runner-linux upload --sarif-file src/testdata/empty-sarif.sarif --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --ref $GITHUB_REF --github-url $GITHUB_SERVER_URL --github-auth ${{ github.token }}

--- a/.github/workflows/script/verify-pr-checks.sh
+++ b/.github/workflows/script/verify-pr-checks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu
+
+# Sanity check that repo is clean to start with
+if [ ! -z "$(git status --porcelain)" ]; then
+    # If we get a fail here then this workflow needs attention...
+    >&2 echo "Failed: Repo should be clean before testing!"
+    exit 1
+fi
+
+# Wipe the generated PR checks in case there are extra unnecessary files in there
+rm -rf .github/workflows/__*
+
+# Generate the PR checks
+cd pr-checks && python3 sync.py
+
+# Check that repo is still clean
+if [ ! -z "$(git status --porcelain)" ]; then
+    # If we get a fail here then the PR needs attention
+    git diff
+    git status
+    >&2 echo "Failed: PR checks are not up to date. Run 'cd pr-checks && python3 sync.py' to update"
+    exit 1
+fi
+echo "Success: PR checks are up to date"

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -1,0 +1,17 @@
+name: "Go: Custom queries"
+description: "Checks that Go works in conjunction with a config file specifying custom queries"
+steps:
+  - uses: actions/setup-go@v2
+    with:
+      go-version: "^1.13.1"
+  - uses: ./../action/init
+    with:
+      languages: go
+      config-file: ./.github/codeql/custom-queries.yml
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    env:
+      TEST_MODE: true

--- a/pr-checks/checks/go-custom-tracing-autobuild.yml
+++ b/pr-checks/checks/go-custom-tracing-autobuild.yml
@@ -1,0 +1,24 @@
+name: "Go: Autobuild custom tracing"
+description: "Checks that Go tracing works in conjunction with the autobuilder"
+os: ["ubuntu-latest", "macos-latest"]
+env:
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: "true"
+steps:
+  - uses: actions/setup-go@v2
+    with:
+      go-version: "^1.13.1"
+  - uses: ./../action/init
+    with:
+      languages: go
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - uses: ./../action/autobuild
+  - uses: ./../action/analyze
+    env:
+      TEST_MODE: true
+  - shell: bash
+    run: |
+      cd "$RUNNER_TEMP/codeql_databases"
+      if [[ ! -d go ]]; then
+        echo "Did not find a Go database"
+        exit 1
+      fi

--- a/pr-checks/checks/go-custom-tracing.yml
+++ b/pr-checks/checks/go-custom-tracing.yml
@@ -1,0 +1,18 @@
+name: "Go: Custom tracing"
+description: "Checks that Go tracing works"
+env:
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: "true"
+steps:
+  - uses: actions/setup-go@v2
+    with:
+      go-version: "^1.13.1"
+  - uses: ./../action/init
+    with:
+      languages: go
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Build code
+    shell: bash
+    run: go build main.go
+  - uses: ./../action/analyze
+    env:
+      TEST_MODE: true

--- a/pr-checks/checks/javascript-source-root.yml
+++ b/pr-checks/checks/javascript-source-root.yml
@@ -1,0 +1,27 @@
+name: "Custom source root"
+description: "Checks that the argument specifying a non-default source root works"
+versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
+os: ["ubuntu-latest"]
+steps:
+  - name: Move codeql-action
+    shell: bash
+    run: |
+      mkdir ../new-source-root
+      mv * ../new-source-root
+  - uses: ./../action/init
+    with:
+      languages: javascript
+      source-root: ../new-source-root
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - uses: ./../action/analyze
+    with:
+      skip-queries: true
+      upload: false
+  - name: Assert database exists
+    shell: bash
+    run: |
+      cd "$RUNNER_TEMP/codeql_databases"
+      if [[ ! -d javascript ]]; then
+        echo "Did not find a JavaScript database"
+        exit 1
+      fi

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -1,0 +1,47 @@
+name: "Multi-language repository"
+description: "An end-to-end integration test of a multi-language repository using automatic language detection"
+os: ["ubuntu-latest", "macos-latest"]
+steps:
+  - uses: ./../action/init
+    with:
+      db-location: "${{ runner.temp }}/customDbLocation"
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    id: analysis
+    env:
+      TEST_MODE: true
+  - shell: bash
+    run: |
+      CPP_DB=${{ fromJson(steps.analysis.outputs.db-locations).cpp }}
+      if [[ ! -d $CPP_DB ]] || [[ ! $CPP_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+        echo "Did not create a database for CPP, or created it in the wrong location."
+        exit 1
+      fi
+      CSHARP_DB=${{ fromJson(steps.analysis.outputs.db-locations).csharp }}
+      if [[ ! -d $CSHARP_DB ]] || [[ ! $CSHARP_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+        echo "Did not create a database for C Sharp, or created it in the wrong location."
+        exit 1
+      fi
+      GO_DB=${{ fromJson(steps.analysis.outputs.db-locations).go }}
+      if [[ ! -d $GO_DB ]] || [[ ! $GO_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+        echo "Did not create a database for Go, or created it in the wrong location."
+        exit 1
+      fi
+      JAVA_DB=${{ fromJson(steps.analysis.outputs.db-locations).java }}
+      if [[ ! -d $JAVA_DB ]] || [[ ! $JAVA_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+        echo "Did not create a database for Java, or created it in the wrong location."
+        exit 1
+      fi
+      JAVASCRIPT_DB=${{ fromJson(steps.analysis.outputs.db-locations).javascript }}
+      if [[ ! -d $JAVASCRIPT_DB ]] || [[ ! $JAVASCRIPT_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+        echo "Did not create a database for Javascript, or created it in the wrong location."
+        exit 1
+      fi
+      PYTHON_DB=${{ fromJson(steps.analysis.outputs.db-locations).python }}
+      if [[ ! -d $PYTHON_DB ]] || [[ ! $PYTHON_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
+        echo "Did not create a database for Python, or created it in the wrong location."
+        exit 1
+      fi

--- a/pr-checks/checks/packaging-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-config-inputs-js.yml
@@ -1,0 +1,33 @@
+name: "Packaging: Config and input"
+description: "Checks that specifying packages using a combination of a config file and input to the Action works"
+versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
+os: ["ubuntu-latest", "macos-latest"]
+steps:
+  - uses: ./../action/init
+    with:
+      config-file: ".github/codeql/codeql-config-packaging3.yml"
+      packs: +dsp-testing/codeql-pack1@0.1.0
+      languages: javascript
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    with:
+      output: "${{ runner.temp }}/results"
+    env:
+      TEST_MODE: true
+  - name: Assert Results
+    shell: bash
+    run: |
+      cd "$RUNNER_TEMP/results"
+      # We should have 3 hits from these rules
+      EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+      # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+      RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+      echo "Found matching rules '$RULES'"
+      if [ "$RULES" != "$EXPECTED_RULES" ]; then
+        echo "Did not match expected rules '$EXPECTED_RULES'."
+        exit 1
+      fi

--- a/pr-checks/checks/packaging-config-js.yml
+++ b/pr-checks/checks/packaging-config-js.yml
@@ -1,0 +1,32 @@
+name: "Packaging: Config file"
+description: "Checks that specifying packages using only a config file works"
+versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
+os: ["ubuntu-latest", "macos-latest"]
+steps:
+  - uses: ./../action/init
+    with:
+      config-file: ".github/codeql/codeql-config-packaging.yml"
+      languages: javascript
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    with:
+      output: "${{ runner.temp }}/results"
+    env:
+      TEST_MODE: true
+  - name: Assert Results
+    shell: bash
+    run: |
+      cd "$RUNNER_TEMP/results"
+      # We should have 3 hits from these rules
+      EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+      # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+      RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+      echo "Found matching rules '$RULES'"
+      if [ "$RULES" != "$EXPECTED_RULES" ]; then
+        echo "Did not match expected rules '$EXPECTED_RULES'."
+        exit 1
+      fi

--- a/pr-checks/checks/packaging-inputs-js.yml
+++ b/pr-checks/checks/packaging-inputs-js.yml
@@ -1,0 +1,33 @@
+name: "Packaging: Action input"
+description: "Checks that specifying packages using the input to the Action works"
+versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
+os: ["ubuntu-latest", "macos-latest"]
+steps:
+  - uses: ./../action/init
+    with:
+      config-file: ".github/codeql/codeql-config-packaging2.yml"
+      languages: javascript
+      packs: dsp-testing/codeql-pack1@0.1.0, dsp-testing/codeql-pack2
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    with:
+      output: "${{ runner.temp }}/results"
+    env:
+      TEST_MODE: true
+  - name: Assert Results
+    shell: bash
+    run: |
+      cd "$RUNNER_TEMP/results"
+      # We should have 3 hits from these rules
+      EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+      # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+      RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+      echo "Found matching rules '$RULES'"
+      if [ "$RULES" != "$EXPECTED_RULES" ]; then
+        echo "Did not match expected rules '$EXPECTED_RULES'."
+        exit 1
+      fi

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -1,0 +1,14 @@
+name: "Remote config file"
+description: "Checks that specifying packages using only a config file works"
+steps:
+  - uses: ./../action/init
+    with:
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+      languages: cpp,csharp,java,javascript,python
+      config-file: github/codeql-action/tests/multi-language-repo/.github/codeql/custom-queries.yml@${{ github.sha }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    env:
+      TEST_MODE: true

--- a/pr-checks/checks/rubocop-multi-language.yml
+++ b/pr-checks/checks/rubocop-multi-language.yml
@@ -1,0 +1,26 @@
+name: "RuboCop multi-language"
+description: "Tests using RuboCop to analyze a multi-language repository and then using the CodeQL Action to upload the resulting SARIF"
+os: ["ubuntu-latest"]
+steps:
+  - name: Set up Ruby
+    uses: ruby/setup-ruby@v1
+    with:
+      ruby-version: 2.6
+  - name: Install Code Scanning integration
+    shell: bash
+    run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
+  - name: Install dependencies
+    shell: bash
+    run: bundle install
+  - name: RuboCop run
+    shell: bash
+    run: |
+      bash -c "
+        bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
+        [[ $? -ne 2 ]]
+      "
+  - uses: ./../action/upload-sarif
+    with:
+      sarif_file: rubocop.sarif
+    env:
+      TEST_MODE: true

--- a/pr-checks/checks/split-workflow.yml
+++ b/pr-checks/checks/split-workflow.yml
@@ -1,0 +1,46 @@
+name: "Split workflow"
+description: "Tests a split-up workflow in which we first build a database and later analyze it"
+versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
+os: ["ubuntu-latest", "macos-latest"]
+steps:
+  - uses: ./../action/init
+    with:
+      config-file: ".github/codeql/codeql-config-packaging3.yml"
+      packs: +dsp-testing/codeql-pack1@0.1.0
+      languages: javascript
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    with:
+      skip-queries: true
+      output: "${{ runner.temp }}/results"
+    env:
+      TEST_MODE: true
+  - name: Assert No Results
+    shell: bash
+    run: |
+      if [ "$(ls -A $RUNNER_TEMP/results)" ]; then
+        echo "Expected results directory to be empty after skipping query execution!"
+        exit 1
+      fi
+  - uses: ./../action/analyze
+    with:
+      output: "${{ runner.temp }}/results"
+    env:
+      TEST_MODE: true
+  - name: Assert Results
+    shell: bash
+    run: |
+      cd "$RUNNER_TEMP/results"
+      # We should have 3 hits from these rules
+      EXPECTED_RULES="javascript/example/empty-or-one-block javascript/example/empty-or-one-block javascript/example/two-block"
+
+      # use tr to replace newlines with spaces and xargs to trim leading and trailing whitespace
+      RULES="$(cat javascript.sarif | jq -r '.runs[0].results[].ruleId' | sort | tr "\n" " " | xargs)"
+      echo "Found matching rules '$RULES'"
+      if [ "$RULES" != "$EXPECTED_RULES" ]; then
+        echo "Did not match expected rules '$EXPECTED_RULES'."
+        exit 1
+      fi

--- a/pr-checks/checks/test-local-codeql.yml
+++ b/pr-checks/checks/test-local-codeql.yml
@@ -1,0 +1,20 @@
+name: "Local CodeQL bundle"
+description: "Tests using a CodeQL bundle from a local file rather than a URL"
+versions: ["nightly-latest"]
+os: ["ubuntu-latest"]
+steps:
+  - name: Fetch a CodeQL bundle
+    shell: bash
+    env:
+      CODEQL_URL: ${{ steps.prepare-test.outputs.tools-url }}
+    run: |
+      wget "$CODEQL_URL"
+  - uses: ./../action/init
+    with:
+      tools: ./codeql-bundle.tar.gz
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    env:
+      TEST_MODE: true

--- a/pr-checks/checks/test-proxy.yml
+++ b/pr-checks/checks/test-proxy.yml
@@ -1,0 +1,22 @@
+name: "Proxy test"
+description: "Tests using a proxy specified by the https_proxy environment variable"
+versions: ["latest"]
+os: ["ubuntu-latest"]
+container:
+  image: ubuntu:18.04
+  options: --dns 127.0.0.1
+services:
+  squid-proxy:
+    image: datadog/squid:latest
+    ports:
+      - 3128:3128
+env:
+  https_proxy: http://squid-proxy:3128
+steps:
+  - uses: ./../action/init
+    with:
+      languages: javascript
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - uses: ./../action/analyze
+    env:
+      TEST_MODE: true

--- a/pr-checks/checks/test-ruby.yml
+++ b/pr-checks/checks/test-ruby.yml
@@ -1,0 +1,23 @@
+name: "Ruby analysis"
+description: "Tests creation of a Ruby database"
+versions: ["latest", "cached", "nightly-latest"]
+os: ["ubuntu-latest", "macos-latest"]
+env:
+  CODEQL_ENABLE_EXPERIMENTAL_FEATURES: "true"
+steps:
+  - uses: ./../action/init
+    with:
+      languages: ruby
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - uses: ./../action/analyze
+    id: analysis
+    env:
+      TEST_MODE: true
+  - name: Check database
+    shell: bash
+    run: |
+      RUBY_DB="${{ fromJson(steps.analysis.outputs.db-locations).ruby }}"
+      if [[ ! -d "$RUBY_DB" ]]; then
+        echo "Did not create a database for Ruby."
+        exit 1
+      fi

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -1,0 +1,104 @@
+import ruamel.yaml
+import os
+
+defaultTestVersions = [
+    # The oldest supported CodeQL version: 2.3.1. If bumping, update `CODEQL_MINIMUM_VERSION` in `codeql.ts`
+    "stable-20201028",
+    # The last CodeQL release in the 2.4 series: 2.4.6.
+    "stable-20210319",
+    # The last CodeQL release in the 2.5 series: 2.5.9.
+    "stable-20210809",
+    # The version of CodeQL currently in the toolcache. Typically either the latest release or the one before.
+    "cached",
+    # The latest release of CodeQL.
+    "latest",
+    # A nightly build directly from the our private repo, built in the last 24 hours.
+    "nightly-latest"
+]
+defaultOperatingSystems = ["ubuntu-latest", "macos-latest", "windows-latest"]
+header = """# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pip install ruamel.yaml && python3 sync.py
+# to regenerate this file.
+
+"""
+
+
+class NonAliasingRTRepresenter(ruamel.yaml.representer.RoundTripRepresenter):
+    def ignore_aliases(self, data):
+        return True
+
+
+def writeHeader(checkStream):
+    checkStream.write(header)
+
+
+yaml = ruamel.yaml.YAML()
+yaml.Representer = NonAliasingRTRepresenter
+allJobs = {}
+for file in os.listdir('checks'):
+    with open(f"checks/{file}", 'r') as checkStream:
+        checkSpecification = yaml.load(checkStream)
+
+    versions = defaultTestVersions
+    if 'versions' in checkSpecification:
+        versions = checkSpecification['versions']
+    operatingSystems = defaultOperatingSystems
+    if 'os' in checkSpecification:
+        operatingSystems = checkSpecification['os']
+
+    steps = [
+        {
+            'name': 'Check out repository',
+            'uses': 'actions/checkout@v2'
+        },
+        {
+            'name': 'Prepare test',
+            'id': 'prepare-test',
+            'uses': './.github/prepare-test',
+            'with': {
+                'version': '${{ matrix.version }}'
+            }
+        }
+    ]
+    steps.extend(checkSpecification['steps'])
+
+    checkJob = {
+        'strategy': {
+            'matrix': {
+                'version': versions,
+                'os': operatingSystems
+            }
+        },
+        'name': checkSpecification['name'],
+        'runs-on': '${{ matrix.os }}',
+        'steps': steps
+    }
+
+    for key in ["env", "container", "services"]:
+        if key in checkSpecification:
+            checkJob[key] = checkSpecification[key]
+
+    checkName = file[:len(file) - 4]
+
+    with open(f"../.github/workflows/__{checkName}.yml", 'w') as output_stream:
+        writeHeader(output_stream)
+        yaml.dump({
+            'name': f"PR Check - {checkSpecification['name']}",
+            'env': {
+                'GITHUB_TOKEN': '${{ secrets.GITHUB_TOKEN }}',
+                'GO111MODULE': 'auto',
+            },
+            'on': {
+                'push': {
+                    'branches': ['main', 'v1']
+                },
+                'pull_request': {
+                    'types': ["opened", "synchronize", "reopened", "ready_for_review"]
+                },
+                'workflow_dispatch': {}
+            },
+            'jobs': {
+                checkName: checkJob
+            }
+        }, output_stream)


### PR DESCRIPTION
This PR does a refactoring of how our PR checks work to try and make it a bit easier to understand the different checks and to ensure we get good coverage of different versions in all our tests. In particular, each check is now specified in an individual YAML file in the `pr-checks/checks` folder. This file has a name and description of the check, as well as the steps that are unique to that check. If the check is not designed to run with all supported versions of the CLI and/or operating systems, this is specified by fields in this YAML file as well.

A script `pr-checks/sync.py` reads in all these test specification files and builds up a workflow using all of them, inserting some common steps at the start of each check and matrixing each one over the combination of CLIs and/or operating systems that they support. If the test specifications claims to support everything, we use the following:

- CLI: 2.3.1 (oldest supported release), 2.4.6, 2.5.9, toolcache version, latest release, latest nightly.
- OS: Ubuntu, MacOS, Windows

This is similar to what the VS code extension tests against (recent versions and latest patch version of old minor versions), however instead of testing against the newest version of the 2.3 series we test against specifically 2.3.1 since it is the oldest version that the Action claims support for. We also don't test against anything in the 2.2 series since the Action does not support this.

A new PR check verifies that the generated workflows are in sync with the YAML files specifying the various checks. This check together with some other checks that do not fit the generating model (in particular, unit tests and tests of the runner) are in a separate workflow. All integration tests of the Action have been migrated to being generated.

The required checks will not pass on this PR because they have changed name - it will require force merging and updating the branch protection rules afterwards.