### PR TITLE
Remove an extraneous commit during the release process

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -292,7 +292,7 @@ def main():
     conflicted_files = run_git('diff', '--name-only', '--diff-filter', 'U').splitlines()
     if len(conflicted_files) > 0:
       run_git('add', '.')
-    run_git('commit', '--no-edit')
+      run_git('commit', '--no-edit')
 
     # Migrate the package version number from a v2 version number to a v1 version number
     print(f'Setting version number to {version}')


### PR DESCRIPTION
We only need to run `git commit` after the `git merge` call if there were conflicts.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
