### PR TITLE
Make PR checks compatible with the latest version of the `ubuntu-latest` runner image

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -25,19 +25,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
         - os: windows-2019
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
         - os: windows-2019
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809
@@ -47,23 +47,19 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: "Analyze: 'ref' and 'sha' from inputs"
     timeout-minutes: 45

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -29,9 +29,7 @@ jobs:
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
     name: autobuild-action
     timeout-minutes: 45

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -25,19 +25,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
         - os: windows-2019
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
         - os: windows-2019
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809
@@ -47,23 +47,19 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Go: Custom queries'
     timeout-minutes: 45

--- a/.github/workflows/__go-custom-tracing-autobuild.yml
+++ b/.github/workflows/__go-custom-tracing-autobuild.yml
@@ -25,15 +25,15 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -25,19 +25,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
         - os: windows-2019
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
         - os: windows-2019
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809
@@ -47,23 +47,19 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Go: Custom tracing'
     timeout-minutes: 45

--- a/.github/workflows/__go-reconciled-tracing-autobuilder.yml
+++ b/.github/workflows/__go-reconciled-tracing-autobuilder.yml
@@ -25,15 +25,15 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809

--- a/.github/workflows/__go-reconciled-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-reconciled-tracing-custom-build-steps.yml
@@ -25,19 +25,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
         - os: windows-2019
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
         - os: windows-2019
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809
@@ -47,23 +47,19 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Go: Reconciled tracing with custom build steps'
     timeout-minutes: 45

--- a/.github/workflows/__go-reconciled-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-reconciled-tracing-legacy-workflow.yml
@@ -25,15 +25,15 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -29,9 +29,7 @@ jobs:
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Packaging: Download using registries'
     timeout-minutes: 45

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -25,15 +25,15 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -29,23 +29,19 @@ jobs:
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Packaging: Config and input passed to the CLI'
     timeout-minutes: 45

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -29,23 +29,19 @@ jobs:
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Packaging: Config and input'
     timeout-minutes: 45

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -29,23 +29,19 @@ jobs:
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Packaging: Config file'
     timeout-minutes: 45

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -29,23 +29,19 @@ jobs:
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: 'Packaging: Action input'
     timeout-minutes: 45

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -25,19 +25,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
         - os: windows-2019
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
         - os: windows-2019
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809
@@ -47,23 +47,19 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: Remote config file
     timeout-minutes: 45

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -25,18 +25,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-20.04
-          version: stable-20210308
-        - os: ubuntu-20.04
-          version: stable-20210319
-        - os: ubuntu-20.04
-          version: stable-20210809
         - os: ubuntu-latest
           version: cached
-        - os: ubuntu-latest
-          version: latest
-        - os: ubuntu-latest
-          version: nightly-latest
     name: RuboCop multi-language
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -25,11 +25,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: ubuntu-latest
           version: cached

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -25,19 +25,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
         - os: windows-2019
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
         - os: windows-2019
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809
@@ -47,23 +47,19 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: "Upload-sarif: 'ref' and 'sha' from inputs"
     timeout-minutes: 45

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -25,19 +25,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
         - os: macos-latest
           version: stable-20210308
         - os: windows-2019
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
         - os: macos-latest
           version: stable-20210319
         - os: windows-2019
           version: stable-20210319
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: macos-latest
           version: stable-20210809
@@ -47,23 +47,19 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
-        - os: windows-2019
+        - os: windows-latest
           version: cached
         - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
-        - os: windows-2019
-          version: latest
-        - os: windows-2022
+        - os: windows-latest
           version: latest
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
-        - os: windows-2019
-          version: nightly-latest
-        - os: windows-2022
+        - os: windows-latest
           version: nightly-latest
     name: Use a custom `checkout_path`
     timeout-minutes: 45

--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -24,7 +24,6 @@ jobs:
     continue-on-error: true
 
     strategy:
-      fail-fast: true
       matrix:
         include:
         - os: ubuntu-latest

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -19,8 +19,31 @@ jobs:
   upload-artifacts:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        version: [stable-20210308, stable-20210319, stable-20210809, cached, latest, nightly-latest]
