### PR TITLE
Expand PR checks to cover `windows-2022`

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -23,14 +23,47 @@ jobs:
   analyze-ref-input:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: windows-2019
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: windows-2019
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: windows-2019
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: windows-2019
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: windows-2019
+          version: latest
+        - os: windows-2022
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
+        - os: windows-2019
+          version: nightly-latest
+        - os: windows-2022
+          version: nightly-latest
     name: "Analyze: 'ref' and 'sha' from inputs"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__debug-artifacts.yml
+++ b/.github/workflows/__debug-artifacts.yml
@@ -23,14 +23,31 @@ jobs:
   debug-artifacts:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
     name: Debug artifact upload
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -23,8 +23,9 @@ jobs:
   extractor-ram-threads:
     strategy:
       matrix:
-        version: [latest]
-        os: [ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          version: latest
     name: Extractor ram and threads options test
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -23,14 +23,47 @@ jobs:
   go-custom-queries:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: windows-2019
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: windows-2019
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: windows-2019
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: windows-2019
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: windows-2019
+          version: latest
+        - os: windows-2022
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
+        - os: windows-2019
+          version: nightly-latest
+        - os: windows-2022
+          version: nightly-latest
     name: 'Go: Custom queries'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__go-custom-tracing-autobuild.yml
+++ b/.github/workflows/__go-custom-tracing-autobuild.yml
@@ -23,14 +23,31 @@ jobs:
   go-custom-tracing-autobuild:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
     name: 'Go: Autobuild custom tracing'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -23,14 +23,47 @@ jobs:
   go-custom-tracing:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: windows-2019
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: windows-2019
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: windows-2019
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: windows-2019
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: windows-2019
+          version: latest
+        - os: windows-2022
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
+        - os: windows-2019
+          version: nightly-latest
+        - os: windows-2022
+          version: nightly-latest
     name: 'Go: Custom tracing'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -23,8 +23,13 @@ jobs:
   javascript-source-root:
     strategy:
       matrix:
-        version: [latest, cached, nightly-latest] # This feature is not compatible with old CLIs
-        os: [ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          version: latest
+        - os: ubuntu-latest
+          version: cached
+        - os: ubuntu-latest
+          version: nightly-latest
     name: Custom source root
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -23,14 +23,31 @@ jobs:
   multi-language-autodetect:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
     name: Multi-language repository
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -23,8 +23,11 @@ jobs:
   packaging-config-inputs-js:
     strategy:
       matrix:
-        version: [nightly-20210831] # This CLI version is known to work with package used in this test
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: nightly-20210831
+        - os: macos-latest
+          version: nightly-20210831
     name: 'Packaging: Config and input'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -23,8 +23,11 @@ jobs:
   packaging-config-js:
     strategy:
       matrix:
-        version: [nightly-20210831] # This CLI version is known to work with package used in this test
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: nightly-20210831
+        - os: macos-latest
+          version: nightly-20210831
     name: 'Packaging: Config file'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -23,8 +23,11 @@ jobs:
   packaging-inputs-js:
     strategy:
       matrix:
-        version: [nightly-20210831] # This CLI version is known to work with package used in this test
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: nightly-20210831
+        - os: macos-latest
+          version: nightly-20210831
     name: 'Packaging: Action input'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -23,14 +23,47 @@ jobs:
   remote-config:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: windows-2019
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: windows-2019
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: windows-2019
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: windows-2019
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: windows-2019
+          version: latest
+        - os: windows-2022
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
+        - os: windows-2019
+          version: nightly-latest
+        - os: windows-2022
+          version: nightly-latest
     name: Remote config file
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -23,14 +23,19 @@ jobs:
   rubocop-multi-language:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
     name: RuboCop multi-language
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -23,8 +23,11 @@ jobs:
   split-workflow:
     strategy:
       matrix:
-        version: [nightly-20210831] # This CLI version is known to work with package used in this test
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: nightly-20210831
+        - os: macos-latest
+          version: nightly-20210831
     name: Split workflow
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -23,8 +23,9 @@ jobs:
   test-local-codeql:
     strategy:
       matrix:
-        version: [nightly-latest]
-        os: [ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          version: nightly-latest
     name: Local CodeQL bundle
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -23,8 +23,9 @@ jobs:
   test-proxy:
     strategy:
       matrix:
-        version: [latest]
-        os: [ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          version: latest
     name: Proxy test
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__test-ruby.yml
+++ b/.github/workflows/__test-ruby.yml
@@ -23,8 +23,19 @@ jobs:
   test-ruby:
     strategy:
       matrix:
-        version: [latest, cached, nightly-latest]
-        os: [ubuntu-latest, macos-latest]
+        include:
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
     name: Ruby analysis
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -23,14 +23,19 @@ jobs:
   unset-environment:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
     name: Test unsetting environment variables
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -23,14 +23,47 @@ jobs:
   upload-ref-sha-input:
     strategy:
       matrix:
-        version:
-        - stable-20210308
-        - stable-20210319
-        - stable-20210809
-        - cached
-        - latest
-        - nightly-latest
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        include:
+        - os: ubuntu-latest
+          version: stable-20210308
+        - os: macos-latest
+          version: stable-20210308
+        - os: windows-2019
+          version: stable-20210308
+        - os: ubuntu-latest
+          version: stable-20210319
+        - os: macos-latest
+          version: stable-20210319
+        - os: windows-2019
+          version: stable-20210319
+        - os: ubuntu-latest
+          version: stable-20210809
+        - os: macos-latest
+          version: stable-20210809
+        - os: windows-2019
+          version: stable-20210809
+        - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: windows-2019
+          version: cached
+        - os: ubuntu-latest
+          version: latest
+        - os: macos-latest
+          version: latest
+        - os: windows-2019
+          version: latest
+        - os: windows-2022
+          version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
+        - os: windows-2019
+          version: nightly-latest
+        - os: windows-2022
+          version: nightly-latest
     name: "Upload-sarif: 'ref' and 'sha' from inputs"
     runs-on: ${{ matrix.os }}
     steps:

--- a/pr-checks/checks/analyze-ref-input.yml
+++ b/pr-checks/checks/analyze-ref-input.yml
@@ -1,8 +1,5 @@
 name: "Analyze: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
-# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
-# `windows-latest`.
-os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -1,8 +1,5 @@
 name: "Go: Custom queries"
 description: "Checks that Go works in conjunction with a config file specifying custom queries"
-# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
-# `windows-latest`.
-os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: actions/setup-go@v2
     with:

--- a/pr-checks/checks/go-custom-tracing.yml
+++ b/pr-checks/checks/go-custom-tracing.yml
@@ -1,8 +1,5 @@
 name: "Go: Custom tracing"
 description: "Checks that Go tracing works"
-# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
-# `windows-latest`.
-os: [ubuntu-latest, macos-latest, windows-2019]
 env:
   CODEQL_EXTRACTOR_GO_BUILD_TRACING: "true"
 steps:

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -1,8 +1,5 @@
 name: "Remote config file"
 description: "Checks that specifying packages using only a config file works"
-# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
-# `windows-latest`.
-os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/upload-ref-sha-input.yml
+++ b/pr-checks/checks/upload-ref-sha-input.yml
@@ -1,8 +1,5 @@
 name: "Upload-sarif: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
-# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
-# `windows-latest`.
-os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -15,7 +15,7 @@ defaultTestVersions = [
     # A nightly build directly from the our private repo, built in the last 24 hours.
     "nightly-latest"
 ]
-defaultOperatingSystems = ["ubuntu-latest", "macos-latest", "windows-latest"]
+defaultOperatingSystems = ["ubuntu-latest", "macos-latest", "windows-2019"]
 header = """# Warning: This file is generated automatically, and should not be modified.
 # Instead, please modify the template in the pr-checks directory and run:
 #     pip install ruamel.yaml && python3 sync.py
@@ -62,11 +62,26 @@ for file in os.listdir('checks'):
     ]
     steps.extend(checkSpecification['steps'])
 
+    matrix = []
+    for version in versions:
+        for os in operatingSystems:
+            matrix.append({
+                'os': os,
+                'version': version
+            })
+            if (version == 'latest' or version == 'nightly-latest') and os == 'windows-2019':
+                # New versions of the CLI should also work with Windows Server 2022.
+                # Once all versions of the CLI that we test against work with Windows Server 2022,
+                # we should remove this logic and instead just add windows-2022 to the test matrix.
+                matrix.append({
+                    'os': 'windows-2022',
+                    'version': version
+                })
+
     checkJob = {
         'strategy': {
             'matrix': {
-                'version': versions,
-                'os': operatingSystems
+                'include': matrix
             }
         },
         'name': checkSpecification['name'],


### PR DESCRIPTION
Expands our test coverage to test against `windows-2022`. In particular, we run these tests in addition to existing ones whenever a test is with a new CLI version and was already being run on Windows.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
