### PR TITLE
Add dotnet env variable to workflow

### DIFF
--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -93,4 +93,5 @@ jobs:
       env:
         TEST_MODE: true
     env:
+      DOTNET_GENERATE_ASPNET_CERTIFICATE: 'false'
       INTERNAL_CODEQL_ACTION_DEBUG_LOC: true

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -1,5 +1,7 @@
 name: "Go: Custom queries"
 description: "Checks that Go works in conjunction with a config file specifying custom queries"
+env: 
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
   - uses: actions/setup-go@v3
     with:


### PR DESCRIPTION
Previously, we considered `go` a non-traced language, and so the tracer was not imported to this workflow at all. Now that we are considering it traced, we need to add this additional environment variable, which is required for our MacOS tests to not time out waiting for a GUI popup. 

We already do this in several other Go-specific checks, such as https://github.com/github/codeql-action/blob/main/.github/workflows/__go-custom-tracing-autobuild.yml and https://github.com/github/codeql-action/blob/main/.github/workflows/__go-reconciled-tracing-autobuilder.yml

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.