### PR TITLE
Remove runner from expected release files

### DIFF
--- a/.github/workflows/check-expected-release-files.yml
+++ b/.github/workflows/check-expected-release-files.yml
@@ -20,6 +20,6 @@ jobs:
         run: |
           bundle_version="$(cat "./src/defaults.json" | jq -r ".bundleVersion")"
           set -x
-          for expected_file in "codeql-bundle.tar.gz" "codeql-bundle-linux64.tar.gz" "codeql-bundle-osx64.tar.gz" "codeql-bundle-win64.tar.gz" "codeql-runner-linux" "codeql-runner-macos" "codeql-runner-win.exe"; do
+          for expected_file in "codeql-bundle.tar.gz" "codeql-bundle-linux64.tar.gz" "codeql-bundle-osx64.tar.gz" "codeql-bundle-win64.tar.gz"; do
             curl --location --fail --head --request GET "https://github.com/github/codeql-action/releases/download/$bundle_version/$expected_file" > /dev/null
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# CodeQL Action and CodeQL Runner Changelog
+# CodeQL Action Changelog
 
 ## [UNRELEASED]
 
 - Update default CodeQL bundle version to 2.8.3.
+- The CodeQL runner is now deprecated and no longer being released. For more information, see [CodeQL runner deprecation](https://github.blog/changelog/2021-09-21-codeql-runner-deprecation/).
 
 ## 1.1.4 - 07 Mar 2022
 


### PR DESCRIPTION
The runner is now deprecated and won't be included in future releases 🎉

Let's remove it from the expected files in our releases so the CI checks on them can pass.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
