### PR TITLE
Set up the Swift version the extractor declares

### DIFF
--- a/.github/setup-swift/action.yml
+++ b/.github/setup-swift/action.yml
@@ -1,0 +1,32 @@
+name: "Setup Swift"
+description: Performs necessary steps to set up appropriate Swift version.
+inputs:
+  codeql-path:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Get Swift version
+      id: get_swift_version
+      # We don't support Swift on Windows or prior versions of CLI.
+      if: "(runner.os != 'Windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
+      shell: bash
+      env: 
+        CODEQL_PATH: ${{inputs.codeql-path}}
+      run: |
+        if [ $RUNNER_OS = "macOS" ]; then
+          PLATFORM="osx64"
+        else # We do not run this step on Windows.
+          PLATFORM="linux64"
+        fi 
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+        # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
+        if [ $VERSION = "5.7" ]; then
+          VERSION="5.7.0"
+        fi
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+      if: "(runner.os != 'Windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
+      with:
+        swift-version: "${{steps.get_swift_version.outputs.version}}"

--- a/.github/setup-swift/action.yml
+++ b/.github/setup-swift/action.yml
@@ -30,3 +30,7 @@ runs:
       if: "(runner.os != 'Windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
       with:
         swift-version: "${{steps.get_swift_version.outputs.version}}"
+     # We run prepare-test again to return to the appropriate directory before building.
+    - uses: ./.github/prepare-test
+      with:
+        version: ${{ matrix.version }}

--- a/.github/setup-swift/action.yml
+++ b/.github/setup-swift/action.yml
@@ -19,8 +19,8 @@ runs:
         else # We do not run this step on Windows.
           PLATFORM="linux64"
         fi 
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+        SWIFT_EXTRACTOR_DIR="$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')"
+        VERSION="$("$SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor" --version | awk '/version/ { print $3 }')"
         # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
         if [ $VERSION = "5.7" ]; then
           VERSION="5.7.0"

--- a/.github/setup-swift/action.yml
+++ b/.github/setup-swift/action.yml
@@ -1,4 +1,4 @@
-name: "Setup Swift"
+name: "Set up Swift"
 description: Performs necessary steps to set up appropriate Swift version.
 inputs:
   codeql-path:
@@ -26,8 +26,6 @@ runs:
           VERSION="5.7.0"
         fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-        # We return to the appropriate directory for the rest of the workflow.
-        cd ../action
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       if: "(runner.os != 'Windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
       with:

--- a/.github/setup-swift/action.yml
+++ b/.github/setup-swift/action.yml
@@ -26,11 +26,9 @@ runs:
           VERSION="5.7.0"
         fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+        # We return to the appropriate directory for the rest of the workflow.
+        cd ../action
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       if: "(runner.os != 'Windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
       with:
         swift-version: "${{steps.get_swift_version.outputs.version}}"
-     # We run prepare-test again to return to the appropriate directory before building.
-    - uses: ./.github/prepare-test
-      with:
-        version: ${{ matrix.version }}

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -43,10 +43,10 @@ jobs:
       with:
         version: ${{ matrix.version }}
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Windows doesn't support Swift, and only macOS latest and nightly-latest support Swift 5.7.1.
-      if: runner.os == 'Linux' || (runner.os == 'macOS' && matrix.version == 'cached')
+    # Windows doesn't support Swift
+      if: runner.os != 'Windows
       with:
-        swift-version: 5.7.0
+        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: javascript

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -49,7 +49,7 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
-    - uses: ../action/.github/setup-swift
+    - uses: ./../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Build code

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -42,11 +42,17 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Windows doesn't support Swift
-      if: runner.os != 'Windows
+    # We don't support Swift on Windows
+      if: runner.os != 'Windows'
       with:
-        swift-version: 5.7.1
+        swift-version: ${{steps.get_swift_version.outputs.version}}
     - uses: ./../action/init
       with:
         languages: javascript

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -57,9 +57,8 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-        echo "$SWIFT_EXTRACTOR_DIR"
-        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       if: runner.os != 'Windows'

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -57,7 +57,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -49,7 +49,7 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
-    - uses: ./.github/setup-swift
+    - uses: ../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Build code

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -42,11 +42,6 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # We don't support Swift on Windows
-      if: runner.os != 'Windows'
-      with:
-        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: javascript
@@ -54,6 +49,17 @@ jobs:
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
         CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    # We don't support Swift on Windows
+      if: runner.os != 'Windows'
+      with:
+        swift-version: ${{steps.get_swift_version.outputs.version}}
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -42,7 +42,6 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: actions/checkout@v3
     - uses: ./../action/init
       id: init
       with:
@@ -50,6 +49,8 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
+  # We check out the repo again in order to access the setup-swift composite action.
+    - uses: actions/checkout@v3
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -58,7 +58,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -54,6 +54,9 @@ jobs:
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
+    - name: Check working directory
+      shell: bash
+      run: pwd
     - name: Build code
       shell: bash
       run: ./build.sh
