### PR TITLE
Limit Swift autobuild runtime in PR check to 10 minutes

### DIFF
--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -54,6 +54,7 @@ jobs:
       shell: bash
       run: pwd
     - uses: ./../action/autobuild
+      timeout-minutes: 10
     - uses: ./../action/analyze
       id: analysis
     - name: Check database

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -18,6 +18,7 @@ steps:
     shell: bash
     run: pwd
   - uses: ./../action/autobuild
+    timeout-minutes: 10
   - uses: ./../action/analyze
     id: analysis
   - name: Check database


### PR DESCRIPTION
There's a known issue that causes the Swift autobuilder to hang.  By setting a timeout, we'll fail earlier and we can rerun the check earlier.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
