### PR TITLE
Add Go to list of supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
         # with:
         #   languages: go, javascript, csharp, python, cpp, java
 
-      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2


### PR DESCRIPTION
This change adds Go to the list of compiled languages that may be autobuilt, or manually built, in our documentation.

A PR to add it to the official starter workflow is up at https://github.com/actions/starter-workflows/pull/1796 as well. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
