### PR TITLE
PR checks: Make Swift setup more consistent with default setup

### DIFF
--- a/.github/actions/setup-swift/action.yml
+++ b/.github/actions/setup-swift/action.yml
@@ -1,5 +1,5 @@
-name: "Set up Swift"
-description: Sets up an appropriate Swift version if supported on this platform.
+name: "Set up Swift on Linux"
+description: Sets up an appropriate Swift version on Linux.
 inputs:
   codeql-path:
     description: Path to the CodeQL CLI executable.
@@ -9,21 +9,16 @@ runs:
   steps:
     - name: Get Swift version
       id: get_swift_version
-      if: runner.os != 'Windows'
+      if: runner.os == 'Linux'
       shell: bash
       env: 
         CODEQL_PATH: ${{ inputs.codeql-path }}
       run: |
-        if [[ $RUNNER_OS = "macOS" ]]; then
-          PLATFORM="osx64"
-        else # We do not run this step on Windows.
-          PLATFORM="linux64"
-        fi 
         SWIFT_EXTRACTOR_DIR="$("$CODEQL_PATH" resolve languages --format json | jq -r '.swift[0]')"
         if [ $SWIFT_EXTRACTOR_DIR = "null" ]; then
           VERSION="null"
         else
-          VERSION="$("$SWIFT_EXTRACTOR_DIR/tools/$PLATFORM/extractor" --version | awk '/version/ { print $3 }')"
+          VERSION="$("$SWIFT_EXTRACTOR_DIR/tools/linux64/extractor" --version | awk '/version/ { print $3 }')"
           # Specify 5.x.0, otherwise setup Action will default to latest minor version. 
           if [ $VERSION = "5.7" ]; then
             VERSION="5.7.0"
@@ -37,6 +32,6 @@ runs:
         echo "version=$VERSION" | tee -a $GITHUB_OUTPUT
 
     - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf # Please update the corresponding SHA in the CLI's CodeQL Action Integration Test.
-      if: runner.os != 'Windows' && steps.get_swift_version.outputs.version != 'null'
+      if: runner.os == 'Linux' && steps.get_swift_version.outputs.version != 'null'
       with:
         swift-version: "${{ steps.get_swift_version.outputs.version }}"

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -62,7 +62,7 @@ jobs:
         CODEQL_FILE_BASELINE_INFORMATION: true
     - uses: ./../action/.github/actions/setup-swift
       with:
-        codeql-path: ${{steps.init.outputs.codeql-path}}
+        codeql-path: ${{ steps.init.outputs.codeql-path }}
     - name: Build code
       shell: bash
       run: ./build.sh

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -11,7 +11,7 @@ steps:
       CODEQL_FILE_BASELINE_INFORMATION: true
   - uses: ./../action/.github/actions/setup-swift
     with:
-      codeql-path: ${{steps.init.outputs.codeql-path}}
+      codeql-path: ${{ steps.init.outputs.codeql-path }}
   - name: Build code
     shell: bash
     run: ./build.sh


### PR DESCRIPTION
In default setup and the starter workflow, we don't setup Swift on macOS.  Therefore in our PR checks, let's do the same.  We continue setting up Swift on Linux, as we only run Swift on macOS in default setup and the starter workflow.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
