### PR TITLE
Bump CodeQL version to 2.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Allow CodeQL packs to be downloaded from GitHub Enterprise Server instances, using the new `registries` input for the `init` action.  [#1221](https://github.com/github/codeql-action/pull/1221)
+- Update default CodeQL bundle version to 2.10.5. [#1240](https://github.com/github/codeql-action/pull/1240)
 
 ## 2.1.22 - 01 Sep 2022
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,3 +1,3 @@
 {
-    "bundleVersion": "codeql-bundle-20220825"
+    "bundleVersion": "codeql-bundle-20220908"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,3 +1,3 @@
 {
-  "bundleVersion": "codeql-bundle-20220825"
+  "bundleVersion": "codeql-bundle-20220908"
 }


### PR DESCRIPTION
Update the default CodeQL bundle to [codeql-bundle-20220908](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20220908).

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