+        include:
+          - os: ubuntu-20.04
+            version: stable-20210308
+          - os: macos-latest
+            version: stable-20210308
+          - os: ubuntu-20.04
+            version: stable-20210319
+          - os: macos-latest
+            version: stable-20210319
+          - os: ubuntu-20.04
+            version: stable-20210809
+          - os: macos-latest
+            version: stable-20210809
+          - os: ubuntu-latest
+            version: cached
+          - os: macos-latest
+            version: cached
+          - os: ubuntu-latest
+            version: latest
+          - os: macos-latest
+            version: latest
+          - os: ubuntu-latest
+            version: nightly-latest
+          - os: macos-latest
+            version: nightly-latest
     name: Upload debug artifacts
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -58,11 +81,15 @@ jobs:
       - name: Check expected artifacts exist
         shell: bash
         run: |
-          OPERATING_SYSTEMS="ubuntu-latest macos-latest"
           VERSIONS="stable-20210308 stable-20210319 stable-20210809 cached latest nightly-latest"
           LANGUAGES="cpp csharp go java javascript python"
-          for os in $OPERATING_SYSTEMS; do
-            for version in $VERSIONS; do
+          for version in $VERSIONS; do
+            if [[ "$version" =~ stable-(20210308|20210319|20210809) ]]; then
+              OPERATING_SYSTEMS="ubuntu-20.04 macos-latest"
+            else
+              OPERATING_SYSTEMS="ubuntu-latest macos-latest"
+            fi
+            for os in $OPERATING_SYSTEMS; do
               pushd "./my-debug-artifacts-$os-$version"
               echo "Artifacts from version $version on $os:"
               for language in $LANGUAGES; do

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -85,7 +85,9 @@ jobs:
           LANGUAGES="cpp csharp go java javascript python"
           for version in $VERSIONS; do
             if [[ "$version" =~ stable-(20210308|20210319|20210809) ]]; then
-              OPERATING_SYSTEMS="ubuntu-20.04 macos-latest"
+              # Note the absence of the period in "ubuntu-2004": this is present in the image name
+              # but not the artifact name
+              OPERATING_SYSTEMS="ubuntu-2004 macos-latest"
             else
               OPERATING_SYSTEMS="ubuntu-latest macos-latest"
             fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,6 @@ jobs:
     timeout-minutes: 45
 
     strategy:
-      fail-fast: true
       matrix:
         node-types-version: [12.12, current]
 

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [ubuntu-latest, ubuntu-22.04, macos-latest]
+          os: [ubuntu-20.04, ubuntu-22.04, macos-latest]
           python_deps_type: [pipenv, poetry, requirements, setup_py]
           python_version: [2, 3]
           exclude:
@@ -65,7 +65,7 @@ jobs:
         cd $GITHUB_WORKSPACE/python-setup/tests/${PYTHON_DEPS_TYPE}/requests-${PYTHON_VERSION}
 
         case ${{ matrix.os }} in
-            ubuntu-latest*)     basePath="/opt";;
+            ubuntu-20.04*)     basePath="/opt";;
             ubuntu-22.04*)     basePath="/opt";;
             macos-latest*)    basePath="/Users/runner";;
         esac
@@ -90,7 +90,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [ubuntu-latest, ubuntu-22.04, macos-latest]
+          os: [ubuntu-20.04, ubuntu-22.04, macos-latest]
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -112,7 +112,7 @@ jobs:
         cd $GITHUB_WORKSPACE/python-setup/tests/requirements/non-standard-location
 
         case ${{ matrix.os }} in
-            ubuntu-latest*)     basePath="/opt";;
+            ubuntu-20.04*)     basePath="/opt";;
             ubuntu-22.04*)     basePath="/opt";;
             macos-latest*)    basePath="/Users/runner";;
         esac

--- a/.github/workflows/unset-environment-new-cli.yml
+++ b/.github/workflows/unset-environment-new-cli.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210809
         - os: ubuntu-latest
           version: cached

