### PR TITLE
Improve the descriptions of PRs created by the release process

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -86,21 +86,29 @@ def open_pr(
       body.append(f'- {commit.sha} - {get_truncated_commit_message(commit)}{author_description}')
 
   body.append('')
-  body.append('Please review the following:')
+  body.append('Please do the following:')
   if len(conflicted_files) > 0:
-    body.append(' - [ ] The `package.json` file contains the correct version.')
-    body.append(' - [ ] You have added commits to this branch that resolve the merge conflicts ' +
+    body.append(' - [ ] Ensure `package.json` file contains the correct version.')
+    body.append(' - [ ] Add commits to this branch to resolve the merge conflicts ' +
       'in the following files:')
     body.extend([f'    - [ ] `{file}`' for file in conflicted_files])
-    body.append(' - [ ] Another maintainer has reviewed the additional commits you added to this ' +
+    body.append(' - [ ] Ensure another maintainer has reviewed the additional commits you added to this ' +
       'branch to resolve the merge conflicts.')
-  body.append(' - [ ] The CHANGELOG displays the correct version and date.')
-  body.append(' - [ ] The CHANGELOG includes all relevant, user-facing changes since the last release.')
-  body.append(' - [ ] There are no unexpected commits being merged into the ' + target_branch + ' branch.')
-  body.append(' - [ ] The docs team is aware of any documentation changes that need to be released.')
+  body.append(' - [ ] Ensure the CHANGELOG displays the correct version and date.')
+  body.append(' - [ ] Ensure the CHANGELOG includes all relevant, user-facing changes since the last release.')
+  body.append(' - [ ] Check that there are not any unexpected commits being merged into the ' + target_branch + ' branch.')
+  body.append(' - [ ] Ensure the docs team is aware of any documentation changes that need to be released.')
+
+  if not is_v2_release:
+    body.append(' - [ ] Remove and re-add the "Update dependencies" label to the PR to trigger just this workflow.')
+    body.append(' - [ ] Wait for the "Update dependencies" workflow to push a commit updating the dependencies.')
+    body.append(' - [ ] Mark the PR as ready for review to trigger the full set of PR checks.')
+
+  body.append(' - [ ] Approve and merge this PR.')
+
   if is_v2_release:
-    body.append(' - [ ] The mergeback PR is merged back into ' + source_branch + ' after this PR is merged.')
-    body.append(' - [ ] The v1 release PR is merged after this PR is merged.')
+    body.append(' - [ ] Merge the mergeback PR that will automatically be created once this PR is merged.')
+    body.append(' - [ ] Merge the v1 release PR that will automatically be created once this PR is merged.')
 
   title = 'Merge ' + source_branch + ' into ' + target_branch
 

--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -67,7 +67,7 @@ def open_pr(
   body.append('Merging ' + source_branch_short_sha + ' into ' + target_branch)
 
   body.append('')
-  body.append('Conductor for this PR is @' + conductor)
+  body.append(f'Conductor for this PR is @{conductor}.')
 
   # List all PRs merged
   if len(pull_requests) > 0:
@@ -75,15 +75,15 @@ def open_pr(
     body.append('Contains the following pull requests:')
     for pr in pull_requests:
       merger = get_merger_of_pr(repo, pr)
-      body.append('- #' + str(pr.number) + ' - ' + pr.title +' (@' + merger + ')')
+      body.append(f'- #{pr.number} (@{merger})')
 
   # List all commits not part of a PR
   if len(commits_without_pull_requests) > 0:
     body.append('')
     body.append('Contains the following commits not from a pull request:')
     for commit in commits_without_pull_requests:
-      author_description = ' (@' + commit.author.login + ')' if commit.author is not None else ''
-      body.append('- ' + commit.sha + ' - ' + get_truncated_commit_message(commit) + author_description)
+      author_description = f' (@{commit.author.login})' if commit.author is not None else ''
+      body.append(f'- {commit.sha} - {get_truncated_commit_message(commit)}{author_description}')
 
   body.append('')
   body.append('Please review the following:')

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -114,7 +114,17 @@ jobs:
         run: |
           set -exu
           pr_title="Mergeback ${VERSION} ${HEAD_BRANCH} into ${BASE_BRANCH}"
-          pr_body="Updates version and changelog."
+          pr_body=$(cat << EOF
+            This PR bumps the version number and updates the changelog after the ${VERSION} release.
+
+            Please do the following:
+
+            - [ ] Remove and re-add the "Update dependencies" label to the PR to trigger just this workflow.
+            - [ ] Wait for the "Update dependencies" workflow to push a commit updating the dependencies.
+            - [ ] Mark the PR as ready for review to trigger the full set of PR checks.
+            - [ ] Approve and merge the PR.
+          EOF
+          )
 
           # Update the version number ready for the next release
           npm version patch --no-git-tag-version
@@ -134,4 +144,5 @@ jobs:
             --title "${pr_title}" \
             --label "Update dependencies" \
             --body "${pr_body}" \
+            --assignee "${GITHUB_ACTOR}" \
             --draft


### PR DESCRIPTION
- Recommend removing and then re-adding the "Update dependencies" label when appropriate to avoid having to run the full set of PR checks twice.  This isn't a completely satisfying solution but should reduce friction before we implement something that updates the dependencies without requiring an additional triggering step.
- Recommend marking the PR as ready for review to avoid having to close and reopen the PR to run checks.
- Avoid duplicating the PR titles like this:
   
   <img width="614" alt="image" src="https://user-images.githubusercontent.com/14129055/190657617-4c1b6c73-5d38-45de-9bd1-91ee926074b9.png">

   Instead, just link the PR and let GitHub format the title nicely.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.