### PR TITLE
Add PR check to validate compatibility with Node 12

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,8 +24,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
+    strategy:
+      fail-fast: true
+      matrix:
+        node-types-version: [12.12, current]
+
     steps:
       - uses: actions/checkout@v2
+
+      - name: Update version of @types/node
+        if: matrix.node-types-version != 'current'
+        env:
+          NODE_TYPES_VERSION: ${{ matrix.node-types-version }}
+        run: |
+          export NODE_TYPES_VERSION="${NODE_TYPES_VERSION}"
+          contents=$(jq '.devDependencies."@types/node" = env.NODE_TYPES_VERSION' package.json)
+          echo "${contents}" > package.json
+          # Usually we need to run `npm install` on macOS, however we're not checking in the result
+          # here, so it's fine to run on Linux.
+          npm install
+
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions[bot]"
+          git add --all
+          git commit -am "Use @types/node=${NODE_TYPES_VERSION}"
+
       - name: Check generated JS
         run: .github/workflows/script/check-js.sh
 


### PR DESCRIPTION
This PR adds a simple PR check that sets the `@types/node` dependency to version 12.12 (i.e. types for Node 12), then attempts to compile the Action.  This helps us guard against introducing new code that doesn't run with Node 12.

Example successful job: https://github.com/github/codeql-action/runs/5722503871?check_suite_focus=true
Example failed job after introducing some Node 16 only code: https://github.com/github/codeql-action/runs/5722718273?check_suite_focus=true

Note that we'll need to update the set of required checks after merging this PR.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
