### PR TITLE
Bump default CodeQL version to 2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - These changes will not affect the majority of code scanning workflows. Continue reading only if your workflow uses [@actions/tool-cache](https://github.com/actions/toolkit/tree/main/packages/tool-cache) or relies on the precise location of CodeQL within the Actions tool cache.
     - The tool cache now contains **two** recent CodeQL versions (previously **one**).
     - Each CodeQL version is located under a directory named after the release date and version number, e.g. CodeQL 2.11.6 is now located under `CodeQL/2.11.6-20221211/x64/codeql` (previously `CodeQL/0.0.0-20221211/x64/codeql`).
+- Update default CodeQL bundle version to 2.12.1. [#1498](https://github.com/github/codeql-action/pull/1498)
 - Fix a bug that forced the `init` Action to run for at least two minutes on JavaScript. [#1494](https://github.com/github/codeql-action/pull/1494)
 
 ## 2.1.39 - 18 Jan 2023

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,6 +1,6 @@
 {
-    "bundleVersion": "codeql-bundle-20230105",
-    "cliVersion": "2.12.0",
-    "priorBundleVersion": "codeql-bundle-20221211",
-    "priorCliVersion": "2.11.6"
+    "bundleVersion": "codeql-bundle-20230120",
+    "cliVersion": "2.12.1",
+    "priorBundleVersion": "codeql-bundle-20230105",
+    "priorCliVersion": "2.12.0"
 }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,6 +1,6 @@
 {
-  "bundleVersion": "codeql-bundle-20230105",
-  "cliVersion": "2.12.0",
-  "priorBundleVersion": "codeql-bundle-20221211",
-  "priorCliVersion": "2.11.6"
+  "bundleVersion": "codeql-bundle-20230120",
+  "cliVersion": "2.12.1",
+  "priorBundleVersion": "codeql-bundle-20230105",
+  "priorCliVersion": "2.12.0"
 }


### PR DESCRIPTION
Update the default CodeQL bundle to `codeql-bundle-20230120`, which packages CodeQL CLI 2.12.1.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
