### PR TITLE
Move changelog entry into correct place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## [UNRELEASED]
 
-No user facing changes.
+- The `analyze` and `upload-sarif` actions will now wait up to 2 minutes for processing to complete after they have uploaded the results so they can report any processing errors that occurred. This behavior can be disabled by setting the `wait-for-processing` action input to `"false"`.
+
 
 ## 1.0.26 - 10 Dec 2021
 
 - Update default CodeQL bundle version to 2.7.3. [#842](https://github.com/github/codeql-action/pull/842)
-- The `analyze` and `upload-sarif` actions will now wait up to 2 minutes for processing to complete after they have uploaded the results so they can report any processing errors that occurred. This behavior can be disabled by setting the `wait-for-processing` action input to `"false"`.
 
 ## 1.0.25 - 06 Dec 2021
 


### PR DESCRIPTION
Looks like the changelog entry in https://github.com/github/codeql-action/pull/843 was in the section for an already released version. This is moving it into the right place. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
