### PR TITLE
Bump default CodeQL version to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `working-directory` input to the `autobuild` action. [#1024](https://github.com/github/codeql-action/pull/1024)
 - The `analyze` and `upload-sarif` actions will now wait up to 2 minutes for processing to complete after they have uploaded the results so they can report any processing errors that occurred. This behavior can be disabled by setting the `wait-for-processing` action input to `"false"`. [#1007](https://github.com/github/codeql-action/pull/1007)
+- Update default CodeQL bundle version to 2.9.0.
 
 ## 2.1.8 - 08 Apr 2022
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,3 +1,3 @@
 {
-    "bundleVersion": "codeql-bundle-20220401"
+    "bundleVersion": "codeql-bundle-20220421"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,3 +1,3 @@
 {
-  "bundleVersion": "codeql-bundle-20220401"
+  "bundleVersion": "codeql-bundle-20220421"
 }


### PR DESCRIPTION
### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