--- a/.github/workflows/unset-environment-old-cli.yml
+++ b/.github/workflows/unset-environment-old-cli.yml
@@ -24,9 +24,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210308
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           version: stable-20210319
     name: Test unsetting environment variables
     timeout-minutes: 45

--- a/pr-checks/checks/extractor-ram-threads.yml
+++ b/pr-checks/checks/extractor-ram-threads.yml
@@ -1,7 +1,7 @@
 name: "Extractor ram and threads options test"
 description: "Tests passing RAM and threads limits to extractors"
 versions: ["latest"]
-os: ["ubuntu-latest"]
+operatingSystems: ["ubuntu"]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/go-custom-tracing-autobuild.yml
+++ b/pr-checks/checks/go-custom-tracing-autobuild.yml
@@ -1,6 +1,6 @@
 name: "Go: Autobuild custom tracing"
 description: "Checks that Go tracing works in conjunction with the autobuilder"
-os: ["ubuntu-latest", "macos-latest"]
+operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_EXTRACTOR_GO_BUILD_TRACING: "on"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"

--- a/pr-checks/checks/go-reconciled-tracing-autobuilder.yml
+++ b/pr-checks/checks/go-reconciled-tracing-autobuilder.yml
@@ -1,6 +1,6 @@
 name: "Go: Reconciled tracing with autobuilder"
 description: "Checks that Go reconciled tracing works when using an autobuilder step"
-os: ["ubuntu-latest", "macos-latest"]
+operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ACTION_RECONCILE_GO_EXTRACTION: "true"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"

--- a/pr-checks/checks/go-reconciled-tracing-legacy-workflow.yml
+++ b/pr-checks/checks/go-reconciled-tracing-legacy-workflow.yml
@@ -1,6 +1,6 @@
 name: "Go: Reconciled tracing with legacy workflow"
 description: "Checks that we run the autobuilder in legacy workflows with neither an autobuild step nor manual build steps"
-os: ["ubuntu-latest", "macos-latest"]
+operatingSystems: ["ubuntu", "macos"]
 env:
   # Enable reconciled Go tracing beta functionality
   CODEQL_ACTION_RECONCILE_GO_EXTRACTION: "true"

--- a/pr-checks/checks/javascript-source-root.yml
+++ b/pr-checks/checks/javascript-source-root.yml
@@ -1,7 +1,7 @@
 name: "Custom source root"
 description: "Checks that the argument specifying a non-default source root works"
 versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
-os: ["ubuntu-latest"]
+operatingSystems: ["ubuntu"]
 steps:
   - name: Move codeql-action
     shell: bash

--- a/pr-checks/checks/ml-powered-queries.yml
+++ b/pr-checks/checks/ml-powered-queries.yml
@@ -7,8 +7,6 @@ versions: [
     "latest",
     "nightly-latest",
   ]
-# Test on all three platforms since ML-powered queries use native code
-os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -1,6 +1,6 @@
 name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
-os: ["ubuntu-latest", "macos-latest"]
+operatingSystems: ["ubuntu", "macos"]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/rubocop-multi-language.yml
+++ b/pr-checks/checks/rubocop-multi-language.yml
@@ -1,6 +1,6 @@
 name: "RuboCop multi-language"
 description: "Tests using RuboCop to analyze a multi-language repository and then using the CodeQL Action to upload the resulting SARIF"
-os: ["ubuntu-latest"]
+operatingSystems: ["ubuntu"]
 steps:
   - name: Set up Ruby
     uses: ruby/setup-ruby@v1

--- a/pr-checks/checks/rubocop-multi-language.yml
+++ b/pr-checks/checks/rubocop-multi-language.yml
@@ -1,6 +1,8 @@
 name: "RuboCop multi-language"
 description: "Tests using RuboCop to analyze a multi-language repository and then using the CodeQL Action to upload the resulting SARIF"
 operatingSystems: ["ubuntu"]
