### PR TITLE
Fix Swift PR Checks on `nightly-latest` CLI

### DIFF
--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -1,5 +1,5 @@
 name: "Set up Swift"
-description: Sets up an appropriate Swift version if Swift is enabled via CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT.
+description: Sets up an appropriate Swift version if supported.
 inputs:
   codeql-path:
     description: Path to the CodeQL CLI executable.
@@ -9,24 +9,28 @@ runs:
   steps:
     - name: Get Swift version
       id: get_swift_version
-      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
       shell: bash
       env: 
         CODEQL_PATH: ${{ inputs.codeql-path }}
       run: |
-        if [ $RUNNER_OS = "macOS" ]; then
+        if [[ $RUNNER_OS = "macOS" ]]; then
           PLATFORM="osx64"
         else # We do not run this step on Windows.
           PLATFORM="linux64"
         fi 
         SWIFT_EXTRACTOR_DIR="$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')"
-        VERSION="$("$SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor" --version | awk '/version/ { print $3 }')"
-        # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
-        if [ $VERSION = "5.7" ]; then
-          VERSION="5.7.0"
+        if [ $SWIFT_EXTRACTOR_DIR = "null" ]; then
+          VERSION="null"
+        else
+          VERSION="$("$SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor" --version | awk '/version/ { print $3 }')"
+          # Specify 5.7.0, otherwise setup Action will default to latest minor version. 
+          if [ $VERSION = "5.7" ]; then
+            VERSION="5.7.0"
+          fi
         fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
+
     - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf # Please update the corresponding SHA in the CLI's CodeQL Action Integration Test.
-      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
+      if: steps.get_swift_version.outputs.version != null
       with:
         swift-version: "${{ steps.get_swift_version.outputs.version }}"

--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -9,6 +9,7 @@ runs:
   steps:
     - name: Get Swift version
       id: get_swift_version
+      if: runner.os != 'Windows'
       shell: bash
       env: 
         CODEQL_PATH: ${{ inputs.codeql-path }}
@@ -31,6 +32,6 @@ runs:
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
 
     - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf # Please update the corresponding SHA in the CLI's CodeQL Action Integration Test.
-      if: steps.get_swift_version.outputs.version != null
+      if: runner.os != 'Windows' && steps.get_swift_version.outputs.version != "null"
       with:
         swift-version: "${{ steps.get_swift_version.outputs.version }}"

--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -9,6 +9,7 @@ runs:
   steps:
     - name: Get Swift version
       id: get_swift_version
+      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
       shell: bash
       env: 
         CODEQL_PATH: ${{ inputs.codeql-path }}
@@ -26,5 +27,6 @@ runs:
         fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf # Please update the corresponding SHA in the CLI's CodeQL Action Integration Test.
+      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
       with:
         swift-version: "${{ steps.get_swift_version.outputs.version }}"

--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -1,5 +1,5 @@
 name: "Set up Swift"
-description: Sets up an appropriate Swift version if supported.
+description: Sets up an appropriate Swift version if supported on this platform.
 inputs:
   codeql-path:
     description: Path to the CodeQL CLI executable.

--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -9,7 +9,6 @@ runs:
   steps:
     - name: Get Swift version
       id: get_swift_version
-      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
       shell: bash
       env: 
         CODEQL_PATH: ${{ inputs.codeql-path }}
@@ -27,6 +26,5 @@ runs:
         fi
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
     - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf # Please update the corresponding SHA in the CLI's CodeQL Action Integration Test.
-      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
       with:
         swift-version: "${{ steps.get_swift_version.outputs.version }}"

--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -32,6 +32,6 @@ runs:
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
 
     - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf # Please update the corresponding SHA in the CLI's CodeQL Action Integration Test.
-      if: runner.os != 'Windows' && steps.get_swift_version.outputs.version != "null"
+      if: runner.os != 'Windows' && steps.get_swift_version.outputs.version != 'null'
       with:
         swift-version: "${{ steps.get_swift_version.outputs.version }}"

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -84,8 +84,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -48,8 +48,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -54,8 +54,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -60,8 +60,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -48,8 +48,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -44,8 +44,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -84,8 +84,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -70,8 +70,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -70,8 +70,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -70,8 +70,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -60,8 +60,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -48,8 +48,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__ml-powered-queries.yml
+++ b/.github/workflows/__ml-powered-queries.yml
@@ -84,8 +84,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -70,8 +70,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -138,7 +138,9 @@ jobs:
         fi
 
     - name: Check language autodetect for Swift