@@ -62,7 +65,6 @@ jobs:
         output: ${{ runner.temp }}/results
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
-        CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
     - name: Upload SARIF
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -49,14 +49,9 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
-  # We check out the repo again in order to access the setup-swift composite action.
-    - uses: actions/checkout@v3
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
-    - name: Check working directory
-      shell: bash
-      run: pwd
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -64,6 +64,9 @@ jobs:
         fi 
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+        if [ $VERSION = "5.7" ]; then
+          VERSION="5.7.0"
+        fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       if: runner.os != 'Windows'

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -42,17 +42,11 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - name: Get Swift version
-      id: get_swift_version
-      shell: bash
-      run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     # We don't support Swift on Windows
       if: runner.os != 'Windows'
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: javascript

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -57,8 +57,13 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
+        if [ $RUNNER_OS = "macOS" ]; then
+          PLATFORM="osx64"
+        else # We do not run this step on Windows.
+          PLATFORM="linux64"
+        fi 
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       if: runner.os != 'Windows'

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -57,8 +57,9 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+        echo "$SWIFT_EXTRACTOR_DIR"
+        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       if: runner.os != 'Windows'

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -43,6 +43,7 @@ jobs:
       with:
         version: ${{ matrix.version }}
     - uses: ./../action/init
+      id: init
       with:
         languages: javascript
         tools: ${{ steps.prepare-test.outputs.tools-url }}
@@ -51,12 +52,16 @@ jobs:
         CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
     - name: Get Swift version
       id: get_swift_version
+    # We don't support Swift on Windows
+      if: runner.os != 'Windows'
       shell: bash
+      env:
+        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # We don't support Swift on Windows
       if: runner.os != 'Windows'
       with:
         swift-version: ${{steps.get_swift_version.outputs.version}}

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -42,6 +42,7 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - uses: actions/checkout@v3
     - uses: ./../action/init
       id: init
       with:
@@ -49,29 +50,9 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
-    - name: Get Swift version
-      id: get_swift_version
-    # We don't support Swift on Windows
-      if: runner.os != 'Windows'
-      shell: bash
-      env:
-        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-      run: |
-        if [ $RUNNER_OS = "macOS" ]; then
-          PLATFORM="osx64"
-        else # We do not run this step on Windows.
-          PLATFORM="linux64"
-        fi 
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
-        if [ $VERSION = "5.7" ]; then
-          VERSION="5.7.0"
-        fi
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-      if: runner.os != 'Windows'
+    - uses: ./.github/setup-swift
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -49,7 +49,6 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
       env:
         CODEQL_FILE_BASELINE_INFORMATION: true
-        CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
     - name: Get Swift version
       id: get_swift_version
     # We don't support Swift on Windows
@@ -98,4 +97,5 @@ jobs:
           fi
         done
     env:
+      CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true # Remove when Swift is GA.
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -79,8 +79,13 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
+        if [ $RUNNER_OS = "macOS" ]; then
+          PLATFORM="osx64"
+        else # We do not run this test on Windows.
+          PLATFORM="linux64"
+        fi 
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
             
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,13 +65,14 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.13.1
-    - uses: actions/checkout@v3
-
     - uses: ./../action/init
       id: init
       with:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+
+  # We check out the repo again in order to access the setup-swift composite action.
+    - uses: actions/checkout@v3
 
     - uses: ./.github/setup-swift
       with:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -71,7 +71,7 @@ jobs:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
 
-    - uses: ./.github/setup-swift
+    - uses: ../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
 

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -71,7 +71,7 @@ jobs:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
 
-    - uses: ../action/.github/setup-swift
+    - uses: ./../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
 

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -78,6 +78,10 @@ jobs:
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
 
+    - name: Check working directory
+      shell: bash
+      run: pwd
+
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,14 +65,21 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.13.1
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-      with:
-        swift-version: 5.7.1
-
     - uses: ./../action/init
       with:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+
+    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+      with:
+        swift-version: ${{steps.get_swift_version.outputs.version}}
 
     - name: Build code
       shell: bash

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,37 +65,17 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.13.1
+    - uses: actions/checkout@v3
+
     - uses: ./../action/init
       id: init
       with:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
 
-    - name: Get Swift version
-      id: get_swift_version
-      if: (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version
-        == 'nightly-latest')
-      shell: bash
-      env:
-        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-      run: |
-        if [ $RUNNER_OS = "macOS" ]; then
-          PLATFORM="osx64"
-        else # We do not run this test on Windows.
-          PLATFORM="linux64"
-        fi 
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
-        if [ $VERSION = "5.7" ]; then
-          VERSION="5.7.0"
-        fi
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-            
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-      if: (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version
-        == 'nightly-latest')
+    - uses: ./.github/setup-swift
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        codeql-path: ${{steps.init.outputs.codeql-path}}
 
     - name: Build code
       shell: bash

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -45,6 +45,10 @@ jobs:
           version: latest
         - os: macos-latest
           version: latest
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
     name: Multi-language repository
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -62,10 +66,8 @@ jobs:
       with:
         go-version: ^1.13.1
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Only macOS latest and nightly-latest support Swift 5.7.1
-      if: runner.os == 'Linux' || matrix.version == 'cached'
       with:
-        swift-version: 5.7.0
+        swift-version: 5.7.1
 
     - uses: ./../action/init
       with:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -66,6 +66,7 @@ jobs:
       with:
         go-version: ^1.13.1
     - uses: ./../action/init
+      id: init
       with:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
@@ -73,8 +74,11 @@ jobs:
     - name: Get Swift version
       id: get_swift_version
       shell: bash
