### PR TITLE
Update to node16

### DIFF
--- a/init/action.yml
+++ b/init/action.yml
@@ -73,5 +73,5 @@ outputs:
   codeql-path:
     description: The path of the CodeQL binary used for analysis
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../lib/init-action.js'


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
