### PR TITLE
Remove debugging output

### DIFF
--- a/.github/prepare-test/action.yml
+++ b/.github/prepare-test/action.yml
@@ -28,7 +28,6 @@ runs:
           echo "::set-output name=tools-url::https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-$VERSION-manual/codeql-bundle.tar.gz"
         elif [[ ${{ inputs.version }} == *"stable"* ]]; then
           export VERSION=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
-          echo "Hello $VERSION"
           echo "::set-output name=tools-url::https://github.com/github/codeql-action/releases/download/codeql-bundle-$VERSION/codeql-bundle.tar.gz"
         elif [[ ${{ inputs.version }} == "latest" ]]; then
           echo "::set-output name=tools-url::latest"


### PR DESCRIPTION
Looks like I accidentally committed some debugging output when I wrote this part of our CI. This PR removes it.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