+      env:
+        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
 
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -79,9 +79,8 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-        echo "$SWIFT_EXTRACTOR_DIR"
-        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
             
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -77,7 +77,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
 

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -138,8 +138,8 @@ jobs:
         fi
 
     - name: Check language autodetect for Swift
-      if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'latest' || matrix.version\
-        \ == 'nightly-latest')"
+      if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version\
+        \ == 'latest' || matrix.version == 'nightly-latest')"
       shell: bash
       run: |
         SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -71,16 +71,9 @@ jobs:
         db-location: ${{ runner.temp }}/customDbLocation
         tools: ${{ steps.prepare-test.outputs.tools-url }}
 
-  # We check out the repo again in order to access the setup-swift composite action.
-    - uses: actions/checkout@v3
-
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
-
-    - name: Check working directory
-      shell: bash
-      run: pwd
 
     - name: Build code
       shell: bash

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -86,6 +86,9 @@ jobs:
         fi 
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+        if [ $VERSION = "5.7" ]; then
+          VERSION="5.7.0"
+        fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
             
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -77,7 +77,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
 

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -77,10 +77,11 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+        echo "$SWIFT_EXTRACTOR_DIR"
+        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-
+            
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:
         swift-version: ${{steps.get_swift_version.outputs.version}}

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -73,6 +73,8 @@ jobs:
 
     - name: Get Swift version
       id: get_swift_version
+      if: (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version
+        == 'nightly-latest')
       shell: bash
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
@@ -83,6 +85,8 @@ jobs:
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
             
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+      if: (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version
+        == 'nightly-latest')
       with:
         swift-version: ${{steps.get_swift_version.outputs.version}}
 
@@ -139,8 +143,8 @@ jobs:
         fi
 
     - name: Check language autodetect for Swift
-      if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version\
-        \ == 'latest' || matrix.version == 'nightly-latest')"
+      if: (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version
+        == 'nightly-latest')
       shell: bash
       run: |
         SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,9 +65,16 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.13.1
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:
-        swift-version: 5.7.1
+        swift-version: ${{steps.get_swift_version.outputs.version}}
 
     - uses: ./../action/init
       with:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,16 +65,9 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ^1.13.1
-    - name: Get Swift version
-      id: get_swift_version
-      shell: bash
-      run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        swift-version: 5.7.1
 
     - uses: ./../action/init
       with:
@@ -134,8 +127,8 @@ jobs:
         fi
 
     - name: Check language autodetect for Swift
-      if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version\
-        \ == 'latest' || matrix.version == 'nightly-latest')"
+      if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'latest' || matrix.version\
+        \ == 'nightly-latest')"
       shell: bash
       run: |
         SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -52,6 +52,9 @@ jobs:
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
+    - name: Check working directory
+      shell: bash
+      run: pwd
     - uses: ./../action/autobuild
     - uses: ./../action/analyze
       id: analysis

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -54,7 +54,7 @@ jobs:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/osx64/extractor --version | awk '/version/ { print $3 }') # Update platform if more operating systems are added to this test.
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -28,8 +28,6 @@ jobs:
         - os: macos-latest
           version: latest
         - os: macos-latest
-          version: cached
-        - os: macos-latest
           version: nightly-latest
     name: Swift analysis using autobuild
     timeout-minutes: 45
@@ -42,15 +40,9 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - name: Get Swift version
-      id: get_swift_version
-      shell: bash
-      run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -42,12 +42,13 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: actions/checkout@v3
     - uses: ./../action/init
       id: init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+  # We check out the repo again in order to access the setup-swift composite action.
+    - uses: actions/checkout@v3
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -47,8 +47,6 @@ jobs:
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-  # We check out the repo again in order to access the setup-swift composite action.
-    - uses: actions/checkout@v3
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -71,5 +71,5 @@ jobs:
           exit 1
         fi
     env:
-      CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: 'true'
+      CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: 'true' # Remove when Swift is GA.
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -42,26 +42,15 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - uses: actions/checkout@v3
     - uses: ./../action/init
       id: init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-    - name: Get Swift version
-      id: get_swift_version
-      shell: bash
-      env:
-        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-      run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/osx64/extractor --version | awk '/version/ { print $3 }') # Update platform if more operating systems are added to this test.
-        if [ $VERSION = "5.7" ]; then
-          VERSION="5.7.0"
-        fi
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    - uses: ./.github/setup-swift
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        codeql-path: ${{steps.init.outputs.codeql-path}}
     - uses: ./../action/autobuild
     - uses: ./../action/analyze
       id: analysis

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -41,14 +41,18 @@ jobs:
       with:
         version: ${{ matrix.version }}
     - uses: ./../action/init
+      id: init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
     - name: Get Swift version
       id: get_swift_version
       shell: bash
