### PR TITLE
Disable python2 + pipenv tests

### DIFF
--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -33,6 +33,9 @@ jobs:
             # Python2 and poetry are not supported. See https://github.com/actions/setup-python/issues/374
             - python_version: 2
               python_deps_type: poetry
+            # Python2 and pipenv are not supported since pipenv v2021.11.5
+            - python_version: 2
+              python_deps_type: pipenv
 
 
     env:
@@ -135,6 +138,9 @@ jobs:
             # Python2 and poetry are not supported. See https://github.com/actions/setup-python/issues/374
             - python_version: 2
               python_deps_type: poetry
+            # Python2 and pipenv are not supported since pipenv v2021.11.5
+            - python_version: 2
+              python_deps_type: pipenv
 
     env:
       PYTHON_DEPS_TYPE: ${{ matrix.python_deps_type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - In debug mode, debug artifacts are now uploaded even if a step in the Actions workflow fails. [#1159](https://github.com/github/codeql-action/pull/1159)
 - Update default CodeQL bundle version to 2.10.3. [#1178](https://github.com/github/codeql-action/pull/1178)
+- The combination of python2 and Pipenv is no longer supported. [#1181](https://github.com/github/codeql-action/pull/1181)
 
 ## 2.1.18 - 03 Aug 2022
 


### PR DESCRIPTION
Just like we did for poetry and Python 2 in https://github.com/github/codeql-action/pull/1124

From looking at changelogs, Python2 has not been supported in Pipenv since [v2021.11.5](https://pipenv.pypa.io/en/latest/changelog/#id149)

It has started failing CI checks: https://github.com/github/codeql-action/runs/7830121042?check_suite_focus=true

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
