### PR TITLE
PR Checks: Test `codeql-bundle.tar.gz`

### DIFF
--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |
         set -e # Fail this Action if `gh release list` fails.
 
-        if [[ ${{ inputs.require-codeql-bundle-all }} == "true" ]]; then
+        if [[ ${{ inputs.use-all-platform-bundle }} == "true" ]]; then
           artifact_name="codeql-bundle.tar.gz"
         elif [[ "$RUNNER_OS" == "Linux" ]]; then
           artifact_name="codeql-bundle-linux64.tar.gz"

--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -4,8 +4,8 @@ inputs:
   version:
     description: "The version of the CodeQL CLI to use. Can be 'latest', 'default', 'nightly-latest', 'nightly-YYYY-MM-DD', or 'stable-YYYY-MM-DD'."
     required: true
-  require-codeql-bundle-all:
-    description: "If true, we output a tools URL with codeql-bundle-all.tar.gz file rather than platform-specific URL"
+  use-all-platform-bundle:
+    description: "If true, we output a tools URL with codeql-bundle.tar.gz file rather than platform-specific URL"
     default: 'false'
     required: false
 outputs:

--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -4,6 +4,10 @@ inputs:
   version:
     description: "The version of the CodeQL CLI to use. Can be 'latest', 'default', 'nightly-latest', 'nightly-YYYY-MM-DD', or 'stable-YYYY-MM-DD'."
     required: true
+  require-codeql-bundle-all:
+    description: "If true, we output a tools URL with codeql-bundle-all.tar.gz file rather than platform-specific URL"
+    default: 'false'
+    required: false
 outputs:
   tools-url:
     description: "The value that should be passed as the 'tools' input of the 'init' step."
@@ -24,7 +28,9 @@ runs:
       run: |
         set -e # Fail this Action if `gh release list` fails.
 
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
+        if [[ ${{ inputs.require-codeql-bundle-all }} == "true" ]]; then
+          artifact_name="codeql-bundle.tar.gz"
+        elif [[ "$RUNNER_OS" == "Linux" ]]; then
           artifact_name="codeql-bundle-linux64.tar.gz"
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           artifact_name="codeql-bundle-osx64.tar.gz"

--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -3,7 +3,7 @@
 #     (cd pr-checks; pip install ruamel.yaml@0.17.31 && python3 sync.py)
 # to regenerate this file.
 
-name: PR Check - All platform bundle (autogen)
+name: PR Check - All-platform bundle
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GO111MODULE: auto
@@ -27,7 +27,7 @@ jobs:
         include:
         - os: ubuntu-latest
           version: nightly-latest
-    name: All platform bundle (autogen)
+    name: All-platform bundle
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -3,7 +3,7 @@
 #     (cd pr-checks; pip install ruamel.yaml@0.17.31 && python3 sync.py)
 # to regenerate this file.
 
-name: 'PR Check - Go: tracing with legacy workflow'
+name: PR Check - All platform bundle (autogen)
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GO111MODULE: auto
@@ -21,39 +21,13 @@ on:
     - ready_for_review
   workflow_dispatch: {}
 jobs:
-  go-tracing-legacy-workflow:
+  all-platform-bundle:
     strategy:
       matrix:
         include:
         - os: ubuntu-latest
-          version: stable-20220615
-        - os: macos-latest
-          version: stable-20220615
-        - os: ubuntu-latest
-          version: stable-20220908
-        - os: macos-latest
-          version: stable-20220908
-        - os: ubuntu-latest
-          version: stable-20221211
-        - os: macos-latest
-          version: stable-20221211
-        - os: ubuntu-latest
-          version: stable-20230418
-        - os: macos-latest
-          version: stable-20230418
-        - os: ubuntu-latest
-          version: default
-        - os: macos-latest
-          version: default
-        - os: ubuntu-latest
-          version: latest
-        - os: macos-latest
-          version: latest
-        - os: ubuntu-latest
           version: nightly-latest
-        - os: macos-latest
-          version: nightly-latest
-    name: 'Go: tracing with legacy workflow'
+    name: All platform bundle (autogen)
     permissions:
       contents: read
       security-events: write
