### PR TITLE
Test each minor version of the CodeQL CLI in PR checks

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__debug-artifacts.yml
+++ b/.github/workflows/__debug-artifacts.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__go-custom-tracing-autobuild.yml
+++ b/.github/workflows/__go-custom-tracing-autobuild.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -27,6 +27,8 @@ jobs:
         - stable-20210308
         - stable-20210319
         - stable-20210809
+        - stable-20211005
+        - stable-20220120
         - cached
         - latest
         - nightly-latest

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -8,6 +8,10 @@ defaultTestVersions = [
     "stable-20210319",
     # The last CodeQL release in the 2.5 series: 2.5.9.
     "stable-20210809",
+    # The last CodeQL release in the 2.6 series: 2.6.3.
+    "stable-20211005",
+    # The last CodeQL release in the 2.7 series: 2.7.6.
+    "stable-20220120",
     # The version of CodeQL currently in the toolcache. Typically either the latest release or the one before.
     "cached",
     # The latest release of CodeQL.


### PR DESCRIPTION
Opening this for discussion: this PR ensures that we test the latest patch version of each minor version of the CodeQL CLI we support.  This gives us better assurance that the versions of the CodeQL CLI we claim to support function correctly with the Action.  However, it does lead to an increase in CI jobs on a repo where the number of CI jobs is already becoming blocking due to concurrency limits.

Let's discuss whether we want this or not, and if we don't want it, let's come up with a principled way of deciding what versions of the CodeQL Bundle we test in PR checks.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
