### PR TITLE
Group together dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,23 @@ updates:
       interval: weekly
     labels:
       - Update dependencies
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-minor
-          - version-update:semver-patch
+    groups:
+      npm:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/.github/actions/setup-swift/" # All subdirectories outside of "/.github/workflows" must be explicitly included.
     schedule:
       interval: weekly
+    groups:
+      actions-setup-swift:
+        patterns:
+          - "*"


### PR DESCRIPTION
Opt into the [Dependabot grouped updates beta](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) to allow us to update dependencies more frequently without too much friction.

Limitation: Ideally we'd be able to separate out update PRs for major version updates, since these may be incompatible / require some work to merge, but this isn't possible yet.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
