### PR TITLE
CI: Add path filters to python-deps workflow

### DIFF
--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -7,6 +7,13 @@ on:
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      # Changes to this workflow.
+      - '.github/workflows/python-deps.yml'
+      # Changes to the Python package installation scripts and their tests.
+      - 'python-setup/**'
+      # Changes to the default CodeQL bundle version.
+      - '**/defaults.json'
 
 jobs:
   test-setup-python-scripts:

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -14,6 +14,10 @@ on:
       - 'python-setup/**'
       # Changes to the default CodeQL bundle version.
       - '**/defaults.json'
+  schedule:
+    # Weekly on Monday.
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 jobs:
   test-setup-python-scripts:


### PR DESCRIPTION
No need to run this workflow on all PRs, only those that change the Python dependency installation mechanism.

Reviewer note: This will need an update to the branch protection rules, because these checks can no longer be required on all PRs.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [N/A] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [N/A] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
