### PR TITLE
Code scanning: Add scheduled trigger to workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.
     types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Weekly on Sunday.
+    - cron: '30 1 * * 0'
 
 env:
   CODEQL_ACTION_TESTING_ENVIRONMENT: codeql-action-pr-checks
@@ -54,7 +57,7 @@ jobs:
         # be the same as `tools: null`. This allows us to make the job for each of the bundles a
         # required status check.
         #
-        # If we're running on push, then we can skip running with `tools: latest` when it would be
+        # If we're running on push or schedule, then we can skip running with `tools: latest` when it would be
         # the same as running with `tools: null`.
         if [[ "$GITHUB_EVENT_NAME" != "pull_request" && "$CODEQL_VERSION_DEFAULT" == "$CODEQL_VERSION_LATEST" ]]; then
           VERSIONS_JSON='[null]'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,8 +81,10 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: ./init
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: ./init
       id: init
       with:
         languages: javascript
@@ -91,4 +93,5 @@ jobs:
     # confirm steps.init.outputs.codeql-path points to the codeql binary
     - name: Print CodeQL Version
       run: ${{steps.init.outputs.codeql-path}} version --format=json
-    - uses: ./analyze
+    - name: Perform CodeQL Analysis
+      uses: ./analyze


### PR DESCRIPTION
Ensure we are regularly running code scanning using the latest CodeQL and remain up to date with the internal security scorecard, even if we have a period longer than a week with no pushes to the repo.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [N/A] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [N/A] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
