### PR TITLE
Dependabot: Ignore minor and patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,14 @@ updates:
       day: "thursday" # Gives us a working day to merge this before our typical release
     labels:
       - "Update dependencies"
+    ignore:
+      dependency-name: "*"
+      update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "npm"
     directory: "/runner"
     schedule:
       interval: "weekly"
       day: "thursday" # Gives us a working day to merge this before our typical release
+    ignore:
+      dependency-name: "*"
+      update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
This PR changes our Dependabot configuration to ignore minor and patch releases of dependencies and only try to carry out an update when the major version is bumped. Per the [documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore), this will not affect security updates which will still be carried out immediately.