### PR TITLE
Bump Action version to 2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-No user facing changes.
+- Bump the version of the Action to 2.20.0. This ensures that users who received a Dependabot upgrade to [`cdcdbb5`](https://github.com/github/codeql-action/commit/cdcdbb579706841c47f7063dda365e292e5cad7a), which was mistakenly marked as Action version 2.13.4, continue to receive updates to the CodeQL Action. Full details in [#1729](https://github.com/github/codeql-action/pull/1729)
 
 ## 2.3.6 - 01 Jun 2023
 

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql",
-  "version": "2.3.7",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeql",
-  "version": "2.3.7",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeql",
-      "version": "2.3.7",
+      "version": "2.20.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeql",
-  "version": "2.3.7",
+  "version": "2.20.0",
   "private": true,
   "description": "CodeQL action",
   "scripts": {


### PR DESCRIPTION
Bump the version of the Action to 2.20.0. This ensures that users who received a Dependabot upgrade to [`cdcdbb5`](https://github.com/github/codeql-action/commit/cdcdbb579706841c47f7063dda365e292e5cad7a), which was mistakenly marked as Action version 2.13.4, continue to receive updates to the CodeQL Action.
  - The CodeQL Action repository contains a series of tags `v*` corresponding to versions of the CodeQL Action. However it also contains a series of tags `codeql-bundle-*` that correspond to versions of the CodeQL Bundle, an artifact that contains the CodeQL CLI and the standard CodeQL libraries.
  - In CodeQL CLI version 2.13.4, we changed the format of the CodeQL Bundle tag from a date, for example `codeql-bundle-20230613`, to a semantic version, for example `codeql-bundle-v2.13.4`. This inadvertently sent out Dependabot PRs that upgraded users from `v2.3.6` to `codeql-bundle-v2.13.4`.
  - To ensure that users who merged this Dependabot upgrade continue to receive correct updates to the CodeQL Action, we are bumping the Action version to make it greater than 2.13.4. We chose version 2.20.0 to help avoid confusion between the version numbers of the CodeQL Action and the CodeQL CLI.


### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
