### PR TITLE
Avoid uploading databases after integration tests

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -88,6 +88,7 @@ jobs:
       run: ./build.sh
     - uses: ./../action/analyze
       with:
+        upload-database: false
         ref: refs/heads/main
         sha: 5e235361806c361d4d3f8859e3c897658025a9a2
     env:

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -56,6 +56,8 @@ jobs:
         CORECLR_PROFILER: ''
         CORECLR_PROFILER_PATH_64: ''
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     - name: Check database
       shell: bash
       run: |

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -86,6 +86,8 @@ jobs:
       shell: bash
       run: ./build.sh
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     env:
       DOTNET_GENERATE_ASPNET_CERTIFICATE: 'false'
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -71,6 +71,8 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
     - uses: ./../action/autobuild
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     - shell: bash
       run: |
         if [[ "${CODEQL_ACTION_DID_AUTOBUILD_GOLANG}" != true ]]; then

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -73,6 +73,8 @@ jobs:
       shell: bash
       run: go build main.go
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     - shell: bash
       run: |
         # Once we start running Bash 4.2 in all environments, we can replace the

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -70,6 +70,8 @@ jobs:
         languages: go
         tools: ${{ steps.prepare-test.outputs.tools-url }}
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     - shell: bash
       run: |
         cd "$RUNNER_TEMP/codeql_databases"

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -54,6 +54,7 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
     - uses: ./../action/analyze
       with:
+        upload-database: false
         skip-queries: true
         upload: false
     - name: Assert database exists

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -81,6 +81,8 @@ jobs:
 
     - uses: ./../action/analyze
       id: analysis
+      with:
+        upload-database: false
 
     - name: Check language autodetect for all languages excluding Ruby, Swift
       shell: bash

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -66,6 +66,7 @@ jobs:
     - uses: ./../action/analyze
       with:
         output: ${{ runner.temp }}/results
+        upload-database: false
 
     - name: Check results
       uses: ./../action/.github/check-sarif

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -66,6 +66,7 @@ jobs:
     - uses: ./../action/analyze
       with:
         output: ${{ runner.temp }}/results
+        upload-database: false
 
     - name: Check results
       uses: ./../action/.github/check-sarif

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -65,6 +65,7 @@ jobs:
     - uses: ./../action/analyze
       with:
         output: ${{ runner.temp }}/results
+        upload-database: false
 
     - name: Check results
       uses: ./../action/.github/check-sarif

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -54,6 +54,8 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
     - uses: ./../action/analyze
       id: analysis
+      with:
+        upload-database: false
     - name: Check database
       shell: bash
       run: |

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -61,6 +61,7 @@ jobs:
       with:
         skip-queries: true
         output: ${{ runner.temp }}/results
+        upload-database: false
 
     - name: Assert No Results
       shell: bash

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -57,6 +57,8 @@ jobs:
       timeout-minutes: 10
     - uses: ./../action/analyze
       id: analysis
+      with:
+        upload-database: false
     - name: Check database
       shell: bash
       run: |

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -64,6 +64,8 @@ jobs:
       run: ./build.sh
     - uses: ./../action/analyze
       id: analysis
+      with:
+        upload-database: false
     - name: Check database
       shell: bash
       run: |

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -53,6 +53,8 @@ jobs:
       with:
         working-directory: autobuild-dir
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     - name: Check database
       shell: bash
       run: |

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -51,5 +51,7 @@ jobs:
       shell: bash
       run: ./build.sh
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -43,6 +43,8 @@ jobs:
         languages: javascript
         tools: ${{ steps.prepare-test.outputs.tools-url }}
     - uses: ./../action/analyze
+      with:
+        upload-database: false
     env:
       https_proxy: http://squid-proxy:3128
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -65,6 +65,8 @@ jobs:
         ./build.sh
     - uses: ./../action/analyze
       id: analysis
