### PR TITLE
Bump `setup-swift` and re-configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/.github/setup-swift/"
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,6 @@ updates:
     schedule:
       interval: weekly
   - package-ecosystem: github-actions
-    directory: "/.github/setup-swift/"
+    directory: "/.github/setup-swift/" # All subdirectories outside of "/.github/workflows" must be explicitly included.
     schedule:
       interval: weekly

--- a/.github/setup-swift/action.yml
+++ b/.github/setup-swift/action.yml
@@ -26,7 +26,7 @@ runs:
           VERSION="5.7.0"
         fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-    - uses: swift-actions/setup-swift@194625b58a582570f61cc707c3b558086c26b723
+    - uses: swift-actions/setup-swift@da0e3e04b5e3e15dbc3861bd835ad9f0afe56296
       if: "(runner.os != 'Windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
       with:
         swift-version: "${{steps.get_swift_version.outputs.version}}"

--- a/.github/setup-swift/action.yml
+++ b/.github/setup-swift/action.yml
@@ -26,7 +26,7 @@ runs:
           VERSION="5.7.0"
         fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
-    - uses: swift-actions/setup-swift@da0e3e04b5e3e15dbc3861bd835ad9f0afe56296
+    - uses: swift-actions/setup-swift@da0e3e04b5e3e15dbc3861bd835ad9f0afe56296 # Please update the corresponding SHA in the CLI's CodeQL Action Integration Test.
       if: "(runner.os != 'Windows') && (matrix.version == 'cached' || matrix.version == 'latest' || matrix.version == 'nightly-latest')"
       with:
         swift-version: "${{steps.get_swift_version.outputs.version}}"


### PR DESCRIPTION
Our Swift extractor is now using Swift v5.7.3, but our `setup-swift` version was pinned to a prior version that doesn't support v5.7.3, so our CI is failing.

This change bumps `setup-swift` to its most recent release commit SHA (https://github.com/swift-actions/setup-swift/releases/tag/v1.22.0).

It also adds a new entry to the `dependabot.yml` file because Dependabot should have bumped this version — `setup-swift` v1.22.0 was released two weeks ago and we run Dependabot checks weekly. Per the dependabot maintainers, the [filepath needed is the root of the repo](https://github.com/dependabot/dependabot-core/issues/5137#issuecomment-1441799333) (`/.github/workflows` is specially cased under `/`). 

We also add a comment reminding the next person who approves a Dependabot update to manually update the SHA in the CLI's CodeQL Action Integration Test. (Note that we should also replicate the logic of finding the appropriate Swift version in the CLI's integration test).

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