+# This check doesn't use CodeQL, so the `version` matrix variable is unused.
+versions: ["cached"]
 steps:
   - name: Set up Ruby
     uses: ruby/setup-ruby@v1

--- a/pr-checks/checks/split-workflow.yml
+++ b/pr-checks/checks/split-workflow.yml
@@ -1,6 +1,6 @@
 name: "Split workflow"
 description: "Tests a split-up workflow in which we first build a database and later analyze it"
-os: ["ubuntu-latest", "macos-latest"]
+operatingSystems: ["ubuntu", "macos"]
 versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/test-autobuild-working-dir.yml
+++ b/pr-checks/checks/test-autobuild-working-dir.yml
@@ -1,7 +1,7 @@
 name: "Autobuild working directory"
 description: "Tests working-directory input of autobuild action"
 versions: ["latest"]
-os: ["ubuntu-latest"]
+operatingSystems: ["ubuntu"]
 steps:
   - name: Test setup
     shell: bash

--- a/pr-checks/checks/test-local-codeql.yml
+++ b/pr-checks/checks/test-local-codeql.yml
@@ -1,7 +1,7 @@
 name: "Local CodeQL bundle"
 description: "Tests using a CodeQL bundle from a local file rather than a URL"
 versions: ["nightly-latest"]
-os: ["ubuntu-latest"]
+operatingSystems: ["ubuntu"]
 steps:
   - name: Fetch a CodeQL bundle
     shell: bash

--- a/pr-checks/checks/test-proxy.yml
+++ b/pr-checks/checks/test-proxy.yml
@@ -1,7 +1,7 @@
 name: "Proxy test"
 description: "Tests using a proxy specified by the https_proxy environment variable"
 versions: ["latest"]
-os: ["ubuntu-latest"]
+operatingSystems: ["ubuntu"]
 container:
   image: ubuntu:18.04
   options: --dns 127.0.0.1

--- a/pr-checks/checks/test-ruby.yml
+++ b/pr-checks/checks/test-ruby.yml
@@ -1,7 +1,7 @@
 name: "Ruby analysis"
 description: "Tests creation of a Ruby database"
 versions: ["latest", "cached", "nightly-latest"]
-os: ["ubuntu-latest", "macos-latest"]
+operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES: "true"
 steps:

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -1,9 +1,5 @@
 name: "Use a custom `checkout_path`"
 description: "Checks that a custom `checkout_path` will find the proper commit_oid"
-# Build tracing currently does not support Windows 2022, so use `windows-2019` instead of
-# `windows-latest`.
-# Must test on all three platforms since this test does path manipulation
-os: [ubuntu-latest, macos-latest, windows-2019]
 steps:
   # Check out the actions repo again, but at a different location.
   # choose an arbitrary SHA so that we can later test that the commit_oid is not from main

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -22,8 +22,8 @@ def isCompatibleWithLatestImages(version):
     if version in ["cached", "latest", "nightly-latest"]:
         return True
     date = version.split("-")[1]
-    # The first version of the CodeQL CLI compatible with the latest runner images is 2.7.3.
-    # This appears in CodeQL Bundle version codeql-bundle-20211208.
+    # The first version of the CodeQL CLI compatible with `ubuntu-22.04` and `windows-2022` is
+    # 2.7.3. This appears in CodeQL Bundle version codeql-bundle-20211208.
     return date >= "20211208"
 
 


### PR DESCRIPTION
This PR updates the PR checks to handle the recent update to the `ubuntu-latest` runner image.  This is being moved over to Ubuntu 22.04, which is only compatible with CodeQL CLI 2.7.3 and later.  Some of our PR checks use very old CLIs, and this PR updates them to run on the `ubuntu-20.04` image instead.

Planned work:
- Introducing a process to run our checks against new runner images before the `-latest` image changes.
- In the future, deprecating support for versions of the CLI earlier than 2.7.3.
- Potentially introducing a more helpful error message into the Action when we hit this case.  Impact depends on how many customers are running the latest Action (so they'll benefit from the new error message) against a very old CLI (older than 2.7.3).

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
