### PR TITLE
Avoid failure if `@types/node` is already 12.12

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,11 +46,13 @@ jobs:
           # `npm install` on Linux.
           npm install
 
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "github-actions[bot]"
-          # The period in `git add --all .` ensures that we stage deleted files too.
-          git add --all .
-          git commit -m "Use @types/node=${NODE_TYPES_VERSION}"
+          if [ ! -z "$(git status --porcelain)" ]; then
+            git config --global user.email "github-actions@github.com"
+            git config --global user.name "github-actions[bot]"
+            # The period in `git add --all .` ensures that we stage deleted files too.
+            git add --all .
+            git commit -m "Use @types/node=${NODE_TYPES_VERSION}"
+          fi
 
       - name: Check generated JS
         run: .github/workflows/script/check-js.sh


### PR DESCRIPTION
Cherry-picks https://github.com/github/codeql-action/commit/9da34a6ec642856a41b22a13739d75e3c505d85c, which we already have on the `v1` branch (where it is needed to avoid a failure) onto `main`. I think we should do this so that our PR checks are the same on all the branches, even though we don't _need_ it outside of `v1`.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