@@ -67,7 +41,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
-        use-all-platform-bundle: 'false'
+        use-all-platform-bundle: 'true'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (
@@ -76,20 +50,18 @@ jobs:
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV
-    - uses: ./../action/init
+    - id: init
+      uses: ./../action/init
       with:
-        languages: go
         tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - uses: ./../action/.github/actions/setup-swift
+      with:
+        codeql-path: ${{ steps.init.outputs.codeql-path }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
     - uses: ./../action/analyze
       with:
         upload-database: false
-    - shell: bash
-      run: |
-        cd "$RUNNER_TEMP/codeql_databases"
-        if [[ ! -d go ]]; then
-          echo "Did not find a Go database"
-          exit 1
-        fi
     env:
-      DOTNET_GENERATE_ASPNET_CERTIFICATE: 'false'
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -81,6 +81,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -45,6 +45,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -51,6 +51,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -57,6 +57,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -45,6 +45,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -41,6 +41,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -81,6 +81,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -67,6 +67,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -67,6 +67,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -58,6 +58,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -45,6 +45,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__ml-powered-queries.yml
+++ b/.github/workflows/__ml-powered-queries.yml
@@ -81,6 +81,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -67,6 +67,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -57,6 +57,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -57,6 +57,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -57,6 +57,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -57,6 +57,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -81,6 +81,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -45,6 +45,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -41,6 +41,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -51,6 +51,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -67,6 +67,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -51,6 +51,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -45,6 +45,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -51,6 +51,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -41,6 +41,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -41,6 +41,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -41,6 +41,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -53,6 +53,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -81,6 +81,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -81,6 +81,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
+        use-all-platform-bundle: 'false'
     - name: Set environment variable for Swift enablement
       if: >-
         runner.os != 'Windows' && (

--- a/.github/workflows/test-codeql-bundle-all.yml
+++ b/.github/workflows/test-codeql-bundle-all.yml
@@ -1,0 +1,56 @@
+name: 'PR Check - CodeQL Bundle All'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+  # Disable Kotlin analysis while it's incompatible with Kotlin 1.8, until we find a
+  # workaround for our PR checks.
+  CODEQL_EXTRACTOR_JAVA_AGENT_DISABLE_KOTLIN: 'true'
+on:
+  push:
+    branches:
+    - main
+    - releases/v2
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+  workflow_dispatch: {}
+jobs:
+  test-codeql-bundle-all:
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-latest
+          version: nightly-latest
+    name: 'CodeQL Bundle All'
+    permissions:
+      contents: read
+      security-events: write
+    timeout-minutes: 45
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+    - name: Prepare test
+      id: prepare-test
+      uses: ./.github/actions/prepare-test
+      with:
+        version: ${{ matrix.version }}
+        require-codeql-bundle-all: true
+    - id: init
+      uses: ./../action/init
+      with:
+        tools: ${{ steps.prepare-test.outputs.tools-url }}
+    - uses: ./../action/.github/actions/setup-swift
+      with:
+        codeql-path: ${{ steps.init.outputs.codeql-path }}
+    - name: Build code
+      shell: bash
+      run: ./build.sh
+    - uses: ./../action/analyze
+      with:
+        upload-database: false
+    env:
+      CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/test-codeql-bundle-all.yml
+++ b/.github/workflows/test-codeql-bundle-all.yml
@@ -38,7 +38,7 @@ jobs:
       uses: ./.github/actions/prepare-test
       with:
         version: ${{ matrix.version }}
-        require-codeql-bundle-all: true
+        use-all-platform-bundle: true
     - id: init
       uses: ./../action/init
       with:

--- a/pr-checks/checks/all-platform-bundle.yml
+++ b/pr-checks/checks/all-platform-bundle.yml
@@ -1,0 +1,19 @@
+name: "All -platform bundle"
+description: "Tests using an all-platform CodeQL Bundle"
+versions: ["nightly-latest"]
+operatingSystems: ["ubuntu"]
+useAllPlatformBundle: "true"
+steps:
+  - id: init
+    uses: ./../action/init
+    with:
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+  - uses: ./../action/.github/actions/setup-swift
+    with:
+      codeql-path: ${{ steps.init.outputs.codeql-path }}
+  - name: Build code
+    shell: bash
+    run: ./build.sh
+  - uses: ./../action/analyze
+    with:
+      upload-database: false

--- a/pr-checks/checks/all-platform-bundle.yml
+++ b/pr-checks/checks/all-platform-bundle.yml
@@ -1,4 +1,4 @@
-name: "All -platform bundle"
+name: "All-platform bundle"
 description: "Tests using an all-platform CodeQL Bundle"
 versions: ["nightly-latest"]
 operatingSystems: ["ubuntu"]

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -63,6 +63,10 @@ for file in os.listdir('checks'):
                 'version': version
             })
 
+        useAllPlatformBundle = "false" # Default to false
+        if checkSpecification.get('useAllPlatformBundle'):
+            useAllPlatformBundle = checkSpecification['useAllPlatformBundle']
+
     steps = [
         {
             'name': 'Check out repository',
@@ -73,7 +77,8 @@ for file in os.listdir('checks'):
             'id': 'prepare-test',
             'uses': './.github/actions/prepare-test',
             'with': {
-                'version': '${{ matrix.version }}'
+                'version': '${{ matrix.version }}',
+                'use-all-platform-bundle': useAllPlatformBundle
             }
         },
         # We don't support Swift on Windows or prior versions of the CLI.


### PR DESCRIPTION
This PR check makes sure that we are testing the case where we use the non-platform specific `codeql-bundle.tar.gz` file for analysis. To do so, we've added a `use-all-platform-bundle` input to the `prepare-test` action that we set to true in the new PR check.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
