### PR TITLE
Fix typos in release workflow

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -49,7 +49,7 @@ jobs:
         python .github/update-release-branch.py \
           --github-token ${{ secrets.GITHUB_TOKEN }} \
           --repository-nwo ${{ github.repository }} \
-          --mode release-v2 \
+          --mode v2-release \
           --conductor ${GITHUB_ACTOR}
 
     - name: Update v1 release branch
@@ -58,5 +58,5 @@ jobs:
         python .github/update-release-branch.py \
           --github-token ${{ secrets.GITHUB_TOKEN }} \
           --repository-nwo ${{ github.repository }} \
-          --mode release-v1 \
+          --mode v1-release \
           --conductor ${GITHUB_ACTOR}


### PR DESCRIPTION
The underlying Python script expects arguments of the form `v2-release` rather than `release-v2`.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