+      with:
+        upload-database: false
     - shell: bash
       run: |
         CPP_DB="${{ fromJson(steps.analysis.outputs.db-locations).cpp }}"

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -88,6 +88,7 @@ jobs:
       run: ./build.sh
     - uses: ./../action/analyze
       with:
+        upload-database: false
         ref: refs/heads/main
         sha: 5e235361806c361d4d3f8859e3c897658025a9a2
         upload: false

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -104,6 +104,7 @@ jobs:
         ref: v1.1.0
         sha: 474bbf07f9247ffe1856c6a0f94aeeb10e7afee6
         upload: false
+        upload-database: false
 
     - uses: ./../action/upload-sarif
       with:

--- a/pr-checks/checks/analyze-ref-input.yml
+++ b/pr-checks/checks/analyze-ref-input.yml
@@ -11,5 +11,6 @@ steps:
     run: ./build.sh
   - uses: ./../action/analyze
     with:
+      upload-database: false
       ref: 'refs/heads/main'
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'

--- a/pr-checks/checks/autobuild-action.yml
+++ b/pr-checks/checks/autobuild-action.yml
@@ -16,6 +16,8 @@ steps:
       CORECLR_PROFILER: ""
       CORECLR_PROFILER_PATH_64: ""
   - uses: ./../action/analyze
+    with:
+      upload-database: false
   - name: Check database
     shell: bash
     run: |

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -1,6 +1,6 @@
 name: "Go: Custom queries"
 description: "Checks that Go works in conjunction with a config file specifying custom queries"
-env: 
+env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
   - uses: ./../action/init
@@ -12,3 +12,5 @@ steps:
     shell: bash
     run: ./build.sh
   - uses: ./../action/analyze
+    with:
+      upload-database: false

--- a/pr-checks/checks/go-tracing-autobuilder.yml
+++ b/pr-checks/checks/go-tracing-autobuilder.yml
@@ -10,6 +10,8 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - uses: ./../action/autobuild
   - uses: ./../action/analyze
+    with:
+      upload-database: false
   - shell: bash
     run: |
       if [[ "${CODEQL_ACTION_DID_AUTOBUILD_GOLANG}" != true ]]; then

--- a/pr-checks/checks/go-tracing-custom-build-steps.yml
+++ b/pr-checks/checks/go-tracing-custom-build-steps.yml
@@ -10,6 +10,8 @@ steps:
     shell: bash
     run: go build main.go
   - uses: ./../action/analyze
+    with:
+      upload-database: false
   - shell: bash
     run: |
       # Once we start running Bash 4.2 in all environments, we can replace the

--- a/pr-checks/checks/go-tracing-legacy-workflow.yml
+++ b/pr-checks/checks/go-tracing-legacy-workflow.yml
@@ -9,6 +9,8 @@ steps:
       languages: go
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - uses: ./../action/analyze
+    with:
+      upload-database: false
   - shell: bash
     run: |
       cd "$RUNNER_TEMP/codeql_databases"

--- a/pr-checks/checks/javascript-source-root.yml
+++ b/pr-checks/checks/javascript-source-root.yml
@@ -15,6 +15,7 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - uses: ./../action/analyze
     with:
+      upload-database: false
       skip-queries: true
       upload: false
   - name: Assert database exists

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -9,7 +9,7 @@ steps:
     with:
       db-location: "${{ runner.temp }}/customDbLocation"
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  
+
   - uses: ./../action/.github/setup-swift
     with:
       codeql-path: ${{steps.init.outputs.codeql-path}}
@@ -20,6 +20,8 @@ steps:
 
   - uses: ./../action/analyze
     id: analysis
+    with:
+      upload-database: false
 
   - name: Check language autodetect for all languages excluding Ruby, Swift
     shell: bash

--- a/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
@@ -18,6 +18,7 @@ steps:
   - uses: ./../action/analyze
     with:
       output: "${{ runner.temp }}/results"
+      upload-database: false
 
   - name: Check results
     uses: ./../action/.github/check-sarif

