### PR TITLE
Bump the min version for code scanning config in the cli

### DIFF
--- a/lib/feature-flags.js
+++ b/lib/feature-flags.js
@@ -37,7 +37,7 @@ exports.featureConfig = {
     },
     [Feature.CliConfigFileEnabled]: {
         envVar: "CODEQL_PASS_CONFIG_TO_CLI",
-        minimumVersion: "2.10.1",
+        minimumVersion: "2.11.1",
     },
     [Feature.GolangExtractionReconciliationEnabled]: {
         envVar: "CODEQL_GOLANG_EXTRACTION_RECONCILIATION",

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -26,7 +26,7 @@ export const featureConfig: Record<
   },
   [Feature.CliConfigFileEnabled]: {
     envVar: "CODEQL_PASS_CONFIG_TO_CLI",
-    minimumVersion: "2.10.1",
+    minimumVersion: "2.11.1",
   },
   [Feature.GolangExtractionReconciliationEnabled]: {
     envVar: "CODEQL_GOLANG_EXTRACTION_RECONCILIATION",


### PR DESCRIPTION
2.11.1 has a fix in it for parsing query filters. Workflows using query filters will break if they are using syntax like:

```yaml
- exclude:
      id: foo/bar
```

instead of

```yaml
- exclude:
      - id: foo/bar
```

So, prevent users of CLI versions earlier than 2.11.1 from using the cli config parsing flag.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