+      env:
+        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -55,6 +55,9 @@ jobs:
       run: |
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         VERSION=$($SWIFT_EXTRACTOR_DIR/tools/osx64/extractor --version | awk '/version/ { print $3 }') # Update platform if more operating systems are added to this test.
+        if [ $VERSION = "5.7" ]; then
+          VERSION="5.7.0"
+        fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -53,8 +53,9 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+        echo "$SWIFT_EXTRACTOR_DIR"
+        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-    - uses: ../action/.github/setup-swift
+    - uses: ./../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Check working directory

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-    - uses: ./.github/setup-swift
+    - uses: ../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Check working directory

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -42,9 +42,15 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:
-        swift-version: 5.7.1
+        swift-version: ${{steps.get_swift_version.outputs.version}}
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -40,13 +40,19 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-      with:
-        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+      with:
+        swift-version: ${{steps.get_swift_version.outputs.version}}
     - uses: ./../action/autobuild
     - uses: ./../action/analyze
       id: analysis

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -53,9 +53,8 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-        echo "$SWIFT_EXTRACTOR_DIR"
-        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -43,10 +43,8 @@ jobs:
       with:
         version: ${{ matrix.version }}
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Only macOS latest and nightly-latest support Swift 5.7.1
-      if: runner.os == 'Linux' || matrix.version == 'cached'
       with:
-        swift-version: 5.7.0
+        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -28,6 +28,8 @@ jobs:
         - os: macos-latest
           version: latest
         - os: macos-latest
+          version: cached
+        - os: macos-latest
           version: nightly-latest
     name: Swift analysis using autobuild
     timeout-minutes: 45

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,9 +59,8 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-        echo "$SWIFT_EXTRACTOR_DIR"
-        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -44,13 +44,19 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-      with:
-        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+      with:
+        swift-version: ${{steps.get_swift_version.outputs.version}}
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -48,12 +48,13 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - uses: actions/checkout@v3
     - uses: ./../action/init
       id: init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+  # We check out the repo again in order to access the setup-swift composite action.
+    - uses: actions/checkout@v3
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -45,14 +45,18 @@ jobs:
       with:
         version: ${{ matrix.version }}
     - uses: ./../action/init
+      id: init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
     - name: Get Swift version
       id: get_swift_version
       shell: bash
+      env:
+        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,7 +59,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+        SWIFT_EXTRACTOR_DIR=`"$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'`
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -33,6 +33,10 @@ jobs:
           version: cached
         - os: macos-latest
           version: cached
+        - os: ubuntu-latest
+          version: nightly-latest
+        - os: macos-latest
+          version: nightly-latest
     name: Swift analysis using a custom build command
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -45,10 +49,8 @@ jobs:
       with:
         version: ${{ matrix.version }}
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Only macOS latest and nightly-latest support Swift 5.7.1
-      if: runner.os == 'Linux' || matrix.version == 'cached'
       with:
-        swift-version: 5.7.0
+        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,7 +59,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -30,10 +30,6 @@ jobs:
         - os: macos-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
-        - os: macos-latest
-          version: cached
-        - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest
@@ -48,15 +44,9 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
-    - name: Get Swift version
-      id: get_swift_version
-      shell: bash
-      run: |
-        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        swift-version: 5.7.1
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,8 +59,13 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
+        if [ $RUNNER_OS = "macOS" ]; then
+          PLATFORM="osx64"
+        else # We do not run this test on Windows.
+          PLATFORM="linux64"
+        fi 
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,7 +59,7 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=`"$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'`
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
@@ -79,6 +79,6 @@ jobs:
           exit 1
         fi
     env:
-      CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: 'true'
+      CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: 'true' # Remove when Swift is GA.
       DOTNET_GENERATE_ASPNET_CERTIFICATE: 'false'
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -53,8 +53,6 @@ jobs:
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-  # We check out the repo again in order to access the setup-swift composite action.
-    - uses: actions/checkout@v3
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-    - uses: ../action/.github/setup-swift
+    - uses: ./../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Check working directory

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-    - uses: ./.github/setup-swift
+    - uses: ../action/.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Check working directory

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,8 +59,9 @@ jobs:
       env:
         CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
       run: |
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-        $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+        echo "$SWIFT_EXTRACTOR_DIR"
+        VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -30,6 +30,10 @@ jobs:
         - os: macos-latest
           version: latest
         - os: ubuntu-latest
+          version: cached
+        - os: macos-latest
+          version: cached
+        - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest
           version: nightly-latest

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -58,6 +58,9 @@ jobs:
     - uses: ./.github/setup-swift
       with:
         codeql-path: ${{steps.init.outputs.codeql-path}}
+    - name: Check working directory
+      shell: bash
+      run: pwd
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -48,9 +48,15 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - name: Get Swift version
+      id: get_swift_version
+      shell: bash
+      run: |
+        codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:
-        swift-version: 5.7.1
+        swift-version: ${{steps.get_swift_version.outputs.version}}
     - uses: ./../action/init
       with:
         languages: swift

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -48,32 +48,15 @@ jobs:
       uses: ./.github/prepare-test
       with:
         version: ${{ matrix.version }}
+    - uses: actions/checkout@v3
     - uses: ./../action/init
       id: init
       with:
         languages: swift
         tools: ${{ steps.prepare-test.outputs.tools-url }}
-    - name: Get Swift version
-      id: get_swift_version
-      shell: bash
-      env:
-        CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-      run: |
-        if [ $RUNNER_OS = "macOS" ]; then
-          PLATFORM="osx64"
-        else # We do not run this test on Windows.
-          PLATFORM="linux64"
-        fi 
-        SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-        VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
-        # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
-        if [ $VERSION = "5.7" ]; then
-          VERSION="5.7.0"
-        fi
-        echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    - uses: ./.github/setup-swift
       with:
-        swift-version: ${{steps.get_swift_version.outputs.version}}
+        codeql-path: ${{steps.init.outputs.codeql-path}}
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -66,6 +66,10 @@ jobs:
         fi 
         SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
         VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+        # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
