### PR TITLE
Fix dependabot ignore syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,13 @@ updates:
     labels:
       - "Update dependencies"
     ignore:
-      dependency-name: "*"
-      update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "npm"
     directory: "/runner"
     schedule:
       interval: "weekly"
       day: "thursday" # Gives us a working day to merge this before our typical release
     ignore:
-      dependency-name: "*"
-      update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
This commit addresses the error:

```
The property '#/updates/0/ignore' of type object did not match the following type: array
The property '#/updates/1/ignore' of type object did not match the following type: array
```

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
