### PR TITLE
Bump ML-powered queries to v0.1.0

### DIFF
--- a/lib/config-utils.test.js
+++ b/lib/config-utils.test.js
@@ -914,7 +914,7 @@ const mlPoweredQueriesMacro = ava_1.default.macro({
 (0, ava_1.default)(mlPoweredQueriesMacro, "2.7.4", true, undefined, "security-extended", undefined);
 (0, ava_1.default)(mlPoweredQueriesMacro, "2.7.5", false, undefined, "security-extended", undefined);
 (0, ava_1.default)(mlPoweredQueriesMacro, "2.7.5", true, undefined, undefined, undefined);
-(0, ava_1.default)(mlPoweredQueriesMacro, "2.7.5", true, undefined, "security-extended", "~0.0.2");
-(0, ava_1.default)(mlPoweredQueriesMacro, "2.7.5", true, undefined, "security-and-quality", "~0.0.2");
+(0, ava_1.default)(mlPoweredQueriesMacro, "2.7.5", true, undefined, "security-extended", "~0.1.0");
+(0, ava_1.default)(mlPoweredQueriesMacro, "2.7.5", true, undefined, "security-and-quality", "~0.1.0");
 (0, ava_1.default)(mlPoweredQueriesMacro, "2.7.5", true, "codeql/javascript-experimental-atm-queries@0.0.1", "security-and-quality", "0.0.1");
 //# sourceMappingURL=config-utils.test.js.map

--- a/lib/util.js
+++ b/lib/util.js
@@ -534,7 +534,7 @@ exports.isGoodVersion = isGoodVersion;
  */
 exports.ML_POWERED_JS_QUERIES_PACK = {
     packName: "codeql/javascript-experimental-atm-queries",
-    version: "~0.0.2",
+    version: "~0.1.0",
 };
 /**
  * Get information about ML-powered JS queries to populate status reports with.

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -1811,7 +1811,7 @@ test(
   true,
   undefined,
   "security-extended",
-  "~0.0.2"
+  "~0.1.0"
 );
 test(
   mlPoweredQueriesMacro,
@@ -1819,7 +1819,7 @@ test(
   true,
   undefined,
   "security-and-quality",
-  "~0.0.2"
+  "~0.1.0"
 );
 test(
   mlPoweredQueriesMacro,

--- a/src/util.ts
+++ b/src/util.ts
@@ -636,7 +636,7 @@ export function isGoodVersion(versionSpec: string) {
  */
 export const ML_POWERED_JS_QUERIES_PACK: PackWithVersion = {
   packName: "codeql/javascript-experimental-atm-queries",
-  version: "~0.0.2",
+  version: "~0.1.0",
 };
 
 /**


### PR DESCRIPTION
Bumps the version range of the ML-powered query pack we run on `security-extended` and `security-and-quality` to the next minor version, i.e. `~0.1.0`.  Here are some of the changes we're shipping:

- Query help improvements
- Queries now have CWE tags
- Optimizations to improve query runtime
- (Internal) The ATM model is now shipped within its own pack

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