+        if [ $VERSION = "5.7" ]; then
+          VERSION="5.7.0"
+        fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
       with:

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -18,7 +18,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -19,8 +19,13 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
+      if [ $RUNNER_OS = "macOS" ]; then
+        PLATFORM="osx64"
+      else # We do not run this step on Windows.
+        PLATFORM="linux64"
+      fi 
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     if: runner.os != 'Windows'

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -1,6 +1,8 @@
 name: "Export file baseline information"
 description: "Tests that file baseline information is exported when the feature is enabled"
 versions: ["nightly-latest"]
+env: 
+  CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true # Remove when Swift is GA.
 steps:
   - uses: ./../action/init
     id: init
@@ -9,7 +11,6 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
-      CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
   - name: Get Swift version
     id: get_swift_version
     # We don't support Swift on Windows

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -2,17 +2,11 @@ name: "Export file baseline information"
 description: "Tests that file baseline information is exported when the feature is enabled"
 versions: ["nightly-latest"]
 steps:
-  - name: Get Swift version
-    id: get_swift_version
-    shell: bash
-    run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     # We don't support Swift on Windows
     if: runner.os != 'Windows'
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"
+      swift-version: "5.7.1"
   - uses: ./../action/init
     with:
       languages: javascript

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -11,14 +11,9 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
-  # We check out the repo again in order to access the setup-swift composite action.
-  - uses: actions/checkout@v3
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
-  - name: Check working directory
-    shell: bash
-    run: pwd
   - name: Build code
     shell: bash
     run: ./build.sh

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -19,7 +19,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -2,11 +2,17 @@ name: "Export file baseline information"
 description: "Tests that file baseline information is exported when the feature is enabled"
 versions: ["nightly-latest"]
 steps:
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Windows doesn't support Swift
-    if: runner.os != 'Windows
+    # We don't support Swift on Windows
+    if: runner.os != 'Windows'
     with:
-      swift-version: "5.7.1"
+      swift-version: "${{steps.get_swift_version.outputs.version}}"
   - uses: ./../action/init
     with:
       languages: javascript

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -26,6 +26,9 @@ steps:
       fi 
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+      if [ $VERSION = "5.7" ]; then
+        VERSION="5.7.0"
+      fi
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     if: runner.os != 'Windows'

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -11,7 +11,7 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
-  - uses: ./.github/setup-swift
+  - uses: ../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Build code

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -3,10 +3,10 @@ description: "Tests that file baseline information is exported when the feature 
 versions: ["nightly-latest"]
 steps:
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Windows doesn't support Swift, and only macOS latest and nightly-latest support Swift 5.7.1.
-    if: runner.os == 'Linux' || (runner.os == 'macOS' && matrix.version == 'cached')
+    # Windows doesn't support Swift
+    if: runner.os != 'Windows
     with:
-      swift-version: "5.7.0"
+      swift-version: "5.7.1"
   - uses: ./../action/init
     with:
       languages: javascript

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -19,8 +19,9 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+      echo "$SWIFT_EXTRACTOR_DIR"
+      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     if: runner.os != 'Windows'

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -19,9 +19,8 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-      echo "$SWIFT_EXTRACTOR_DIR"
-      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     if: runner.os != 'Windows'

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -16,6 +16,9 @@ steps:
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
+  - name: Check working directory
+    shell: bash
+    run: pwd
   - name: Build code
     shell: bash
     run: ./build.sh
@@ -24,7 +27,6 @@ steps:
       output: "${{ runner.temp }}/results"
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
-      CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
   - name: Upload SARIF
     uses: actions/upload-artifact@v3
     with:

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -2,11 +2,6 @@ name: "Export file baseline information"
 description: "Tests that file baseline information is exported when the feature is enabled"
 versions: ["nightly-latest"]
 steps:
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # We don't support Swift on Windows
-    if: runner.os != 'Windows'
-    with:
-      swift-version: "5.7.1"
   - uses: ./../action/init
     with:
       languages: javascript
@@ -14,6 +9,17 @@ steps:
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
       CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    # We don't support Swift on Windows
+    if: runner.os != 'Windows'
+    with:
+      swift-version: "${{steps.get_swift_version.outputs.version}}"
   - name: Build code
     shell: bash
     run: ./build.sh

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -3,6 +3,7 @@ description: "Tests that file baseline information is exported when the feature 
 versions: ["nightly-latest"]
 steps:
   - uses: ./../action/init
+    id: init
     with:
       languages: javascript
       tools: ${{ steps.prepare-test.outputs.tools-url }}
@@ -11,12 +12,16 @@ steps:
       CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
   - name: Get Swift version
     id: get_swift_version
+    # We don't support Swift on Windows
+    if: runner.os != 'Windows'
     shell: bash
+    env: 
+      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # We don't support Swift on Windows
     if: runner.os != 'Windows'
     with:
       swift-version: "${{steps.get_swift_version.outputs.version}}"

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -11,7 +11,7 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
-  - uses: ../action/.github/setup-swift
+  - uses: ./../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Build code

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -4,7 +4,6 @@ versions: ["nightly-latest"]
 env: 
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true # Remove when Swift is GA.
 steps:
-  - uses: actions/checkout@v3
   - uses: ./../action/init
     id: init
     with:
@@ -12,6 +11,8 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
+  # We check out the repo again in order to access the setup-swift composite action.
+  - uses: actions/checkout@v3
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -4,6 +4,7 @@ versions: ["nightly-latest"]
 env: 
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true # Remove when Swift is GA.
 steps:
+  - uses: actions/checkout@v3
   - uses: ./../action/init
     id: init
     with:
@@ -11,29 +12,9 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_FILE_BASELINE_INFORMATION: true
-  - name: Get Swift version
-    id: get_swift_version
-    # We don't support Swift on Windows
-    if: runner.os != 'Windows'
-    shell: bash
-    env: 
-      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-    run: |
-      if [ $RUNNER_OS = "macOS" ]; then
-        PLATFORM="osx64"
-      else # We do not run this step on Windows.
-        PLATFORM="linux64"
-      fi 
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
-      if [ $VERSION = "5.7" ]; then
-        VERSION="5.7.0"
-      fi
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    if: runner.os != 'Windows'
+  - uses: ./.github/setup-swift
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"
+      codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Build code
     shell: bash
     run: ./build.sh

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,9 +4,16 @@ operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:
-      swift-version: "5.7.1"
+      swift-version: "${{steps.get_swift_version.outputs.version}}"
 
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -10,16 +10,9 @@ steps:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   
-  # We check out the repo again in order to access the setup-swift composite action.
-  - uses: actions/checkout@v3
-
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
-
-  - name: Check working directory
-    shell: bash
-    run: pwd
 
   - name: Build code
     shell: bash

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,35 +4,17 @@ operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
+  - uses: actions/checkout@v3
+
   - uses: ./../action/init
     id: init
     with:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
 
-  - name: Get Swift version
-    id: get_swift_version
-    if: "(matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
-    shell: bash
-    env: 
-      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-    run: |
-      if [ $RUNNER_OS = "macOS" ]; then
-        PLATFORM="osx64"
-      else # We do not run this test on Windows.
-        PLATFORM="linux64"
-      fi 
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
-      if [ $VERSION = "5.7" ]; then
-        VERSION="5.7.0"
-      fi
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-          
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    if: "(matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
+  - uses: ./.github/setup-swift
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"
+      codeql-path: ${{steps.init.outputs.codeql-path}}
 
   - name: Build code
     shell: bash

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -16,7 +16,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -12,6 +12,7 @@ steps:
 
   - name: Get Swift version
     id: get_swift_version
+    if: "(matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
     shell: bash
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
@@ -22,6 +23,7 @@ steps:
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
           
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    if: "(matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
     with:
       swift-version: "${{steps.get_swift_version.outputs.version}}"
 
@@ -77,7 +79,7 @@ steps:
       fi
 
   - name: Check language autodetect for Swift
-    if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
+    if: "(matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
     shell: bash
     run: |
       SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -1,16 +1,12 @@
 name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
-# Temporarily exclude nightly-latest to unblock release
-versions: ["stable-20211005", "stable-20220120", "stable-20220401", "cached", "latest"]
 operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Only macOS latest and nightly-latest support Swift 5.7.1
-    if: runner.os == 'Linux' || matrix.version == 'cached'
     with:
-      swift-version: "5.7.0"
+      swift-version: "5.7.1"
 
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -5,6 +5,7 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
   - uses: ./../action/init
+    id: init
     with:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
@@ -12,8 +13,11 @@ steps:
   - name: Get Swift version
     id: get_swift_version
     shell: bash
+    env: 
+      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -76,7 +76,7 @@ steps:
       fi
 
   - name: Check language autodetect for Swift
-    if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'latest' || matrix.version == 'nightly-latest')"
+    if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
     shell: bash
     run: |
       SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -17,8 +17,13 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
+      if [ $RUNNER_OS = "macOS" ]; then
+        PLATFORM="osx64"
+      else # We do not run this test on Windows.
+        PLATFORM="linux64"
+      fi 
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
           
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -16,10 +16,11 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+      echo "$SWIFT_EXTRACTOR_DIR"
+      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-    
+          
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:
       swift-version: "${{steps.get_swift_version.outputs.version}}"

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -10,7 +10,7 @@ steps:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   
-  - uses: ./.github/setup-swift
+  - uses: ../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
 

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -17,6 +17,10 @@ steps:
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
 
+  - name: Check working directory
+    shell: bash
+    run: pwd
+
   - name: Build code
     shell: bash
     run: ./build.sh

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -17,9 +17,8 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-      echo "$SWIFT_EXTRACTOR_DIR"
-      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
           
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,14 +4,21 @@ operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    with:
-      swift-version: "5.7.1"
-
   - uses: ./../action/init
     with:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+    
+  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    with:
+      swift-version: "${{steps.get_swift_version.outputs.version}}"
 
   - name: Build code
     shell: bash

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -16,7 +16,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,13 +4,14 @@ operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
-  - uses: actions/checkout@v3
-
   - uses: ./../action/init
     id: init
     with:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+  
+  # We check out the repo again in order to access the setup-swift composite action.
+  - uses: actions/checkout@v3
 
   - uses: ./.github/setup-swift
     with:

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,16 +4,9 @@ operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
-  - name: Get Swift version
-    id: get_swift_version
-    shell: bash
-    run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"
+      swift-version: "5.7.1"
 
   - uses: ./../action/init
     with:
