### PR TITLE
Update version number to 1.1.19

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql",
-  "version": "2.1.19",
+  "version": "1.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeql",
-  "version": "2.1.19",
+  "version": "1.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codeql",
-      "version": "2.1.19",
+      "version": "1.1.19",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql",
-  "version": "2.1.19",
+  "version": "1.1.19",
   "private": true,
   "description": "CodeQL action",
   "scripts": {


### PR DESCRIPTION
Complement to https://github.com/github/codeql-action/pull/1197.  This fixes the version number on the `releases/v1` branch, which should be 1.1.19 instead of 2.1.19.  The bug that got us into this position is explained on and fixed by the linked PR.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
