### PR TITLE
Add a timeout of 30 min

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -65,6 +65,7 @@ jobs:
         - os: windows-2022
           version: nightly-latest
     name: "Analyze: 'ref' and 'sha' from inputs"
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__debug-artifacts.yml
+++ b/.github/workflows/__debug-artifacts.yml
@@ -49,6 +49,7 @@ jobs:
         - os: macos-latest
           version: nightly-latest
     name: Debug artifact upload
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -27,6 +27,7 @@ jobs:
         - os: ubuntu-latest
           version: latest
     name: Extractor ram and threads options test
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -65,6 +65,7 @@ jobs:
         - os: windows-2022
           version: nightly-latest
     name: 'Go: Custom queries'
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__go-custom-tracing-autobuild.yml
+++ b/.github/workflows/__go-custom-tracing-autobuild.yml
@@ -49,6 +49,7 @@ jobs:
         - os: macos-latest
           version: nightly-latest
     name: 'Go: Autobuild custom tracing'
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -65,6 +65,7 @@ jobs:
         - os: windows-2022
           version: nightly-latest
     name: 'Go: Custom tracing'
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -31,6 +31,7 @@ jobs:
         - os: ubuntu-latest
           version: nightly-latest
     name: Custom source root
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -49,6 +49,7 @@ jobs:
         - os: macos-latest
           version: nightly-latest
     name: Multi-language repository
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -29,6 +29,7 @@ jobs:
         - os: macos-latest
           version: nightly-20210831
     name: 'Packaging: Config and input'
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -29,6 +29,7 @@ jobs:
         - os: macos-latest
           version: nightly-20210831
     name: 'Packaging: Config file'
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -29,6 +29,7 @@ jobs:
         - os: macos-latest
           version: nightly-20210831
     name: 'Packaging: Action input'
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -65,6 +65,7 @@ jobs:
         - os: windows-2022
           version: nightly-latest
     name: Remote config file
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -37,6 +37,7 @@ jobs:
         - os: ubuntu-latest
           version: nightly-latest
     name: RuboCop multi-language
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -29,6 +29,7 @@ jobs:
         - os: macos-latest
           version: nightly-20210831
     name: Split workflow
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -27,6 +27,7 @@ jobs:
         - os: ubuntu-latest
           version: nightly-latest
     name: Local CodeQL bundle
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -27,6 +27,7 @@ jobs:
         - os: ubuntu-latest
           version: latest
     name: Proxy test
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__test-ruby.yml
+++ b/.github/workflows/__test-ruby.yml
@@ -37,6 +37,7 @@ jobs:
         - os: macos-latest
           version: nightly-latest
     name: Ruby analysis
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -37,6 +37,7 @@ jobs:
         - os: ubuntu-latest
           version: nightly-latest
     name: Test unsetting environment variables
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -65,6 +65,7 @@ jobs:
         - os: windows-2022
           version: nightly-latest
     name: "Upload-sarif: 'ref' and 'sha' from inputs"
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,6 +13,7 @@ jobs:
   lint-js:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2
@@ -21,6 +22,7 @@ jobs:
 
   check-js:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2
@@ -30,6 +32,7 @@ jobs:
   check-node-modules:
     name: Check modules up to date
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2
@@ -39,6 +42,7 @@ jobs:
   verify-pr-checks:
     name: Verify PR checks up to date
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2
@@ -60,6 +64,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2
@@ -69,6 +74,7 @@ jobs:
   runner-analyze-javascript-ubuntu:
     name: Runner ubuntu JS analyze
     needs: [check-js, check-node-modules]
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:
@@ -97,6 +103,7 @@ jobs:
   runner-analyze-javascript-windows:
     name: Runner windows JS analyze
     needs: [check-js, check-node-modules]
+    timeout-minutes: 30
     runs-on: windows-latest
 
     steps:
@@ -121,6 +128,7 @@ jobs:
   runner-analyze-javascript-macos:
     name: Runner macos JS analyze
     needs: [check-js, check-node-modules]
+    timeout-minutes: 30
     runs-on: macos-latest
 
     steps:
@@ -145,6 +153,7 @@ jobs:
   runner-analyze-csharp-ubuntu:
     name: Runner ubuntu C# analyze
     needs: [check-js, check-node-modules]
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:
@@ -184,6 +193,7 @@ jobs:
     needs: [check-js, check-node-modules]
     # Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
     # `windows-latest`.
+    timeout-minutes: 30
     runs-on: windows-2019
 
     steps:
@@ -228,6 +238,7 @@ jobs:
 
   runner-analyze-csharp-macos:
     name: Runner macos C# analyze
+    timeout-minutes: 30
     needs: [check-js, check-node-modules]
     runs-on: macos-latest
 
@@ -266,6 +277,7 @@ jobs:
 
   runner-analyze-csharp-autobuild-ubuntu:
     name: Runner ubuntu autobuild C# analyze
+    timeout-minutes: 30
     needs: [check-js, check-node-modules]
     runs-on: ubuntu-latest
 
@@ -301,6 +313,7 @@ jobs:
           TEST_MODE: true
 
   runner-analyze-csharp-autobuild-windows:
+    timeout-minutes: 30
     name: Runner windows autobuild C# analyze
     needs: [check-js, check-node-modules]
     # Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
@@ -343,6 +356,7 @@ jobs:
     name: Runner macos autobuild C# analyze
     needs: [check-js, check-node-modules]
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2
@@ -380,6 +394,7 @@ jobs:
     name: Runner upload sarif
     needs: [check-js, check-node-modules]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id }}
 
@@ -402,6 +417,7 @@ jobs:
     name: Runner ubuntu extractor RAM and threads options
     needs: [check-js, check-node-modules]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test-setup-python-scripts:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
         fail-fast: false

--- a/.github/workflows/release-runner.yml
+++ b/.github/workflows/release-runner.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release-runner:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: "${{ github.event.inputs.bundle-tag }}"

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       CLI_RELEASE: "${{ github.event.inputs.cli-release }}"
       RELEASE_TAG: "${{ github.event.inputs.bundle-tag }}"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   update:
     name: Update dependencies
+    timeout-minutes: 30
     runs-on: macos-latest
     if: contains(github.event.pull_request.labels.*.name, 'Update dependencies') && (github.event.pull_request.head.repo.full_name == 'github/codeql-action')
     steps:

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'github/codeql-action' }}
     steps:

--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update-supported-enterprise-server-versions:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'github/codeql-action' }}
 

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -85,6 +85,7 @@ for file in os.listdir('checks'):
             }
         },
         'name': checkSpecification['name'],
+        'timeout-minutes': 30,
         'runs-on': '${{ matrix.os }}',
         'steps': steps
     }


### PR DESCRIPTION
For most CI jobs. Based on some eye-balling 30 minutes should be enough time for all jobs to complete.

### Merge / deployment checklist

- [n/a] Confirm this change is backwards compatible with existing workflows.
- [n/a] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [n/a] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
