### PR TITLE
Update Dependabot config to ignore incompatible updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,17 @@ updates:
       interval: weekly
     labels:
       - Update dependencies
+    # Ignore incompatible dependency updates
+    ignore:
+      # There is a type incompatibility issue between v0.0.9 and our other dependencies.
+      - dependency-name: "@octokit/plugin-retry"
+        versions: ["~6.0.0"]
+      # There is a type incompatibility issue between v0.0.9 and our other dependencies.
+      - dependency-name: "@schemastore/package"
+        versions: ["0.0.9"]
+      # v7 requires ESM
+      - dependency-name: "del"
+        versions: ["^7.0.0"]
     groups:
       npm:
         patterns:


### PR DESCRIPTION
In https://github.com/github/codeql-action/pull/1774, I found I had to downgrade these dependencies to make things work.  This PR ignores them in the Dependabot config so they won't be included in our grouped updates. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
