### PR TITLE
Bump default CodeQL version to 2.6.2 bundle

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -213,6 +213,12 @@ jobs:
           $Env:CODEQL_EXTRACTOR_CSHARP_ROOT = ""
           & $Env:CODEQL_RUNNER dotnet build
 
+      - name: Upload tracer logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: tracer-logs
+          path: ./codeql-runner
+
       - name: Run analyze
         run: |
           ../action/runner/dist/codeql-runner-win.exe analyze --repository $Env:GITHUB_REPOSITORY --commit $Env:GITHUB_SHA --ref $Env:GITHUB_REF --github-url $Env:GITHUB_SERVER_URL --github-auth ${{ github.token }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Build code
         run: |
           . ./codeql-runner/codeql-env.sh
-          $CODEQL_RUNNER dotnet build
+          $CODEQL_RUNNER dotnet build /p:UseSharedCompilation=false
 
       - name: Run analyze
         run: |
@@ -211,13 +211,13 @@ jobs:
         run: |
           cat ./codeql-runner/codeql-env.sh | Invoke-Expression
           $Env:CODEQL_EXTRACTOR_CSHARP_ROOT = ""
-          & $Env:CODEQL_RUNNER dotnet build
+          & $Env:CODEQL_RUNNER dotnet build /p:UseSharedCompilation=false
 
       - name: Upload tracer logs
         uses: actions/upload-artifact@v2
         with:
           name: tracer-logs
-          path: ./codeql-runner
+          path: ./codeql-runner/compound-build-tracer.log
 
       - name: Run analyze
         run: |
@@ -255,7 +255,7 @@ jobs:
         shell: bash
         run: |
           . ./codeql-runner/codeql-env.sh
-          $CODEQL_RUNNER dotnet build
+          $CODEQL_RUNNER dotnet build /p:UseSharedCompilation=false
 
       - name: Run analyze
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-No user facing changes.
+- Update default CodeQL bundle version to 2.6.2. [#746](https://github.com/github/codeql-action/pull/746)
 
 ## 1.0.14 - 09 Sep 2021
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,3 +1,3 @@
 {
-    "bundleVersion": "codeql-bundle-20210909"
+    "bundleVersion": "codeql-bundle-20210921"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,3 +1,3 @@
 {
-  "bundleVersion": "codeql-bundle-20210909"
+  "bundleVersion": "codeql-bundle-20210921"
 }

--- a/tests/multi-language-repo/build.sh
+++ b/tests/multi-language-repo/build.sh
@@ -2,7 +2,7 @@
 
 gcc -o main main.c
 
-dotnet build
+dotnet build -p:UseSharedCompilation=false
 
 javac Main.java
 


### PR DESCRIPTION
Part of the 2.6.2 release process.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