@@ -72,7 +65,7 @@ steps:
       fi
 
   - name: Check language autodetect for Swift
-    if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
+    if: "!startsWith(matrix.os, 'windows') && (matrix.version == 'latest' || matrix.version == 'nightly-latest')"
     shell: bash
     run: |
       SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -10,7 +10,7 @@ steps:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   
-  - uses: ../action/.github/setup-swift
+  - uses: ./../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
 

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -24,6 +24,9 @@ steps:
       fi 
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+      if [ $VERSION = "5.7" ]; then
+        VERSION="5.7.0"
+      fi
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
           
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -1,6 +1,6 @@
 name: "Swift analysis using autobuild"
 description: "Tests creation of a Swift database using autobuild"
-versions: ["latest", "nightly-latest"]
+versions: ["latest", "cached", "nightly-latest"]
 # Swift autobuilder is only supported on MacOS for private beta
 operatingSystems: ["macos"]
 env:

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -17,8 +17,9 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+      echo "$SWIFT_EXTRACTOR_DIR"
+      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -1,20 +1,14 @@
 name: "Swift analysis using autobuild"
 description: "Tests creation of a Swift database using autobuild"
-versions: ["latest", "cached", "nightly-latest"]
+versions: ["latest", "nightly-latest"]
 # Swift autobuilder is only supported on MacOS for private beta
 operatingSystems: ["macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
 steps:
-  - name: Get Swift version
-    id: get_swift_version
-    shell: bash
-    run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"
+      swift-version: "5.7.1"
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -17,7 +17,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -11,7 +11,7 @@ steps:
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - uses: ./.github/setup-swift
+  - uses: ../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Check working directory

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -11,8 +11,6 @@ steps:
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  # We check out the repo again in order to access the setup-swift composite action.
-  - uses: actions/checkout@v3
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -17,7 +17,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -11,7 +11,7 @@ steps:
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - uses: ../action/.github/setup-swift
+  - uses: ./../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Check working directory

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -6,26 +6,15 @@ operatingSystems: ["macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
+  - uses: actions/checkout@v3
   - uses: ./../action/init
     id: init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - name: Get Swift version
-    id: get_swift_version
-    shell: bash
-    env: 
-      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-    run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/osx64/extractor --version | awk '/version/ { print $3 }') # Update platform if more operating systems are added to this test.
-      if [ $VERSION = "5.7" ]; then
-        VERSION="5.7.0"
-      fi
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+  - uses: ./.github/setup-swift
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"
+      codeql-path: ${{steps.init.outputs.codeql-path}}
   - uses: ./../action/autobuild
   - uses: ./../action/analyze
     id: analysis

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -6,13 +6,19 @@ operatingSystems: ["macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
 steps:
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    with:
-      swift-version: "5.7.1"
   - uses: ./../action/init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    with:
+      swift-version: "${{steps.get_swift_version.outputs.version}}"
   - uses: ./../action/autobuild
   - uses: ./../action/analyze
     id: analysis

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -17,9 +17,8 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-      echo "$SWIFT_EXTRACTOR_DIR"
-      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -19,6 +19,9 @@ steps:
     run: |
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       VERSION=$($SWIFT_EXTRACTOR_DIR/tools/osx64/extractor --version | awk '/version/ { print $3 }') # Update platform if more operating systems are added to this test.
+      if [ $VERSION = "5.7" ]; then
+        VERSION="5.7.0"
+      fi
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -6,9 +6,15 @@ operatingSystems: ["macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
 steps:
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:
-      swift-version: "5.7.1"
+      swift-version: "${{steps.get_swift_version.outputs.version}}"
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -7,10 +7,8 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
 steps:
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Only macOS latest and nightly-latest support Swift 5.7.1
-    if: runner.os == 'Linux' || matrix.version == 'cached'
     with:
-      swift-version: "5.7.0"
+      swift-version: "5.7.1"
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -16,6 +16,9 @@ steps:
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
+  - name: Check working directory
+    shell: bash
+    run: pwd
   - uses: ./../action/autobuild
   - uses: ./../action/analyze
     id: analysis

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -6,12 +6,13 @@ operatingSystems: ["macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
-  - uses: actions/checkout@v3
   - uses: ./../action/init
     id: init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+  # We check out the repo again in order to access the setup-swift composite action.
+  - uses: actions/checkout@v3
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -18,7 +18,7 @@ steps:
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/osx64/extractor --version | awk '/version/ { print $3 }') # Update platform if more operating systems are added to this test.
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -4,7 +4,7 @@ versions: ["latest", "cached", "nightly-latest"]
 # Swift autobuilder is only supported on MacOS for private beta
 operatingSystems: ["macos"]
 env:
-  CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
+  CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
 steps:
   - uses: ./../action/init
     id: init

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -7,14 +7,18 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
 steps:
   - uses: ./../action/init
+    id: init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - name: Get Swift version
     id: get_swift_version
     shell: bash
+    env: 
+      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -17,8 +17,9 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
-      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
+      echo "$SWIFT_EXTRACTOR_DIR"
+      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -1,6 +1,6 @@
 name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
-versions: ["latest", "nightly-latest"]
+versions: ["latest", "cached", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -6,12 +6,13 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
-  - uses: actions/checkout@v3
   - uses: ./../action/init
     id: init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+  # We check out the repo again in order to access the setup-swift composite action.
+  - uses: actions/checkout@v3
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -3,7 +3,7 @@ description: "Tests creation of a Swift database using custom build"
 versions: ["latest", "cached", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
 env:
-  CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
+  CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
   - uses: ./../action/init
@@ -17,7 +17,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=`"$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'`
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -17,7 +17,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      SWIFT_EXTRACTOR_DIR=`"$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'`
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -11,7 +11,7 @@ steps:
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - uses: ./.github/setup-swift
+  - uses: ../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Check working directory

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -11,8 +11,6 @@ steps:
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  # We check out the repo again in order to access the setup-swift composite action.
-  - uses: actions/checkout@v3
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -17,7 +17,7 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json)
       $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -11,7 +11,7 @@ steps:
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - uses: ../action/.github/setup-swift
+  - uses: ./../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Check working directory

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -17,8 +17,13 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
+      if [ $RUNNER_OS = "macOS" ]; then
+        PLATFORM="osx64"
+      else # We do not run this test on Windows.
+        PLATFORM="linux64"
+      fi 
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -6,32 +6,15 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true" # Remove when Swift is GA.
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
+  - uses: actions/checkout@v3
   - uses: ./../action/init
     id: init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - name: Get Swift version
-    id: get_swift_version
-    shell: bash
-    env: 
-      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
-    run: |
-      if [ $RUNNER_OS = "macOS" ]; then
-        PLATFORM="osx64"
-      else # We do not run this test on Windows.
-        PLATFORM="linux64"
-      fi 
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
-      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
-      # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
-      if [ $VERSION = "5.7" ]; then
-        VERSION="5.7.0"
-      fi
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+  - uses: ./.github/setup-swift
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"
+      codeql-path: ${{steps.init.outputs.codeql-path}}
   - name: Build code
     shell: bash
     run: ./build.sh

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -17,9 +17,8 @@ steps:
     env: 
       CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq '.swift[0]')
-      echo "$SWIFT_EXTRACTOR_DIR"
-      VERSION=$($SWIFT_EXTRACTOR_DIR --version | awk '/version/ { print $3 }')
+      SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
+      VERSION=$($SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }')
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -7,14 +7,18 @@ env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
   - uses: ./../action/init
+    id: init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - name: Get Swift version
     id: get_swift_version
     shell: bash
+    env: 
+      CODEQL_PATH: ${{steps.init.outputs.codeql-path}}
     run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      SWIFT_EXTRACTOR_DIR="$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]'
+      $SWIFT_EXTRACTOR_DIR/tools/*/extractor --version | awk '/version/ { print $3 }'
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -6,9 +6,15 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:
-      swift-version: "5.7.1"
+      swift-version: "${{steps.get_swift_version.outputs.version}}"  
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -16,6 +16,9 @@ steps:
   - uses: ./.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
+  - name: Check working directory
+    shell: bash
+    run: pwd
   - name: Build code
     shell: bash
     run: ./build.sh

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -1,20 +1,14 @@
 name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
-versions: ["latest", "cached", "nightly-latest"]
+versions: ["latest", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
-  - name: Get Swift version
-    id: get_swift_version
-    shell: bash
-    run: |
-      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
-      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:
-      swift-version: "${{steps.get_swift_version.outputs.version}}"  
+      swift-version: "5.7.1" 
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -1,17 +1,14 @@
 name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
-# Temporarily exclude nightly-latest to unblock release
-versions: ["latest", "cached"]
+versions: ["latest", "cached", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    # Only macOS latest and nightly-latest support Swift 5.7.1
-    if: runner.os == 'Linux' || matrix.version == 'cached'
     with:
-      swift-version: "5.7.0"
+      swift-version: "5.7.1"
   - uses: ./../action/init
     with:
       languages: swift

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -24,6 +24,10 @@ steps:
       fi 
       SWIFT_EXTRACTOR_DIR=$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')
       VERSION=$($SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor --version | awk '/version/ { print $3 }')
+      # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
+      if [ $VERSION = "5.7" ]; then
+        VERSION="5.7.0"
+      fi
       echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
   - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -6,13 +6,19 @@ env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: "true"
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
-  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
-    with:
-      swift-version: "5.7.1" 
   - uses: ./../action/init
     with:
       languages: swift
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - name: Get Swift version
+    id: get_swift_version
+    shell: bash
+    run: |
+      codeql/experimental/swift/tools/*/extractor --version | awk '/version/ { print $3 }'
+      echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+  - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    with:
+      swift-version: "${{steps.get_swift_version.outputs.version}}"
   - name: Build code
     shell: bash
     run: ./build.sh


### PR DESCRIPTION
This PR changes the `setup-swift` Action to set up the version of Swift the extractor declares (except on Windows). It also adds the `nightly-latest` PR check back to a couple of PR checks, which were removed in https://github.com/github/codeql-action/pull/1412 to unblock the release.

Note that after this PR merges, we should remember to update the corresponding integration test within the CLI, and include the bumped `setup-swift` SHA (https://github.com/github/codeql-action/pull/1415) as well. 

When the newest version of the CLI (that supports 5.7.1) makes it to `latest` and `cached`, we should be able to remove this logic and unconditionally setup 5.7.1, as future versions of the extractor should maintain backwards compatibility with prior Swift versions. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
