### PR TITLE
Remove v1 from release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,8 @@ Here are a few things you can do that will increase the likelihood of your pull 
     This mergeback incorporates the changelog updates into `main`, tags the release using the merge commit of the "Merge main into releases/v2" pull request, and bumps the patch version of the CodeQL Action.
 
     Approve the mergeback PR and automerge it.
-1. When the "Merge main into releases/v2" pull request is merged into the `releases/v2` branch, the "Update release branch" workflow will create a "Merge releases/v2 into releases/v1" pull request to merge the changes since the last release into the `releases/v1` release branch.
-    This ensures we keep both the `releases/v1` and `releases/v2` release branches up to date and fully supported.
 
-    Review the checklist items in the pull request description.
-    Once you've checked off all the items, approve the PR and automerge it.
-1. Once the mergeback has been merged to `main` and the "Merge releases/v2 into releases/v1" PR has been merged to `releases/v1`, the release is complete.
+Once the mergeback has been merged to `main`, the release is complete.
 
 ## Keeping the PR checks up to date (admin access required)
 


### PR DESCRIPTION
Now that we are no longer supporting v1, we should remove mention of it in our release documentation.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
