### PR TITLE
Add `security-experimental` to `codeql-config.yml`

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -7,6 +7,7 @@ queries:
   # we include both even though one is a superset of the
   # other, because we're testing the parsing logic and
   # that the suites exist in the codeql bundle.
+  - uses: security-experimental
   - uses: security-extended
   - uses: security-and-quality
 paths-ignore:


### PR DESCRIPTION
We added the support of `security-experimental` in https://github.com/github/codeql-action/pull/1519, but did not add `security-experimental` to the `codeql-config.yml` file then because we were waiting on a CLI v2.12.2 release to make it to the cached tools. Now that this is in, we can add the suite in to ensure it continues to work. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
