### PR TITLE
Fix changelog for 2.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No user facing changes.
 
 ## 2.3.6 - 01 Jun 2023
 
-No user facing changes.
+- Update default CodeQL bundle version to 2.13.3. [#1698](https://github.com/github/codeql-action/pull/1698)
 
 ## 2.3.5 - 25 May 2023
 
@@ -22,7 +22,6 @@ No user facing changes.
   - This change does not affect the majority of workflows, and we will not be changing tags for existing bundle releases.
   - Some workflows with custom logic that depends on the specific format of the CodeQL bundle tag may need to be updated. For example, if your workflow matches CodeQL bundle tag names against a `codeql-bundle-yyyymmdd` pattern, you should update it to also recognize `codeql-bundle-vx.y.z` tags.
 - Remove the requirement for `on.push` and `on.pull_request` to trigger on the same branches. [#1675](https://github.com/github/codeql-action/pull/1675)
-- Update default CodeQL bundle version to 2.13.3. [#1698](https://github.com/github/codeql-action/pull/1698)
 
 ## 2.3.3 - 04 May 2023
 


### PR DESCRIPTION
One of the changelog entries for 2.3.6 ended up incorrectly being associated with 2.3.4 due to a bad merge conflict resolution.  As a long term fix, we could store unreleased changelog entries in a separate directory and only edit `CHANGELOG.md` with automation.  

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
