### PR TITLE
Open "Update supported enterprise versions" PR as draft

### DIFF
--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -40,5 +40,6 @@ jobs:
           body: ""
           author: GitHub <noreply@github.com>
           branch: update-supported-enterprise-server-versions
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Actions will not run checks on PRs opened by Actions, so opening the PR as draft allows us to trigger PR checks by marking the PR as ready for review.

The `draft` input appears in the version of the Action that we've pinned: see [this part of the README](https://github.com/peter-evans/create-pull-request/tree/c7f493a8000b8aeb17a1332e326ba76b57cb83eb#action-inputs).

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
