### PR TITLE
CI: Combine JS lint and JS check jobs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,17 +10,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint-js:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run Lint
-        run: npm run-script lint
-
   check-js:
+    name: Check JS
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -30,7 +21,11 @@ jobs:
         node-types-version: [12.12, current]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint
+        run: npm run-script lint
 
       - name: Update version of @types/node
         if: matrix.node-types-version != 'current'


### PR DESCRIPTION
Reduce the number of concurrent jobs (by 1, but every job counts!).
This will require a branch protection rule update, renaming `check-js` to `Check JS` and removing `Lint`.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [N/A] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [N/A] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
