### PR TITLE
Stop checking for Go log artifacts on failure

### DIFF
--- a/.github/workflows/debug-artifacts-failure.yml
+++ b/.github/workflows/debug-artifacts-failure.yml
@@ -79,7 +79,7 @@ jobs:
                 echo "Missing database initialization logs"
                 exit 1
               fi
-              if [[ ! -d "$language/log" ]] ; then
+              if [[ ! "$language" == "go" ]] && [[ ! -d "$language/log" ]] ; then
                 echo "Missing logs for $language"
                 exit 1
               fi


### PR DESCRIPTION
The new Go extraction reconciliation feature flag treats Go as a traced rather than scanned language, and so it does not run `database trace-command` and produce logs from this command. The Go extractor and autobuilder themselves also do not create log files; their logs are written to stdout. Therefore, our check for the log artifact upon failure should be removed in this case only.

We continue to check for Go logs when debug artifacts succeed in https://github.com/github/codeql-action/actions/workflows/debug-artifacts.yml because we should then see other logs from database finalization. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
