### PR TITLE
Bump default CodeQL version to 2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - [v2+ only] The CodeQL Action now runs on Node.js v16. [#1000](https://github.com/github/codeql-action/pull/1000)
+- Update default CodeQL bundle version to 2.8.4. [#990](https://github.com/github/codeql-action/pull/990)
 
 ## 1.1.5 - 15 Mar 2022
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,3 +1,3 @@
 {
-    "bundleVersion": "codeql-bundle-20220311"
+    "bundleVersion": "codeql-bundle-20220322"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,3 +1,3 @@
 {
-  "bundleVersion": "codeql-bundle-20220311"
+  "bundleVersion": "codeql-bundle-20220322"
 }


### PR DESCRIPTION
Part of the 2.8.4 release process.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
