### PR TITLE
Update default CodeQL bundle version to 2.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Update default CodeQL bundle version to 2.11.4. [#1391](https://github.com/github/codeql-action/pull/1391)
 - Fixed a bug where some the `init` action and the `analyze` action would have different sets of experimental feature flags enabled. [#1384](https://github.com/github/codeql-action/pull/1384)
 
 ## 2.1.33 - 16 Nov 2022

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,3 +1,3 @@
 {
-    "bundleVersion": "codeql-bundle-20221105"
+    "bundleVersion": "codeql-bundle-20221123"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,3 +1,3 @@
 {
-  "bundleVersion": "codeql-bundle-20221105"
+  "bundleVersion": "codeql-bundle-20221123"
 }


### PR DESCRIPTION
For some reason `npm run build` wasn't updating lib so I did it manually.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
