### PR TITLE
Deal with new dotnet version

### DIFF
--- a/.github/workflows/__debug-artifacts.yml
+++ b/.github/workflows/__debug-artifacts.yml
@@ -41,6 +41,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -44,6 +44,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: actions/setup-go@v2
       with:
         go-version: ^1.13.1

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -41,6 +41,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         db-location: ${{ runner.temp }}/customDbLocation

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -35,6 +35,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         config-file: .github/codeql/codeql-config-packaging3.yml

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -35,6 +35,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         config-file: .github/codeql/codeql-config-packaging.yml

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -35,6 +35,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         config-file: .github/codeql/codeql-config-packaging2.yml

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -44,6 +44,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -35,6 +35,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         config-file: .github/codeql/codeql-config-packaging3.yml

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -35,6 +35,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - name: Fetch a CodeQL bundle
       shell: bash
       env:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -41,6 +41,8 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Initialize dotnet
+      run: dotnet restore
     - uses: ./../action/init
       with:
         db-location: ${{ runner.temp }}/customDbLocation

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -163,6 +163,9 @@ jobs:
           cd ../action/runner
           npm install
           npm run build-runner
+      
+      - name: Initialize dotnet
+        run: dotnet restore
 
       - name: Run init
         run: |
@@ -200,6 +203,9 @@ jobs:
           cd ../action/runner
           npm install
           npm run build-runner
+      
+      - name: Initialize dotnet
+        run: dotnet restore
 
       - name: Run init
         run: |
@@ -245,6 +251,9 @@ jobs:
           cd ../action/runner
           npm install
           npm run build-runner
+
+      - name: Initialize dotnet
+        run: dotnet restore
 
       - name: Run init
         run: |

--- a/pr-checks/checks/debug-artifacts.yml
+++ b/pr-checks/checks/debug-artifacts.yml
@@ -2,6 +2,8 @@ name: "Debug artifact upload"
 description: "Checks that debugging artifacts are correctly uploaded"
 os: ["ubuntu-latest", "macos-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -1,6 +1,8 @@
 name: "Go: Custom queries"
 description: "Checks that Go works in conjunction with a config file specifying custom queries"
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: actions/setup-go@v2
     with:
       go-version: "^1.13.1"

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -2,6 +2,8 @@ name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
 os: ["ubuntu-latest", "macos-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       db-location: "${{ runner.temp }}/customDbLocation"

--- a/pr-checks/checks/packaging-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-config-inputs-js.yml
@@ -3,6 +3,8 @@ description: "Checks that specifying packages using a combination of a config fi
 versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
 os: ["ubuntu-latest", "macos-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       config-file: ".github/codeql/codeql-config-packaging3.yml"

--- a/pr-checks/checks/packaging-config-js.yml
+++ b/pr-checks/checks/packaging-config-js.yml
@@ -3,6 +3,8 @@ description: "Checks that specifying packages using only a config file works"
 versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
 os: ["ubuntu-latest", "macos-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       config-file: ".github/codeql/codeql-config-packaging.yml"

--- a/pr-checks/checks/packaging-inputs-js.yml
+++ b/pr-checks/checks/packaging-inputs-js.yml
@@ -3,6 +3,8 @@ description: "Checks that specifying packages using the input to the Action work
 versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
 os: ["ubuntu-latest", "macos-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       config-file: ".github/codeql/codeql-config-packaging2.yml"

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -1,6 +1,8 @@
 name: "Remote config file"
 description: "Checks that specifying packages using only a config file works"
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/pr-checks/checks/split-workflow.yml
+++ b/pr-checks/checks/split-workflow.yml
@@ -3,6 +3,8 @@ description: "Tests a split-up workflow in which we first build a database and l
 versions: ["nightly-20210831"] # This CLI version is known to work with package used in this test
 os: ["ubuntu-latest", "macos-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       config-file: ".github/codeql/codeql-config-packaging3.yml"

--- a/pr-checks/checks/test-local-codeql.yml
+++ b/pr-checks/checks/test-local-codeql.yml
@@ -3,6 +3,8 @@ description: "Tests using a CodeQL bundle from a local file rather than a URL"
 versions: ["nightly-latest"]
 os: ["ubuntu-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - name: Fetch a CodeQL bundle
     shell: bash
     env:

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -2,6 +2,8 @@ name: "Test unsetting environment variables"
 description: "An end-to-end integration test that unsets some environment variables"
 os: ["ubuntu-latest"]
 steps:
+  - name: Initialize dotnet
+    run: dotnet restore
   - uses: ./../action/init
     with:
       db-location: "${{ runner.temp }}/customDbLocation"


### PR DESCRIPTION
A few CI checks are currently failing because dotnet is waiting for some user-input. e.g. https://github.com/github/codeql-action/runs/4381100962?check_suite_focus=true

This seems to be because of a change in the CodeQL CLI and how it handles dotnet under tracing in macos. This may get fixed in CodeQL but for now a workaround to get our CI working is to call `dotnet restore` when not traced by CodeQL so it can do it's first-time setup without interference.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
