### PR TITLE
Fix broken regex

### DIFF
--- a/src/sarif-schema-2.1.0.json
+++ b/src/sarif-schema-2.1.0.json
@@ -2368,7 +2368,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^(?i)[a-zA]{2}(-[a-z]{2})?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "versionControlProvenance": {
@@ -3078,7 +3078,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^(?i)[a-zA]{2}(-[a-z]{2})?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "contents": {


### PR DESCRIPTION
`($i)` is not valid for javascript regexes.

Fixes https://github.com/github/codeql-action/issues/1671