--- a/pr-checks/checks/packaging-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-config-inputs-js.yml
@@ -14,6 +14,7 @@ steps:
   - uses: ./../action/analyze
     with:
       output: "${{ runner.temp }}/results"
+      upload-database: false
 
   - name: Check results
     uses: ./../action/.github/check-sarif

--- a/pr-checks/checks/packaging-config-js.yml
+++ b/pr-checks/checks/packaging-config-js.yml
@@ -13,6 +13,7 @@ steps:
   - uses: ./../action/analyze
     with:
       output: "${{ runner.temp }}/results"
+      upload-database: false
 
   - name: Check results
     uses: ./../action/.github/check-sarif

--- a/pr-checks/checks/ruby.yml
+++ b/pr-checks/checks/ruby.yml
@@ -9,6 +9,8 @@ steps:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - uses: ./../action/analyze
     id: analysis
+    with:
+      upload-database: false
   - name: Check database
     shell: bash
     run: |

--- a/pr-checks/checks/split-workflow.yml
+++ b/pr-checks/checks/split-workflow.yml
@@ -16,6 +16,7 @@ steps:
     with:
       skip-queries: true
       output: "${{ runner.temp }}/results"
+      upload-database: false
 
   - name: Assert No Results
     shell: bash

--- a/pr-checks/checks/swift-autobuild.yml
+++ b/pr-checks/checks/swift-autobuild.yml
@@ -21,6 +21,8 @@ steps:
     timeout-minutes: 10
   - uses: ./../action/analyze
     id: analysis
+    with:
+      upload-database: false
   - name: Check database
     shell: bash
     run: |

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -22,6 +22,8 @@ steps:
     run: ./build.sh
   - uses: ./../action/analyze
     id: analysis
+    with:
+      upload-database: false
   - name: Check database
     shell: bash
     run: |

--- a/pr-checks/checks/test-autobuild-working-dir.yml
+++ b/pr-checks/checks/test-autobuild-working-dir.yml
@@ -18,6 +18,8 @@ steps:
     with:
       working-directory: autobuild-dir
   - uses: ./../action/analyze
+    with:
+      upload-database: false
   - name: Check database
     shell: bash
     run: |

--- a/pr-checks/checks/test-local-codeql.yml
+++ b/pr-checks/checks/test-local-codeql.yml
@@ -16,3 +16,5 @@ steps:
     shell: bash
     run: ./build.sh
   - uses: ./../action/analyze
+    with:
+      upload-database: false

--- a/pr-checks/checks/test-proxy.yml
+++ b/pr-checks/checks/test-proxy.yml
@@ -18,3 +18,5 @@ steps:
       languages: javascript
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - uses: ./../action/analyze
+    with:
+      upload-database: false

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -13,6 +13,8 @@ steps:
     run: env -i CODEQL_EXTRACTOR_JAVA_AGENT_DISABLE_KOTLIN=true PATH="$PATH" HOME="$HOME" ./build.sh
   - uses: ./../action/analyze
     id: analysis
+    with:
+      upload-database: false
   - shell: bash
     run: |
       CPP_DB="${{ fromJson(steps.analysis.outputs.db-locations).cpp }}"

--- a/pr-checks/checks/upload-ref-sha-input.yml
+++ b/pr-checks/checks/upload-ref-sha-input.yml
@@ -11,6 +11,7 @@ steps:
     run: ./build.sh
   - uses: ./../action/analyze
     with:
+      upload-database: false
       ref: 'refs/heads/main'
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'
       upload: false

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -30,6 +30,7 @@ steps:
       ref: v1.1.0
       sha: 474bbf07f9247ffe1856c6a0f94aeeb10e7afee6
       upload: false
+      upload-database: false
 
   - uses: ./../action/upload-sarif
     with:


### PR DESCRIPTION
We are still getting coverage of the upload capability through the standard codeql analysis workflow.

This ensures that when you download a database from codeql-action, you are not accidentally getting one of the integration test dbs.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
