### PR TITLE
Run check-sarif Action using Node 16

### DIFF
--- a/.github/actions/check-sarif/action.yml
+++ b/.github/actions/check-sarif/action.yml
@@ -16,5 +16,5 @@ inputs:
       Comma separated list of query ids that should NOT be included in this SARIF file.
 
 runs:
-  using: node12
+  using: node16
   main: index.js


### PR DESCRIPTION
`using: node12` Actions have already been running using Node 16 for some time, so this won't have any effect, but it is more correct and avoids warnings.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
