### PR TITLE
Fix the `bundleVersion` field set by the automated bundle update PR

### DIFF
--- a/.github/actions/update-bundle/index.ts
+++ b/.github/actions/update-bundle/index.ts
@@ -18,50 +18,50 @@ function getCodeQLCliVersionForRelease(release): string {
   // Instead, we use a marker file `cli-version-<version>.txt` to record the CLI version.
   // This marker file is uploaded as a release asset for all new CodeQL bundles.
   const cliVersionsFromMarkerFiles = release.assets
-  .map((asset) => asset.name.match(/cli-version-(.*)\.txt/)?.[1])
-  .filter((v) => v)
-  .map((v) => v as string);
+    .map((asset) => asset.name.match(/cli-version-(.*)\.txt/)?.[1])
+    .filter((v) => v)
+    .map((v) => v as string);
   if (cliVersionsFromMarkerFiles.length > 1) {
     throw new Error(
       `Release ${release.tag_name} has multiple CLI version marker files.`
-      );
-    } else if (cliVersionsFromMarkerFiles.length === 0) {
-      throw new Error(
-        `Failed to find the CodeQL CLI version for release ${release.tag_name}.`
-        );
-      }
-      return cliVersionsFromMarkerFiles[0];
-    }
+    );
+  } else if (cliVersionsFromMarkerFiles.length === 0) {
+    throw new Error(
+      `Failed to find the CodeQL CLI version for release ${release.tag_name}.`
+    );
+  }
+  return cliVersionsFromMarkerFiles[0];
+}
 
-    async function getBundleInfoFromRelease(release): Promise<BundleInfo> {
-      return {
-        bundleVersion: release.tag_name,
-        cliVersion: getCodeQLCliVersionForRelease(release)
-      };
-    }
+async function getBundleInfoFromRelease(release): Promise<BundleInfo> {
+  return {
+    bundleVersion: release.tag_name,
+    cliVersion: getCodeQLCliVersionForRelease(release)
+  };
+}
 
-    async function getNewDefaults(currentDefaults: Defaults): Promise<Defaults> {
-      const release = github.context.payload.release;
-      console.log('Updating default bundle as a result of the following release: ' +
-      `${JSON.stringify(release)}.`)
+async function getNewDefaults(currentDefaults: Defaults): Promise<Defaults> {
+  const release = github.context.payload.release;
+  console.log('Updating default bundle as a result of the following release: ' +
+    `${JSON.stringify(release)}.`)
 
-      const bundleInfo = await getBundleInfoFromRelease(release);
-      return {
-        bundleVersion: bundleInfo.bundleVersion,
-        cliVersion: bundleInfo.cliVersion,
-        priorBundleVersion: currentDefaults.bundleVersion,
-        priorCliVersion: currentDefaults.cliVersion
-      };
-    }
+  const bundleInfo = await getBundleInfoFromRelease(release);
+  return {
+    bundleVersion: bundleInfo.bundleVersion,
+    cliVersion: bundleInfo.cliVersion,
+    priorBundleVersion: currentDefaults.bundleVersion,
+    priorCliVersion: currentDefaults.cliVersion
+  };
+}
 
-    async function main() {
-      const previousDefaults: Defaults = JSON.parse(fs.readFileSync('../../../src/defaults.json', 'utf8'));
-      const newDefaults = await getNewDefaults(previousDefaults);
-      // Update the source file in the repository. Calling workflows should subsequently rebuild
-      // the Action to update `lib/defaults.json`.
-      fs.writeFileSync('../../../src/defaults.json', JSON.stringify(newDefaults, null, 2) + "\n");
-    }
+async function main() {
+  const previousDefaults: Defaults = JSON.parse(fs.readFileSync('../../../src/defaults.json', 'utf8'));
+  const newDefaults = await getNewDefaults(previousDefaults);
+  // Update the source file in the repository. Calling workflows should subsequently rebuild
+  // the Action to update `lib/defaults.json`.
+  fs.writeFileSync('../../../src/defaults.json', JSON.stringify(newDefaults, null, 2) + "\n");
+}
 
-    // Ideally, we'd await main() here, but that doesn't work well with `ts-node`.
-    // So instead we rely on the fact that Node won't exit until the event loop is empty.
-    main();
+// Ideally, we'd await main() here, but that doesn't work well with `ts-node`.
+// So instead we rely on the fact that Node won't exit until the event loop is empty.
+main();

--- a/.github/actions/update-bundle/index.ts
+++ b/.github/actions/update-bundle/index.ts
@@ -13,8 +13,6 @@ interface Defaults {
   priorCliVersion: string;
 }
 
-const CODEQL_BUNDLE_PREFIX = 'codeql-bundle-';
-
 function getCodeQLCliVersionForRelease(release): string {
   // We do not currently tag CodeQL bundles based on the CLI version they contain.
   // Instead, we use a marker file `cli-version-<version>.txt` to record the CLI version.
@@ -37,7 +35,7 @@ function getCodeQLCliVersionForRelease(release): string {
 
     async function getBundleInfoFromRelease(release): Promise<BundleInfo> {
       return {
-        bundleVersion: release.tag_name.substring(CODEQL_BUNDLE_PREFIX.length),
+        bundleVersion: release.tag_name,
         cliVersion: getCodeQLCliVersionForRelease(release)
       };
     }


### PR DESCRIPTION
The `bundleVersion` is the whole tag, we don't want to remove the `codeql-bundle-` prefix.

Commit-by-commit review recommended since we autoformat the update bundle Action in the second commit.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
