### PR TITLE
Revert "Start waiting for processing by default."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-No user facing changes.
+- The feature to wait for SARIF processing to complete after upload has been disabled by default due to a bug in its interaction with pull requests from forks.
 
 ## 1.0.28 - 18 Jan 2022
 

--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -55,7 +55,7 @@ inputs:
   wait-for-processing:
     description: If true, the Action will wait for the uploaded SARIF to be processed before completing.
     required: true
-    default: "true"
+    default: "false"
   token:
     default: ${{ github.token }}
   matrix:

--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -23,7 +23,7 @@ inputs:
   wait-for-processing:
     description: If true, the Action will wait for the uploaded SARIF to be processed before completing.
     required: true
-    default: "true"
+    default: "false"
 runs:
   using: 'node12'
   main: '../lib/upload-sarif-action.js'


### PR DESCRIPTION
This reverts commit b661ef1697d555e1f2ab5c42d3c60b5bb71b6cf2.

It looks like this change caused issues with analyses on pull requests from forks. This is due to the complicated nature of the permissions of workflows run on these pull requests. They are able to upload analyses for their own pull requests refs, but are not able to access other Code Scanning APIs such as the one required to get the status of a delivery.

This reverts adding this new functionality until we update the API to make it able to safely determine whether a pull request should be able to get the status of a particular delivery.

This is a hotfix on the v1 branch.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
