### PR TITLE
Add CLI version field and prior release fields to `defaults` file

### DIFF
--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,4 +1,6 @@
 {
     "bundleVersion": "codeql-bundle-20221211",
-    "cliVersion": "2.11.6"
+    "cliVersion": "2.11.6",
+    "priorBundleVersion": "codeql-bundle-20221202",
+    "priorCliVersion": "2.11.5"
 }

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,3 +1,4 @@
 {
-    "bundleVersion": "codeql-bundle-20221211"
+    "bundleVersion": "codeql-bundle-20221211",
+    "cliVersion": "2.11.6"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,4 +1,6 @@
 {
   "bundleVersion": "codeql-bundle-20221211",
-  "cliVersion": "2.11.6"
+  "cliVersion": "2.11.6",
+  "priorBundleVersion": "codeql-bundle-20221202",
+  "priorCliVersion": "2.11.5"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,3 +1,4 @@
 {
-  "bundleVersion": "codeql-bundle-20221211"
+  "bundleVersion": "codeql-bundle-20221211",
+  "cliVersion": "2.11.6"
 }


### PR DESCRIPTION
In order to have more fine-grained control the CLI version present in the toolcache, we will be downloading the most recent 2 versions of the CLI bundle to the toolcache and selecting a version (based on feature flag rollout of the most recent version) for the Action.  

The runner image script selects the bundle from the `defaults` file to determine which version of CodeQL to download. This change adds the bundle release prior to the most recent release under the field `priorBundleVersion` so that it is able to download both versions. We keep the `bundleVersion` field named the same to maintain backwards compatibility so that this change can be merged independently of the other changes in the Action.

The change also adds the CLI version for both the most recent release, and the prior release, so that the versions downloaded to the toolcache can be named appropriately (currently they are all prefixed with `0.0.0` rather than the actual `x.y.z` version of the CodeQL bundle. 

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
