### PR TITLE
Use Swift version 5.7 in PR checks

### DIFF
--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       if: "!startsWith(matrix.os, 'windows')"
       with:
-        swift-version: 5.7
+        swift-version: '5.7'
     - uses: ./../action/init
       with:
         languages: javascript

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         version: ${{ matrix.version }}
     - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
-      if: "!startsWith(matrix.os, 'windows')"
+      if: runner.os != 'Windows'
       with:
         swift-version: '5.7'
     - uses: ./../action/init

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -42,7 +42,7 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       if: "!startsWith(matrix.os, 'windows')"
       with:
         swift-version: 5.7

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -42,6 +42,10 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - uses: swift-actions/setup-swift@v1
+      if: "!startsWith(matrix.os, 'windows')"
+      with:
+        swift-version: 5.7
     - uses: ./../action/init
       with:
         languages: javascript

--- a/.github/workflows/__ml-powered-queries.yml
+++ b/.github/workflows/__ml-powered-queries.yml
@@ -87,8 +87,7 @@ jobs:
     - name: Check sarif
       uses: ./../action/.github/check-sarif
     # Running on Windows requires CodeQL CLI 2.9.0+.
-      if: "!(matrix.version == 'stable-20220120' && (matrix.os == 'windows-latest'\
-        \ || matrix.os == 'windows-2019'))"
+      if: "!(matrix.version == 'stable-20220120' && runner.os == 'Windows')"
       with:
         sarif-file: ${{ runner.temp }}/results/javascript.sarif
         queries-run: js/ml-powered/nosql-injection,js/ml-powered/path-injection,js/ml-powered/sql-injection,js/ml-powered/xss
@@ -98,7 +97,7 @@ jobs:
       env:
       # Running on Windows requires CodeQL CLI 2.9.0+.
         SHOULD_RUN_ML_POWERED_QUERIES: ${{ !(matrix.version == 'stable-20220120' &&
-          (matrix.os == 'windows-latest' || matrix.os == 'windows-2019')) }}
+          runner.os == 'Windows') }}
       shell: bash
       run: |
         echo "Expecting ML-powered queries to be run: ${SHOULD_RUN_ML_POWERED_QUERIES}"

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,15 +65,23 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.13.1
+    - uses: swift-actions/setup-swift@v1
+      if: "!startsWith(matrix.os, 'windows')"
+      with:
+        swift-version: 5.7
+
     - uses: ./../action/init
       with:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+
     - name: Build code
       shell: bash
       run: ./build.sh
+
     - uses: ./../action/analyze
       id: analysis
+
     - name: Check language autodetect for all languages excluding Ruby, Swift
       shell: bash
       run: |
@@ -107,16 +115,23 @@ jobs:
           echo "Did not create a database for Python, or created it in the wrong location."
           exit 1
         fi
-    - name: Check language autodetect for Ruby, Swift
+
+    - name: Check language autodetect for Ruby
       if: (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version
         == 'nightly-latest')
       shell: bash
