### PR TITLE
Bump release to `codeql-bundle-20210909`

### DIFF
--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,3 +1,3 @@
 {
-    "bundleVersion": "codeql-bundle-20210907"
+    "bundleVersion": "codeql-bundle-20210909"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,3 +1,3 @@
 {
-	"bundleVersion": "codeql-bundle-20210907"
+  "bundleVersion": "codeql-bundle-20210909"
 }


### PR DESCRIPTION
Bumps the default version to `codeql-bundle-20210909` which contains a patch to an upgrade script. This shouldn't actually affect the Action but it will be useful to run this repo's CI checks on the new bundle.