### PR TITLE
Add permissions to workflow

### DIFF
--- a/.github/workflows/update-required-checks.yml
+++ b/.github/workflows/update-required-checks.yml
@@ -22,13 +22,15 @@ jobs:
       run: echo "$GITHUB_CONTEXT"
 
     - name: Update checks
+      env:
+        GITHUB_TOKEN: "${{ secrets.CODEQL_CI_TOKEN }}"
       run: |
         # Update the required checks based on the current branch.
         # Typically, this will be main.
         echo "Getting checks for $GITHUB_SHA"
 
         # Ignore any checks with "https://", CodeQL, LGTM, and Update checks.
-        CHECKS="$(gh api repos/github/codeql-action/commits/${GITHUB_SHA}/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "LGTM.com" or contains("Update") | not)] | sort')"
+        CHECKS="$(gh api repos/github/codeql-action/commits/${GITHUB_SHA}/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "LGTM.com" or contains("Update") or contains("update-") | not)] | sort')"
 
         echo "::group::New Checks"
         echo "$CHECKS" | jq


### PR DESCRIPTION
I needed to do a few things in order to get the update-required-checks workflow to succeed:

1. Create a new secret for the codeql-ci user
2. Add this secret to this repository
3. Add the codeql-ci user as an admin for this repository

Successful run:
https://github.com/github/codeql-action/actions/runs/2259813401

Note that this run removed all previous checks. I'll add them back manually. 