### PR TITLE
Use CodeQL path from `init` Action in Windows Python dependencies PR checks

### DIFF
--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -1,4 +1,4 @@
-name: Test Python Package Installation on Linux and Mac
+name: Test Python Package Installation
 
 on:
   push:

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -144,6 +144,7 @@ jobs:
         python-version: ${{ matrix.python_version }}
 
     - name: Initialize CodeQL
+      id: init
       uses: ./init
       with:
         tools: latest
@@ -151,15 +152,15 @@ jobs:
         setup-python-dependencies: false
 
     - name: Test Auto Package Installation
+      env:
+        CODEQL_PATH: ${{ steps.init.outputs.codeql-path }}
       run: |
         $cmd = $Env:GITHUB_WORKSPACE + "\\python-setup\\install_tools.ps1"
         powershell -File $cmd
 
         cd $Env:GITHUB_WORKSPACE\\python-setup/tests/$Env:PYTHON_DEPS_TYPE/requests-$Env:PYTHON_VERSION
-        $DefaultsPath = Join-Path (Join-Path $Env:GITHUB_WORKSPACE "src") "defaults.json"
-        $CodeQLBundleName = (Get-Content -Raw -Path $DefaultsPath | ConvertFrom-Json).bundleVersion
-        $CodeQLVersion = "0.0.0-" + $CodeQLBundleName.split("-")[-1]
-        py -3 $Env:GITHUB_WORKSPACE\\python-setup\\auto_install_packages.py C:\\hostedtoolcache\\windows\\CodeQL\\$CodeQLVersion\\x64\\codeql
+        $codeql_dist = (get-item $Env:CODEQL_PATH).Directory.FullName
+        py -3 $Env:GITHUB_WORKSPACE\\python-setup\\auto_install_packages.py $codeql_dist
 
     - name: Setup for extractor
       run: |


### PR DESCRIPTION
This replicates what we do for other OSes, and makes the PR check stable to changes in the layout of the toolcache, such as #1475.  I've also updated the workflow name to reflect the fact some of the tests run on Windows.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
