### PR TITLE
Avoid using `pull_request_target`

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,7 +1,11 @@
 name: Update dependencies
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+
+permissions:
+  issues: write
+  contents: write
 
 jobs:
   update:


### PR DESCRIPTION
Move to using `pull_request` and a permissions block.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
