### PR TITLE
Ignore classic GHES version when updating supported versions 

### DIFF
--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -3,6 +3,7 @@ name: Update Supported Enterprise Server Versions
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   update-supported-enterprise-server-versions:

--- a/.github/workflows/update-supported-enterprise-server-versions/update.py
+++ b/.github/workflows/update-supported-enterprise-server-versions/update.py
@@ -15,6 +15,11 @@ def main():
 	api_compatibility_data = json.loads(_API_COMPATIBILITY_PATH.read_text())
 
 	releases = json.loads(_RELEASE_FILE_PATH.read_text())
+
+	# Remove GHES version using a previous version numbering scheme.
+	if "11.10.340" in releases:
+		del releases["11.10.340"]
+
 	oldest_supported_release = None
 	newest_supported_release = semver.VersionInfo.parse(api_compatibility_data["maximumVersion"] + ".0")
 


### PR DESCRIPTION
A classic GHES version which does not follow the current version numbering scheme was recently added to [`releases.json`](https://github.com/github/enterprise-releases/blob/master/releases.json), which broke the script we use to update the versions of GHES supported by the Action.

This PR ignores this version when performing the comparison.

Example Actions run: https://github.com/github/codeql-action/actions/runs/4448233726/jobs/7810782068

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
