### PR TITLE
Remove redundant environment variable from PR check

### DIFF
--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -101,6 +101,5 @@ jobs:
           }
           core.info('Finished config export tests.');
     env:
-      CODEQL_ACTION_EXPORT_CODE_SCANNING_CONFIG: true
       CODEQL_PASS_CONFIG_TO_CLI: true
       CODEQL_ACTION_TEST_MODE: true

--- a/pr-checks/checks/config-export.yml
+++ b/pr-checks/checks/config-export.yml
@@ -2,7 +2,6 @@ name: "Config export"
 description: "Tests that the code scanning configuration file is exported to SARIF correctly."
 versions: ["latest", "nightly-latest"]
 env:
-  CODEQL_ACTION_EXPORT_CODE_SCANNING_CONFIG: true
   CODEQL_PASS_CONFIG_TO_CLI: true
 steps:
   - uses: ./../action/init


### PR DESCRIPTION
This was used to enable a feature flag, but the associated feature flag has now been removed and the functionality enabled for everyone.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
