### PR TITLE
PR checks: Rename `cached` to `default`

### DIFF
--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -2,7 +2,7 @@ name: "Prepare test"
 description: Performs some preparation to run tests
 inputs:
   version:
-    description: "The version of the CodeQL CLI to use. Can be 'latest', 'cached', 'nightly-latest', 'nightly-YYYY-MM-DD', or 'stable-YYYY-MM-DD'."
+    description: "The version of the CodeQL CLI to use. Can be 'latest', 'default', 'nightly-latest', 'nightly-YYYY-MM-DD', or 'stable-YYYY-MM-DD'."
     required: true
 outputs:
   tools-url:
@@ -46,7 +46,7 @@ runs:
           echo "tools-url=https://github.com/github/codeql-action/releases/download/codeql-bundle-$version/$artifact_name" >> $GITHUB_OUTPUT
         elif [[ ${{ inputs.version }} == "latest" ]]; then
           echo "tools-url=latest" >> $GITHUB_OUTPUT
-        elif [[ ${{ inputs.version }} == "cached" ]]; then
+        elif [[ ${{ inputs.version }} == "default" ]]; then
           echo "tools-url=" >> $GITHUB_OUTPUT
         else
           echo "::error::Unrecognized version specified!"

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -50,11 +50,11 @@ jobs:
         - os: windows-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -50,11 +50,11 @@ jobs:
         - os: windows-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -42,9 +42,9 @@ jobs:
         - os: macos-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -42,9 +42,9 @@ jobs:
         - os: macos-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -42,9 +42,9 @@ jobs:
         - os: macos-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -26,11 +26,11 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -28,7 +28,7 @@ jobs:
         - os: ubuntu-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
     name: Custom source root

--- a/.github/workflows/__ml-powered-queries.yml
+++ b/.github/workflows/__ml-powered-queries.yml
@@ -50,11 +50,11 @@ jobs:
         - os: windows-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -42,9 +42,9 @@ jobs:
         - os: macos-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -32,11 +32,11 @@ jobs:
         - os: windows-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -32,11 +32,11 @@ jobs:
         - os: windows-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -32,11 +32,11 @@ jobs:
         - os: windows-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -32,11 +32,11 @@ jobs:
         - os: windows-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -50,11 +50,11 @@ jobs:
         - os: windows-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          version: cached
+          version: default
     name: RuboCop multi-language
     permissions:
       contents: read

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -30,9 +30,9 @@ jobs:
         - os: macos-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -42,9 +42,9 @@ jobs:
         - os: macos-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -30,9 +30,9 @@ jobs:
         - os: macos-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -28,7 +28,7 @@ jobs:
         - os: ubuntu-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
     name: Submit SARIF after failure

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -30,9 +30,9 @@ jobs:
         - os: macos-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -34,7 +34,7 @@ jobs:
         - os: ubuntu-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: ubuntu-latest

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -50,11 +50,11 @@ jobs:
         - os: windows-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -50,11 +50,11 @@ jobs:
         - os: windows-latest
           version: stable-20230418
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: windows-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: latest
         - os: macos-latest

--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -30,9 +30,9 @@ jobs:
         - os: macos-latest
           version: latest
         - os: ubuntu-latest
-          version: cached
+          version: default
         - os: macos-latest
-          version: cached
+          version: default
         - os: ubuntu-latest
           version: nightly-latest
         - os: macos-latest

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -29,7 +29,7 @@ jobs:
         - stable-20220908
         - stable-20221211
         - stable-20230418
-        - cached
+        - default
         - latest
         - nightly-latest
     name: Upload debug artifacts
@@ -74,7 +74,7 @@ jobs:
       - name: Check expected artifacts exist
         shell: bash
         run: |
-          VERSIONS="stable-20220615 stable-20220908 stable-20221211 stable-20230418 cached latest nightly-latest"
+          VERSIONS="stable-20220615 stable-20220908 stable-20221211 stable-20230418 default latest nightly-latest"
           LANGUAGES="cpp csharp go java javascript python"
           for version in $VERSIONS; do
             for os in ubuntu-latest macos-latest; do