-      run: |-
+      run: |
         RUBY_DB=${{ fromJson(steps.analysis.outputs.db-locations).ruby }}
         if [[ ! -d $RUBY_DB ]] || [[ ! $RUBY_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
           echo "Did not create a database for Ruby, or created it in the wrong location."
           exit 1
         fi
+
+    - name: Check language autodetect for Swift
+      if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version\
+        \ == 'latest' || matrix.version == 'nightly-latest')"
+      shell: bash
+      run: |
         SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}
         if [[ ! -d $SWIFT_DB ]] || [[ ! $SWIFT_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
           echo "Did not create a database for Swift, or created it in the wrong location."

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       if: "!startsWith(matrix.os, 'windows')"
       with:
-        swift-version: 5.7
+        swift-version: '5.7'
 
     - uses: ./../action/init
       with:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         go-version: ^1.13.1
     - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
-      if: "!startsWith(matrix.os, 'windows')"
+      if: runner.os != 'Windows'
       with:
         swift-version: '5.7'
 

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,7 +65,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.13.1
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       if: "!startsWith(matrix.os, 'windows')"
       with:
         swift-version: 5.7

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -63,5 +63,4 @@ jobs:
           exit 1
         fi
     env:
-      CODEQL_ENABLE_EXPERIMENTAL_FEATURES: 'true'
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -42,7 +42,7 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       with:
         swift-version: 5.7
     - uses: ./../action/init

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -44,7 +44,7 @@ jobs:
         version: ${{ matrix.version }}
     - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       with:
-        swift-version: 5.7
+        swift-version: '5.7'
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -42,6 +42,9 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: 5.7
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -50,7 +50,7 @@ jobs:
         version: ${{ matrix.version }}
     - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       with:
-        swift-version: 5.7
+        swift-version: '5.7'
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -48,6 +48,9 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: 5.7
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -48,7 +48,7 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
       with:
         swift-version: 5.7
     - uses: ./../action/init

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -2,6 +2,10 @@ name: "Export file baseline information"
 description: "Tests that file baseline information is exported when the feature is enabled"
 versions: ["nightly-latest"]
 steps:
+  - uses: swift-actions/setup-swift@v1
+    if: "!startsWith(matrix.os, 'windows')"
+    with:
+      swift-version: 5.7
   - uses: ./../action/init
     with:
       languages: javascript

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -3,7 +3,7 @@ description: "Tests that file baseline information is exported when the feature 
 versions: ["nightly-latest"]
 steps:
   - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
-    if: "!startsWith(matrix.os, 'windows')"
+    if: runner.os != 'Windows'
     with:
       swift-version: "5.7"
   - uses: ./../action/init

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -2,7 +2,7 @@ name: "Export file baseline information"
 description: "Tests that file baseline information is exported when the feature is enabled"
 versions: ["nightly-latest"]
 steps:
-  - uses: swift-actions/setup-swift@v1
+  - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     if: "!startsWith(matrix.os, 'windows')"
     with:
       swift-version: 5.7

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -5,7 +5,7 @@ steps:
   - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     if: "!startsWith(matrix.os, 'windows')"
     with:
-      swift-version: 5.7
+      swift-version: "5.7"
   - uses: ./../action/init
     with:
       languages: javascript

--- a/pr-checks/checks/ml-powered-queries.yml
+++ b/pr-checks/checks/ml-powered-queries.yml
@@ -30,7 +30,7 @@ steps:
   - name: Check sarif
     uses: ./../action/.github/check-sarif
     # Running on Windows requires CodeQL CLI 2.9.0+.
-    if: "!(matrix.version == 'stable-20220120' && (matrix.os == 'windows-latest' || matrix.os == 'windows-2019'))"
+    if: "!(matrix.version == 'stable-20220120' && runner.os == 'Windows')"
     with:
       sarif-file: ${{ runner.temp }}/results/javascript.sarif
       queries-run: js/ml-powered/nosql-injection,js/ml-powered/path-injection,js/ml-powered/sql-injection,js/ml-powered/xss
@@ -39,7 +39,7 @@ steps:
   - name: Check results
     env:
       # Running on Windows requires CodeQL CLI 2.9.0+.
-      SHOULD_RUN_ML_POWERED_QUERIES: ${{ !(matrix.version == 'stable-20220120' && (matrix.os == 'windows-latest' || matrix.os == 'windows-2019')) }}
+      SHOULD_RUN_ML_POWERED_QUERIES: ${{ !(matrix.version == 'stable-20220120' && runner.os == 'Windows') }}
     shell: bash
     run: |
       echo "Expecting ML-powered queries to be run: ${SHOULD_RUN_ML_POWERED_QUERIES}"

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -5,7 +5,7 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
   - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
-    if: "!startsWith(matrix.os, 'windows')"
+    if: runner.os != 'Windows'
     with:
       swift-version: "5.7"
 

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -7,7 +7,7 @@ steps:
   - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     if: "!startsWith(matrix.os, 'windows')"
     with:
-      swift-version: 5.7
+      swift-version: "5.7"
 
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,15 +4,23 @@ operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
+  - uses: swift-actions/setup-swift@v1
+    if: "!startsWith(matrix.os, 'windows')"
+    with:
+      swift-version: 5.7
+
   - uses: ./../action/init
     with:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+
   - name: Build code
     shell: bash
     run: ./build.sh
+
   - uses: ./../action/analyze
     id: analysis
+
   - name: Check language autodetect for all languages excluding Ruby, Swift
     shell: bash
     run: |
@@ -46,7 +54,8 @@ steps:
         echo "Did not create a database for Python, or created it in the wrong location."
         exit 1
       fi
-  - name: Check language autodetect for Ruby, Swift
+
+  - name: Check language autodetect for Ruby
     if: "(matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
     shell: bash
     run: |
@@ -55,6 +64,11 @@ steps:
         echo "Did not create a database for Ruby, or created it in the wrong location."
         exit 1
       fi
+
+  - name: Check language autodetect for Swift
+    if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
+    shell: bash
+    run: |
       SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}
       if [[ ! -d $SWIFT_DB ]] || [[ ! $SWIFT_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
         echo "Did not create a database for Swift, or created it in the wrong location."

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,7 +4,7 @@ operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
-  - uses: swift-actions/setup-swift@v1
+  - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     if: "!startsWith(matrix.os, 'windows')"
     with:
       swift-version: 5.7

--- a/pr-checks/checks/ruby.yml
+++ b/pr-checks/checks/ruby.yml
@@ -2,8 +2,6 @@ name: "Ruby analysis"
 description: "Tests creation of a Ruby database"
 versions: ["latest", "cached", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
-env:
-  CODEQL_ENABLE_EXPERIMENTAL_FEATURES: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -8,7 +8,7 @@ env:
 steps:
   - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     with:
-      swift-version: 5.7
+      swift-version: "5.7"
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -6,6 +6,9 @@ operatingSystems: ["macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
 steps:
+  - uses: swift-actions/setup-swift@v1
+    with:
+      swift-version: 5.7
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -6,7 +6,7 @@ operatingSystems: ["macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
 steps:
-  - uses: swift-actions/setup-swift@v1
+  - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     with:
       swift-version: 5.7
   - uses: ./../action/init

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -8,7 +8,7 @@ env:
 steps:
   - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     with:
-      swift-version: 5.7
+      swift-version: "5.7"
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -6,7 +6,7 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
-  - uses: swift-actions/setup-swift@v1
+  - uses: swift-actions/setup-swift@5cdaa9161ad1f55ae39a5ea1784ef96de72f95d9
     with:
       swift-version: 5.7
   - uses: ./../action/init

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -6,6 +6,9 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
+  - uses: swift-actions/setup-swift@v1
+    with:
+      swift-version: 5.7
   - uses: ./../action/init
     with:
       languages: swift


### PR DESCRIPTION
The version installed in the latest runner image, 5.7.1, is not yet supported.

cc @AlexDenisov 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
