### PR TITLE
python-setup: Don't allow Poetry to make venv in project

### DIFF
--- a/python-setup/auto_install_packages.py
+++ b/python-setup/auto_install_packages.py
@@ -33,10 +33,16 @@ def _check_output(command, extra_env={}):
 
 def install_packages_with_poetry():
 
-    # To handle poetry 1.2, which started to use keyring interaction MUCH more, we need
-    # add a workaround. See
-    # https://github.com/python-poetry/poetry/issues/2692#issuecomment-1235683370
-    extra_poetry_env = {"PYTHON_KEYRING_BACKEND": "keyring.backends.null.Keyring"}
+    extra_poetry_env = {
+        # To handle poetry 1.2, which started to use keyring interaction MUCH more, we need
+        # add a workaround. See
+        # https://github.com/python-poetry/poetry/issues/2692#issuecomment-1235683370
+        "PYTHON_KEYRING_BACKEND": "keyring.backends.null.Keyring",
+        # Projects that specify `in-project = true` in their poetry.toml would get the
+        # venv created inside the repo directory, which would cause CodeQL to consider
+        # it as user-written code. We don't want this to happen.
+        "POETRY_VIRTUALENVS_IN_PROJECT": "False",
+    }
 
     command = [sys.executable, '-m', 'poetry']
     if sys.platform.startswith('win32'):

--- a/python-setup/tests/poetry/requests-3/poetry.toml
+++ b/python-setup/tests/poetry/requests-3/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
As highlighted in the code comments, Projects that specify `in-project = true` in their poetry.toml would get the venv created inside the repo directory, which would cause CodeQL to consider it as user-written code. We don't want this to happen.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.

I have not updated changelog or readme since I thought this was a small enough change, but let me know if you think that woudl be needed.