### PR TITLE
Fix missing Docker image in proxy test

### DIFF
--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -51,10 +51,10 @@ jobs:
       https_proxy: http://squid-proxy:3128
       INTERNAL_CODEQL_ACTION_DEBUG_LOC: true
     container:
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       options: --dns 127.0.0.1
     services:
       squid-proxy:
-        image: datadog/squid:latest
+        image: ubuntu/squid:latest
         ports:
         - 3128:3128

--- a/pr-checks/checks/test-proxy.yml
+++ b/pr-checks/checks/test-proxy.yml
@@ -3,11 +3,11 @@ description: "Tests using a proxy specified by the https_proxy environment varia
 versions: ["latest"]
 operatingSystems: ["ubuntu"]
 container:
-  image: ubuntu:18.04
+  image: ubuntu:22.04
   options: --dns 127.0.0.1
 services:
   squid-proxy:
-    image: datadog/squid:latest
+    image: ubuntu/squid:latest
     ports:
       - 3128:3128
 env:


### PR DESCRIPTION
`datadog/squid` no longer exists, so replace it with `ubuntu/squid`.  Also bump the Ubuntu version while we're here.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