--- a/pr-checks/checks/init-with-registries.yml
+++ b/pr-checks/checks/init-with-registries.yml
@@ -6,7 +6,7 @@ name: "Packaging: Download using registries"
 description: "Checks that specifying a registries block and associated auth works as expected"
 versions: [
     # This feature is not compatible with older CLIs
-    "cached",
+    "default",
     "latest",
     "nightly-latest",
 ]

--- a/pr-checks/checks/javascript-source-root.yml
+++ b/pr-checks/checks/javascript-source-root.yml
@@ -1,6 +1,6 @@
 name: "Custom source root"
 description: "Checks that the argument specifying a non-default source root works"
-versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 operatingSystems: ["ubuntu"]
 steps:
   - name: Move codeql-action

--- a/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Config and input passed to the CLI"
 description: "Checks that specifying packages using a combination of a config file and input to the Action works"
-versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 
 env:
   CODEQL_PASS_CONFIG_TO_CLI: true

--- a/pr-checks/checks/packaging-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-config-inputs-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Config and input"
 description: "Checks that specifying packages using a combination of a config file and input to the Action works"
-versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-config-js.yml
+++ b/pr-checks/checks/packaging-config-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Config file"
 description: "Checks that specifying packages using only a config file works"
-versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-inputs-js.yml
+++ b/pr-checks/checks/packaging-inputs-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Action input"
 description: "Checks that specifying packages using the input to the Action works"
-versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/rubocop-multi-language.yml
+++ b/pr-checks/checks/rubocop-multi-language.yml
@@ -2,7 +2,7 @@ name: "RuboCop multi-language"
 description: "Tests using RuboCop to analyze a multi-language repository and then using the CodeQL Action to upload the resulting SARIF"
 operatingSystems: ["ubuntu"]
 # This check doesn't use CodeQL, so the `version` matrix variable is unused.
-versions: ["cached"]
+versions: ["default"]
 steps:
   - name: Set up Ruby
     uses: ruby/setup-ruby@v1

--- a/pr-checks/checks/ruby.yml
+++ b/pr-checks/checks/ruby.yml
@@ -1,6 +1,6 @@
 name: "Ruby analysis"
 description: "Tests creation of a Ruby database"
-versions: ["latest", "cached", "nightly-latest"]
+versions: ["latest", "default", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/split-workflow.yml
+++ b/pr-checks/checks/split-workflow.yml
@@ -1,7 +1,7 @@
 name: "Split workflow"
 description: "Tests a split-up workflow in which we first build a database and later analyze it"
 operatingSystems: ["ubuntu", "macos"]
-versions: ["latest", "cached", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/submit-sarif-failure.yml
+++ b/pr-checks/checks/submit-sarif-failure.yml
@@ -1,6 +1,6 @@
 name: Submit SARIF after failure
 description: Check that a SARIF file is submitted for the workflow run if it fails
-versions: ["latest", "cached", "nightly-latest"]
+versions: ["latest", "default", "nightly-latest"]
 operatingSystems: ["ubuntu"]
 
 env:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -1,6 +1,6 @@
 name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
-versions: ["latest", "cached", "nightly-latest"]
+versions: ["latest", "default", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -13,9 +13,11 @@ defaultTestVersions = [
     "stable-20221211",
     # The last CodeQL release in the 2.12 series: 2.12.7.
     "stable-20230418",
-    # The version of CodeQL currently in the toolcache. Typically either the latest release or the one before.
-    "cached",
-    # The latest release of CodeQL.
+    # The default version of CodeQL for Dotcom, as determined by feature flags.
+    "default",
+    # The version of CodeQL shipped with the Action in `defaults.json`. During the release process
+    # for a new CodeQL release, there will be a period of time during which this will be newer than
+    # the default version on Dotcom.
     "latest",
     # A nightly build directly from the our private repo, built in the last 24 hours.
     "nightly-latest"


### PR DESCRIPTION
Before controlled rollout, the CodeQL Action used to use the version of CodeQL in the toolcache by default.  However, the CodeQL Action now determines which version of CodeQL to run based on feature flags.  This PR updates the naming of the label associated with this default behavior from "cached" to "default" to avoid potential confusion.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