-      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
+      if: >-
+        env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true' || 
+            (runner.os != 'Windows' && matrix.version == 'nightly-latest')
       shell: bash
       run: |
         SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -60,8 +60,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -60,8 +60,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -60,8 +60,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -60,8 +60,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -84,8 +84,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -44,8 +44,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -54,8 +54,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -54,8 +54,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -48,8 +48,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -54,8 +54,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -44,8 +44,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -44,8 +44,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -44,8 +44,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -56,8 +56,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -84,8 +84,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -84,8 +84,7 @@ jobs:
             matrix.version == '20220908' ||
             matrix.version == '20221211' ||
             matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
+            matrix.version == 'latest'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -54,6 +54,9 @@ jobs:
           debug: true
           debug-artifact-name: my-debug-artifacts
           debug-database-name: my-db
+      - uses: ./../action/.github/actions/setup-swift
+        with:
+        codeql-path: ${{ steps.init.outputs.codeql-path }}
       - name: Build code
         shell: bash
         run: ./build.sh

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -48,6 +48,17 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ^1.13.1
+      - name: Set environment variable for Swift enablement
+      if: >-
+        runner.os != 'Windows' && (
+            matrix.version == '20220908' ||
+            matrix.version == '20221211' ||
+            matrix.version == 'cached' ||
+            matrix.version == 'latest' ||
+            matrix.version == 'nightly-latest'
+        )
+      shell: bash
+      run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           go-version: ^1.13.1
       - uses: ./../action/init
+        id: init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}
           debug: true

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -55,6 +55,7 @@ jobs:
           debug-artifact-name: my-debug-artifacts
           debug-database-name: my-db
       - uses: ./../action/.github/actions/setup-swift
+        if: matrix.version == 'nightly-latest'
         with:
           codeql-path: ${{ steps.init.outputs.codeql-path }}
       - name: Build code

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -56,7 +56,7 @@ jobs:
           debug-database-name: my-db
       - uses: ./../action/.github/actions/setup-swift
         with:
-        codeql-path: ${{ steps.init.outputs.codeql-path }}
+          codeql-path: ${{ steps.init.outputs.codeql-path }}
       - name: Build code
         shell: bash
         run: ./build.sh

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -48,17 +48,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ^1.13.1
-      - name: Set environment variable for Swift enablement
-      if: >-
-        runner.os != 'Windows' && (
-            matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest' ||
-            matrix.version == 'nightly-latest'
-        )
-      shell: bash
-      run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -66,7 +66,9 @@ steps:
       fi
 
   - name: Check language autodetect for Swift
-    if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
+    if: >- 
+      env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true' || 
+          (runner.os != 'Windows' && matrix.version == 'nightly-latest')
     shell: bash
     run: |
       SWIFT_DB=${{ fromJson(steps.analysis.outputs.db-locations).swift }}

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -83,8 +83,7 @@ for file in os.listdir('checks'):
                     matrix.version == '20220908' ||
                     matrix.version == '20221211' ||
                     matrix.version == 'cached' ||
-                    matrix.version == 'latest' ||
-                    matrix.version == 'nightly-latest'
+                    matrix.version == 'latest'
                 )
             ''').strip()),
             'shell': 'bash',


### PR DESCRIPTION
Now that Swift analysis is on by default in the latest nightly CLI version, we are autodetecting Swift, but Swift is not set up in this workflow. This change fixes the Swift setup workflow to unblock CI by:

- adding `setup-swift` workflow, and `CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT` for all versions except `nightly-latest` to the debug artifacts check
- no longer setting the `CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT` flag for the `nightly-latest` CLI version, for any other check. This allows us to test the case where the flag is not set for `nightly-latest` as well. 
- updating the `setup-swift` workflow to only set up Swift if the `codeql resolve languages` includes Swift. 

Once CLI v2.13.3 is released, we can stop setting the experimental flag for `latest`.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
