### PR TITLE
Improve automation for updating supported versions of GHES

### DIFF
--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -35,14 +35,22 @@ jobs:
           npm run build
         env:
           ENTERPRISE_RELEASES_PATH: ${{ github.workspace }}/enterprise-releases/
-      - name: Commit Changes
-        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
-        with:
-          commit-message: Update supported GitHub Enterprise Server versions.
-          title: Update supported GitHub Enterprise Server versions.
-          body: ""
-          author: GitHub <noreply@github.com>
-          branch: update-supported-enterprise-server-versions
-          draft: true
+
+      - name: Update git config
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Commit changes and open PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -z $(git status --porcelain) ]]; then
+            echo "No changes to commit"
+          else
+            git checkout -b update-supported-enterprise-server-versions
+            git add .
+            git commit --message "Update supported GitHub Enterprise Server versions"
+            git push
+            gh pr create --fill --draft
+          fi

--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -51,6 +51,6 @@ jobs:
             git checkout -b update-supported-enterprise-server-versions
             git add .
             git commit --message "Update supported GitHub Enterprise Server versions"
-            git push
+            git push origin update-supported-enterprise-server-versions
             gh pr create --fill --draft
           fi

--- a/.github/workflows/update-supported-enterprise-server-versions/update.py
+++ b/.github/workflows/update-supported-enterprise-server-versions/update.py
@@ -35,7 +35,9 @@ def main():
 
 		if oldest_supported_release is None or release_version < oldest_supported_release:
 			end_of_life_date = datetime.date.fromisoformat(release_data["end"])
-			if end_of_life_date > datetime.date.today():
+			# The GHES version is not actually end of life until the end of the day specified by
+			# `end_of_life_date`. Wait an extra week to be safe.
+			if end_of_life_date > datetime.date.today() + datetime.timedelta(weeks=1):
 				oldest_supported_release = release_version
 
 	api_compatibility_data = {

--- a/.github/workflows/update-supported-enterprise-server-versions/update.py
+++ b/.github/workflows/update-supported-enterprise-server-versions/update.py
@@ -37,7 +37,7 @@ def main():
 			end_of_life_date = datetime.date.fromisoformat(release_data["end"])
 			# The GHES version is not actually end of life until the end of the day specified by
 			# `end_of_life_date`. Wait an extra week to be safe.
-			if end_of_life_date > datetime.date.today() + datetime.timedelta(weeks=1):
+			if end_of_life_date > datetime.date.today() - datetime.timedelta(weeks=1):
 				oldest_supported_release = release_version
 
 	api_compatibility_data = {

--- a/.github/workflows/update-supported-enterprise-server-versions/update.py
+++ b/.github/workflows/update-supported-enterprise-server-versions/update.py
@@ -37,7 +37,8 @@ def main():
 			end_of_life_date = datetime.date.fromisoformat(release_data["end"])
 			# The GHES version is not actually end of life until the end of the day specified by
 			# `end_of_life_date`. Wait an extra week to be safe.
-			if end_of_life_date > datetime.date.today() - datetime.timedelta(weeks=1):
+			is_end_of_life = datetime.date.today() > end_of_life_date + datetime.timedelta(weeks=1)
+			if not is_end_of_life:
 				oldest_supported_release = release_version
 
 	api_compatibility_data = {


### PR DESCRIPTION
Wait a week to ensure the GHES version is definitely end of life, and open the PR using the `gh` CLI rather than a third-party Action.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
