### PR TITLE
Add workflow to regenerate required checks

### DIFF
--- a/.github/workflows/update-required-checks.yml
+++ b/.github/workflows/update-required-checks.yml
@@ -1,0 +1,43 @@
+
+# This job updates the required checks on the codeql-action repository based on the
+# checks performed on the most recent commit.
+
+name: Update required checks
+on:
+  schedule:
+    # 23:01 on Saturdays
+    - cron: "1 23 * * 6"
+  workflow_dispatch:
+
+jobs:
+  update-required-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump environment
+      run: env
+
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: '${{ toJson(github) }}'
+      run: echo "$GITHUB_CONTEXT"
+
+    - name: Update checks
+      run: |
+        # Update the required checks based on the current branch.
+        # Typically, this will be main.
+        echo "Getting checks for $GITHUB_SHA"
+
+        # Ignore any checks with "https://", CodeQL, LGTM, and Update checks.
+        CHECKS="$(gh api repos/github/codeql-action/commits/${GITHUB_SHA}/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "LGTM.com" or contains("Update") | not)] | sort')"
+
+        echo "::group::New Checks"
+        echo "$CHECKS" | jq
+        echo "::endgroup::"
+
+        echo "{\"contexts\": ${CHECKS}}" > checks.json
+        echo "Updating main"
+        gh api -X "PATCH" repos/github/codeql-action/branches/main/protection/required_status_checks --input checks.json
+        echo "Updating v2"
+        gh api -X "PATCH" repos/github/codeql-action/branches/releases/v2/protection/required_status_checks --input checks.json
+        echo "Updating v1"
+        gh api -X "PATCH" repos/github/codeql-action/branches/releases/v1/protection/required_status_checks --input checks.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,9 +80,9 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 ## Keeping the PR checks up to date (admin access required)
 
-Since the `codeql-action` runs most of its testing through individual Actions workflows, there are over two hundred jobs that need to pass in order for a PR to turn green. Managing these PR checks manually is time consuming and complex. Here is a semi-automated approach.
+Since the `codeql-action` runs most of its testing through individual Actions workflows, there are over two hundred jobs that need to pass in order for a PR to turn green. You can regenerate the checks automatically by running the [Update required checks](.github/workflows/update-required-checks.yml) workflow.
 
-To regenerate the PR jobs for the action:
+Or you can use this semi-automated approach:
 
 1. In a terminal check out the `SHA` whose checks you want to use as the base. Typically, this will be `main`. 
 2. From a terminal, run the following commands:


### PR DESCRIPTION
Update contributing guide. Ensure this workflow runs once a week.
