### PR TITLE
Support Pipfile without Pipfile.lock

### DIFF
--- a/python-setup/auto_install_packages.py
+++ b/python-setup/auto_install_packages.py
@@ -48,13 +48,13 @@ def install_packages_with_poetry():
     return python_executable_path
 
 
-def install_packages_with_pipenv(skip_lock=False):
+def install_packages_with_pipenv(has_lockfile):
     command = [sys.executable, '-m', 'pipenv']
     if sys.platform.startswith('win32'):
         # In windows the default path were the deps are installed gets wiped out between steps,
         # so we have to set it up to a folder that will be kept
         os.environ['WORKON_HOME'] = os.path.join(os.environ['RUNNER_WORKSPACE'], 'virtualenvs')
-    lock_args = ['--skip-lock'] if skip_lock else ['--keep-outdated', '--ignore-pipfile']
+    lock_args = ['--keep-outdated', '--ignore-pipfile'] if has_lockfile else ['--skip-lock']
     try:
         _check_call(command + ['install'] + lock_args)
     except subprocess.CalledProcessError:
@@ -146,11 +146,10 @@ def install_packages(codeql_base_dir) -> Optional[str]:
     if os.path.exists('Pipfile') or os.path.exists('Pipfile.lock'):
         if os.path.exists('Pipfile.lock'):
             print('Found Pipfile.lock, will install packages with Pipenv', flush=True)
-            return install_packages_with_pipenv()
+            return install_packages_with_pipenv(has_lockfile=True)
         else:
             print('Found Pipfile, will install packages with Pipenv', flush=True)
-            return install_packages_with_pipenv(skip_lock=True)
-        
+            return install_packages_with_pipenv(has_lockfile=False)
 
     # get_extractor_version returns the Python version the extractor thinks this repo is using
     version = extractor_version.get_extractor_version(codeql_base_dir, quiet=False)

--- a/python-setup/auto_install_packages.py
+++ b/python-setup/auto_install_packages.py
@@ -48,14 +48,15 @@ def install_packages_with_poetry():
     return python_executable_path
 
 
-def install_packages_with_pipenv():
+def install_packages_with_pipenv(skip_lock=False):
     command = [sys.executable, '-m', 'pipenv']
     if sys.platform.startswith('win32'):
         # In windows the default path were the deps are installed gets wiped out between steps,
         # so we have to set it up to a folder that will be kept
         os.environ['WORKON_HOME'] = os.path.join(os.environ['RUNNER_WORKSPACE'], 'virtualenvs')
+    lock_args = ['--skip-lock'] if skip_lock else ['--keep-outdated', '--ignore-pipfile']
     try:
-        _check_call(command + ['install', '--keep-outdated', '--ignore-pipfile'])
+        _check_call(command + ['install'] + lock_args)
     except subprocess.CalledProcessError:
         sys.exit('package installation with pipenv failed, see error above')
 
@@ -145,9 +146,11 @@ def install_packages(codeql_base_dir) -> Optional[str]:
     if os.path.exists('Pipfile') or os.path.exists('Pipfile.lock'):
         if os.path.exists('Pipfile.lock'):
             print('Found Pipfile.lock, will install packages with Pipenv', flush=True)
+            return install_packages_with_pipenv()
         else:
             print('Found Pipfile, will install packages with Pipenv', flush=True)
-        return install_packages_with_pipenv()
+            return install_packages_with_pipenv(skip_lock=True)
+        
 
     # get_extractor_version returns the Python version the extractor thinks this repo is using
     version = extractor_version.get_extractor_version(codeql_base_dir, quiet=False)


### PR DESCRIPTION
As previously written, if codeql finds a `Pipfile`, but no `Pipfile.lock`, it will run `pipenv install` with args that require `Pipfile.lock` to exist. Pipfile will fail with this message:

```
  Usage: python -m pipenv install [OPTIONS] [PACKAGES]...
  
  ERROR:: Pipfile.lock must exist to use --keep-outdated!
  package installation with pipenv failed, see error above
```

This changeset enables auto_install to work with Pipfile when there is no lock. (Bonus: `--skip-lock` is generally a bit faster.)

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
