### PR TITLE
python-setup: Allow newest `virtualenv`

### DIFF
--- a/python-setup/install_tools.ps1
+++ b/python-setup/install_tools.ps1
@@ -5,8 +5,8 @@ py -3 -m pip install --user --upgrade pip setuptools wheel
 
 # virtualenv is a bit nicer for setting up virtual environment, since it will provide up-to-date versions of
 # pip/setuptools/wheel which basic `python3 -m venv venv` won't
-py -2 -m pip install --user 'virtualenv<20.11'
-py -3 -m pip install --user 'virtualenv<20.11'
+py -2 -m pip install --user 'virtualenv!=20.12.0'
+py -3 -m pip install --user virtualenv
 
 # We aren't compatible with poetry 1.2
 py -3 -m pip install --user "poetry>=1.1,<1.2"

--- a/python-setup/install_tools.sh
+++ b/python-setup/install_tools.sh
@@ -15,7 +15,7 @@ python3 -m pip install --user --upgrade pip setuptools wheel
 
 # virtualenv is a bit nicer for setting up virtual environment, since it will provide up-to-date versions of
 # pip/setuptools/wheel which basic `python3 -m venv venv` won't
-python3 -m pip install --user 'virtualenv<20.11'
+python3 -m pip install --user virtualenv
 
 # We install poetry with pip instead of the recommended way, since the recommended way
 # caused some problem since `poetry run` gives output like:
@@ -42,5 +42,5 @@ if command -v python2 >/dev/null 2>&1; then
 
 	python2 -m pip install --user --upgrade pip setuptools wheel
 
-	python2 -m pip install --user 'virtualenv<20.11'
+	python2 -m pip install --user 'virtualenv!=20.12.0'
 fi


### PR DESCRIPTION
Context for previous version is
https://github.com/github/codeql-action/pull/862

Locally, I was able to install `20.15.1` with Python2.

I don't see any reason why python3 version should be restricted.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
