### PR TITLE
Force virtualenv version

### DIFF
--- a/python-setup/install_tools.ps1
+++ b/python-setup/install_tools.ps1
@@ -5,8 +5,8 @@ py -3 -m pip install --user --upgrade pip setuptools wheel
 
 # virtualenv is a bit nicer for setting up virtual environment, since it will provide up-to-date versions of
 # pip/setuptools/wheel which basic `python3 -m venv venv` won't
-py -2 -m pip install --user virtualenv
-py -3 -m pip install --user virtualenv
+py -2 -m pip install --user 'virtualenv<20.11'
+py -3 -m pip install --user 'virtualenv<20.11'
 
 # poetry 1.0.10 has error (https://github.com/python-poetry/poetry/issues/2711)
 py -3 -m pip install --user poetry!=1.0.10

--- a/python-setup/install_tools.sh
+++ b/python-setup/install_tools.sh
@@ -15,7 +15,7 @@ python3 -m pip install --user --upgrade pip setuptools wheel
 
 # virtualenv is a bit nicer for setting up virtual environment, since it will provide up-to-date versions of
 # pip/setuptools/wheel which basic `python3 -m venv venv` won't
-python3 -m pip install --user virtualenv
+python3 -m pip install --user 'virtualenv<20.11'
 
 # We install poetry with pip instead of the recommended way, since the recommended way
 # caused some problem since `poetry run` gives output like:
@@ -35,5 +35,5 @@ if command -v python2 &> /dev/null; then
 
 	python2 -m pip install --user --upgrade pip setuptools wheel
 
-	python2 -m pip install --user virtualenv
+	python2 -m pip install --user 'virtualenv<20.11'
 fi


### PR DESCRIPTION
Force the virtualenv version to be 20.11 or less. The 20.12 version is failing for python 2 right now.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
