### PR TITLE
Remove `persist-credentials: false` from workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        persist-credentials: false
 
     - name: Remove PR label
       env:


### PR DESCRIPTION
This addition in https://github.com/github/codeql-action/pull/786 appears to have broken the workflow, reverting for now.

Successful run without that: https://github.com/github/codeql-action/actions/runs/1396501976/workflow
Failing run with that: https://github.com/github/codeql-action/actions/runs/1421162875/workflow

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
