### PR TITLE
Further fix to update dependencies workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -35,5 +35,5 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git add node_modules
           git commit -am "Update checked-in dependencies"
-          git push origin "$BRANCH"
+          git push origin "HEAD:$BRANCH"
         fi


### PR DESCRIPTION
Follows on from https://github.com/github/codeql-action/pull/789.

Looks like the workflow still isn't quite working as intended: https://github.com/github/codeql-action/runs/3999885219?check_suite_focus=true

My understanding of that message is that because we're now in a detached HEAD state and haven't checked out the branch we need to change how we do the `git push`.