### PR TITLE
python-setup: Fix pipenv (`--keep-outdated` deprecated)

### DIFF
--- a/python-setup/auto_install_packages.py
+++ b/python-setup/auto_install_packages.py
@@ -76,7 +76,7 @@ def install_packages_with_pipenv(has_lockfile):
         # In windows the default path were the deps are installed gets wiped out between steps,
         # so we have to set it up to a folder that will be kept
         os.environ['WORKON_HOME'] = os.path.join(os.environ['RUNNER_WORKSPACE'], 'virtualenvs')
-    lock_args = ['--keep-outdated', '--ignore-pipfile'] if has_lockfile else ['--skip-lock']
+    lock_args = ['--ignore-pipfile'] if has_lockfile else ['--skip-lock']
     try:
         _check_call(command + ['install'] + lock_args)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Recently released pipenv removed support for `--keep-outdated` flag (see https://github.com/pypa/pipenv/blob/main/CHANGELOG.rst#pipenv-202379-2023-07-09)

Local testing showed that installation was fine without this :+1:

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary. **no change made**
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary. **no change made**