### PR TITLE
PR checks: stop setting experimental Swift var for new CLI versions

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -85,9 +85,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -49,9 +49,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -55,9 +55,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -61,9 +61,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -49,9 +49,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -45,9 +45,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -85,9 +85,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -71,9 +71,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -71,9 +71,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -71,9 +71,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -62,9 +62,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -49,9 +49,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__ml-powered-queries.yml
+++ b/.github/workflows/__ml-powered-queries.yml
@@ -85,9 +85,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -71,9 +71,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -61,9 +61,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -61,9 +61,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -61,9 +61,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -61,9 +61,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -85,9 +85,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -45,9 +45,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -55,9 +55,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -55,9 +55,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -49,9 +49,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -55,9 +55,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -45,9 +45,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -45,9 +45,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -45,9 +45,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -57,9 +57,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -85,9 +85,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -85,9 +85,7 @@ jobs:
       if: >-
         runner.os != 'Windows' && (
             matrix.version == '20220908' ||
-            matrix.version == '20221211' ||
-            matrix.version == 'cached' ||
-            matrix.version == 'latest'
+            matrix.version == '20221211'
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -81,9 +81,7 @@ for file in os.listdir('checks'):
             'if': FoldedScalarString(textwrap.dedent('''
                 runner.os != 'Windows' && (
                     matrix.version == '20220908' ||
-                    matrix.version == '20221211' ||
-                    matrix.version == 'cached' ||
-                    matrix.version == 'latest'
+                    matrix.version == '20221211'
                 )
             ''').strip()),
             'shell': 'bash',


### PR DESCRIPTION
Now that `latest` and `cached` are both 2.13.3, which is the version in which we GA'ed Swift, we should stop setting this experimental variable when we test these CLI versions so we can test the case where the variable is unset.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
