### PR TITLE
Clarify merging with merge commit

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -104,7 +104,7 @@ def open_pr(
     body.append(' - [ ] Wait for the "Update dependencies" workflow to push a commit updating the dependencies.')
     body.append(' - [ ] Mark the PR as ready for review to trigger the full set of PR checks.')
 
-  body.append(' - [ ] Approve and merge this PR.')
+  body.append(' - [ ] Approve and merge this PR. Make sure `Create a merge commit` is selected rather than `Squash and merge` or `Rebase and merge`.')
 
   if is_v2_release:
     body.append(' - [ ] Merge the mergeback PR that will automatically be created once this PR is merged.')

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -122,7 +122,7 @@ jobs:
             - [ ] Remove and re-add the "Update dependencies" label to the PR to trigger just this workflow.
             - [ ] Wait for the "Update dependencies" workflow to push a commit updating the dependencies.
             - [ ] Mark the PR as ready for review to trigger the full set of PR checks.
-            - [ ] Approve and merge the PR.
+            - [ ] Approve and merge the PR. Make sure `Create a merge commit` is selected rather than `Squash and merge` or `Rebase and merge`.
           EOF
           )
 


### PR DESCRIPTION
We want to add an explicit statement that merging release commits should not be squashed or rebased 😸 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
