### PR TITLE
Trigger half visible dismissal dropdown

### DIFF
--- a/.github/check-sarif/action.yml
+++ b/.github/check-sarif/action.yml
@@ -3,12 +3,12 @@ description: Checks a SARIF file to see if certain queries were run and others w
 inputs:
   sarif-file:
     required: true
-    description: The SARIF file to check
+    description: Different definition
 
   queries-run:
-    required: true
+    required: false
     description: |
-      Comma separated list of query ids that should be included in this SARIF file.
+      Different definitions
 
   queries-not-run:
     required: true

--- a/.github/query-filter-test/action.yml
+++ b/.github/query-filter-test/action.yml
@@ -2,8 +2,8 @@ name: Query Filter Test
 description: Runs a test of query filters using the check sarif action
 inputs:
   sarif-file:
-    required: true
-    description: The SARIF file to check
+    required: false
+    description: trigger alert
 
   queries-run:
     required: true
@@ -31,7 +31,7 @@ runs:
     - uses: ./../action/init
       with:
         languages: javascript
-        config-file: ${{ inputs.config-file }}
+        config-file: ./.github/codeql/fake_file.yml
         tools: ${{ inputs.tools }}
         db-location: ${{ runner.temp }}/query-filter-test
     - uses: ./../action/analyze


### PR DESCRIPTION
Creating a test commit in order to trigger a half visible alert dropdown similar to this one: 

<img width="383" alt="Fix_input_to_action_by_aeisenberg_·_Pull_Request__1102_·_github_codeql-action_and_Google_Calendar_-_Week_of_June_19__2022" src="https://user-images.githubusercontent.com/1354439/175557047-9c3f2fd4-d826-4771-983b-2174cf925743.png">


### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
