### PR TITLE
Fix issue with required checks sync script

### DIFF
--- a/.github/workflows/script/update-required-checks.sh
+++ b/.github/workflows/script/update-required-checks.sh
@@ -21,7 +21,7 @@ fi
 echo "Getting checks for $GITHUB_SHA"
 
 # Ignore any checks with "https://", CodeQL, LGTM, and Update checks.
-CHECKS="$(gh api repos/github/codeql-action/commits/${GITHUB_SHA}/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "LGTM.com" or contains("Update") | not)] | unique | sort')"
+CHECKS="$(gh api repos/github/codeql-action/commits/${GITHUB_SHA}/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "LGTM.com" or contains("Update") or contains("update") | not)] | unique | sort')"
 
 echo "$CHECKS" | jq
 


### PR DESCRIPTION
This script didn't quite work on my machine because the update check that we want to filter out was called `update` and `jq` was matching in a case-sensitive way so did not filter it out with `contains("Update")`. Lets add another case to the filter to cover this, to avoid others hitting this issue.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
