### PR TITLE
Add option to override TRAP caching feature flag

### DIFF
--- a/init/action.yml
+++ b/init/action.yml
@@ -72,6 +72,11 @@ inputs:
       The name of the database uploaded to the debugging artifact.
       This is only used when debug mode is enabled.
     required: false
+  trap-caching:
+    description: >-
+      Explicitly enable or disable TRAP caching rather than respecting the feature flag for it.
+      This is currently a no-op, as the feature behind this has not been implemented yet.
+    required: false
 outputs:
   codeql-path:
     description: The path of the CodeQL binary used for analysis


### PR DESCRIPTION
This is a no-op for now, but let's add it in so DCA can opt out already without any warnings.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
