### PR TITLE
Fix CI jobs that broke as a result of `windows-latest` being upgraded to Windows Server 2022

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -30,10 +30,7 @@ jobs:
         - cached
         - latest
         - nightly-latest
-        os:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        os: [ubuntu-latest, macos-latest, windows-2019]
     name: "Analyze: 'ref' and 'sha' from inputs"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -30,10 +30,7 @@ jobs:
         - cached
         - latest
         - nightly-latest
-        os:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        os: [ubuntu-latest, macos-latest, windows-2019]
     name: 'Go: Custom queries'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -30,10 +30,7 @@ jobs:
         - cached
         - latest
         - nightly-latest
-        os:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        os: [ubuntu-latest, macos-latest, windows-2019]
     name: 'Go: Custom tracing'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -30,10 +30,7 @@ jobs:
         - cached
         - latest
         - nightly-latest
-        os:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        os: [ubuntu-latest, macos-latest, windows-2019]
     name: Remote config file
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -30,10 +30,7 @@ jobs:
         - cached
         - latest
         - nightly-latest
-        os:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        os: [ubuntu-latest, macos-latest, windows-2019]
     name: "Upload-sarif: 'ref' and 'sha' from inputs"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -182,7 +182,9 @@ jobs:
   runner-analyze-csharp-windows:
     name: Runner windows C# analyze
     needs: [check-js, check-node-modules]
-    runs-on: windows-latest
+    # Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
+    # `windows-latest`.
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v2
@@ -301,7 +303,9 @@ jobs:
   runner-analyze-csharp-autobuild-windows:
     name: Runner windows autobuild C# analyze
     needs: [check-js, check-node-modules]
-    runs-on: windows-latest
+    # Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
+    # `windows-latest`.
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -125,7 +125,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python_version }}
 
     - name: Initialize CodeQL
       uses: ./init

--- a/pr-checks/checks/analyze-ref-input.yml
+++ b/pr-checks/checks/analyze-ref-input.yml
@@ -1,5 +1,8 @@
 name: "Analyze: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
+# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
+# `windows-latest`.
+os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -1,5 +1,8 @@
 name: "Go: Custom queries"
 description: "Checks that Go works in conjunction with a config file specifying custom queries"
+# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
+# `windows-latest`.
+os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: actions/setup-go@v2
     with:

--- a/pr-checks/checks/go-custom-tracing.yml
+++ b/pr-checks/checks/go-custom-tracing.yml
@@ -1,5 +1,8 @@
 name: "Go: Custom tracing"
 description: "Checks that Go tracing works"
+# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
+# `windows-latest`.
+os: [ubuntu-latest, macos-latest, windows-2019]
 env:
   CODEQL_EXTRACTOR_GO_BUILD_TRACING: "true"
 steps:

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -1,5 +1,8 @@
 name: "Remote config file"
 description: "Checks that specifying packages using only a config file works"
+# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
+# `windows-latest`.
+os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/upload-ref-sha-input.yml
+++ b/pr-checks/checks/upload-ref-sha-input.yml
@@ -1,5 +1,8 @@
 name: "Upload-sarif: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
+# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
+# `windows-latest`.
+os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: ./../action/init
     with:


### PR DESCRIPTION
`windows-latest` is currently migrating from an image based on Windows Server 2019 to an image based on Windows Server 2022.  This breaks some of our CI jobs for two reasons:

1. Build tracing doesn't yet support Windows Server 2022
2. Python 2 isn't supported in the `windows-2022` image.

This PR addresses (1) by moving relevant jobs to use the `windows-2019` image and (2) by fixing a typo that prevented `setup-python` from downloading and installing Python 2 when it's not already in the Actions VM image.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
