### PR TITLE
Handle concurrency waste out-of-the-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ on:
     #        *  * * * *
     - cron: '30 1 * * 0'
 
+# We cancel any in-progess scans on the same ref/pr, as they are unnecessary.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest


### PR DESCRIPTION
### Contents
Default implementation shown in readme does not handle concurrency in any way, wasting minutes running scans on each and every commit when it's unnecessary.

This PR proposes that the default implementation cancels in-progress runs of the workflow for the same github ref or PR. Meaning that, for example, quickly successive commits to an open pull request will not end with multiple completed runs, and only complete the latest commit.


### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
