### PR TITLE
Fix mergeback PR description

### DIFF
--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -121,7 +121,8 @@ jobs:
             - [ ] Remove and re-add the "Update dependencies" label to the PR to trigger just this workflow.
             - [ ] Wait for the "Update dependencies" workflow to push a commit updating the dependencies.
             - [ ] Mark the PR as ready for review to trigger the full set of PR checks.
-            - [ ] Approve and merge the PR. Make sure `Create a merge commit` is selected rather than `Squash and merge` or `Rebase and merge`.
+            - [ ] Approve and merge the PR. When merging the PR, make sure "Create a merge commit" is
+                  selected rather than "Squash and merge" or "Rebase and merge".
           EOF
           )
 


### PR DESCRIPTION
Previously the quoted values weren't visible in the PR description. See https://github.com/github/codeql-action/pull/1324 for an example.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
