### PR TITLE
Remove unnecessary conditional for Ruby autodetect

### DIFF
--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -93,7 +93,7 @@ jobs:
       with:
         upload-database: false
 
-    - name: Check language autodetect for all languages excluding Ruby, Swift
+    - name: Check language autodetect for all languages excluding Swift
       shell: bash
       run: |
         CPP_DB=${{ fromJson(steps.analysis.outputs.db-locations).cpp }}
@@ -126,11 +126,6 @@ jobs:
           echo "Did not create a database for Python, or created it in the wrong location."
           exit 1
         fi
-
-    - name: Check language autodetect for Ruby
-      if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
-      shell: bash
-      run: |
         RUBY_DB=${{ fromJson(steps.analysis.outputs.db-locations).ruby }}
         if [[ ! -d $RUBY_DB ]] || [[ ! $RUBY_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
           echo "Did not create a database for Ruby, or created it in the wrong location."

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -21,7 +21,7 @@ steps:
     with:
       upload-database: false
 
-  - name: Check language autodetect for all languages excluding Ruby, Swift
+  - name: Check language autodetect for all languages excluding Swift
     shell: bash
     run: |
       CPP_DB=${{ fromJson(steps.analysis.outputs.db-locations).cpp }}
@@ -54,11 +54,6 @@ steps:
         echo "Did not create a database for Python, or created it in the wrong location."
         exit 1
       fi
-
-  - name: Check language autodetect for Ruby
-    if: env.CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT == 'true'
-    shell: bash
-    run: |
       RUBY_DB=${{ fromJson(steps.analysis.outputs.db-locations).ruby }}
       if [[ ! -d $RUBY_DB ]] || [[ ! $RUBY_DB == ${{ runner.temp }}/customDbLocation/* ]]; then
         echo "Did not create a database for Ruby, or created it in the wrong location."


### PR DESCRIPTION
We should check language autodetect for Ruby unconditionally. We can now move it into the step that checks all other languages; it was likely separated from other languages because of an experimental environment variable we needed to have set for Ruby before it was in GA. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
