### PR TITLE
feat: bump to use node20 runtime, actions/checkout to v4

### DIFF
--- a/.github/actions/check-sarif/action.yml
+++ b/.github/actions/check-sarif/action.yml
@@ -16,5 +16,5 @@ inputs:
       Comma separated list of query ids that should NOT be included in this SARIF file.
 
 runs:
-  using: node16
+  using: node20
   main: index.js

--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -84,6 +84,6 @@ outputs:
   sarif-id:
     description: The ID of the uploaded SARIF file.
 runs:
-  using: "node16"
+  using: "node20"
   main: "../lib/analyze-action.js"
   post: "../lib/analyze-action-post.js"

--- a/autobuild/action.yml
+++ b/autobuild/action.yml
@@ -13,5 +13,5 @@ inputs:
       $GITHUB_WORKSPACE as its working directory.
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../lib/autobuild-action.js'

--- a/init/action.yml
+++ b/init/action.yml
@@ -44,7 +44,7 @@ inputs:
   db-location:
     description: Path where CodeQL databases should be created. If not specified, a temporary directory will be used.
     required: false
-  config:    
+  config:
     description: Configuration passed as a YAML string in the same format as the config-file input. This takes precedence over the config-file input.
     required: false
   queries:
@@ -108,6 +108,6 @@ outputs:
   codeql-path:
     description: The path of the CodeQL binary used for analysis
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../lib/init-action.js'
   post: '../lib/init-action-post.js'

--- a/resolve-environment/action.yml
+++ b/resolve-environment/action.yml
@@ -19,5 +19,5 @@ outputs:
   environment:
     description: The inferred build environment configuration.
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../lib/resolve-environment-action.js'

--- a/src/init-action-post-helper.test.ts
+++ b/src/init-action-post-helper.test.ts
@@ -87,7 +87,7 @@ test("uploads failed SARIF run with `diagnostics export` if feature flag is off"
   const actionsWorkflow = createTestWorkflow([
     {
       name: "Checkout repository",
-      uses: "actions/checkout@v3",
+      uses: "actions/checkout@v4",
     },
     {
       name: "Initialize CodeQL",
@@ -111,7 +111,7 @@ test("uploads failed SARIF run with `diagnostics export` if the database doesn't
   const actionsWorkflow = createTestWorkflow([
     {
       name: "Checkout repository",
-      uses: "actions/checkout@v3",
+      uses: "actions/checkout@v4",
     },
     {
       name: "Initialize CodeQL",
@@ -138,7 +138,7 @@ test("uploads failed SARIF run with database export-diagnostics if the database 
   const actionsWorkflow = createTestWorkflow([
     {
       name: "Checkout repository",
-      uses: "actions/checkout@v3",
+      uses: "actions/checkout@v4",
     },
     {
       name: "Initialize CodeQL",
@@ -195,7 +195,7 @@ for (const { uploadInput, shouldUpload } of UPLOAD_INPUT_TEST_CASES) {
     const actionsWorkflow = createTestWorkflow([
       {
         name: "Checkout repository",
-        uses: "actions/checkout@v3",
+        uses: "actions/checkout@v4",
       },
       {
         name: "Initialize CodeQL",
@@ -230,7 +230,7 @@ test("uploading failed SARIF run succeeds when workflow uses an input with a mat
   const actionsWorkflow = createTestWorkflow([
     {
       name: "Checkout repository",
-      uses: "actions/checkout@v3",
+      uses: "actions/checkout@v4",
     },
     {
       name: "Initialize CodeQL",
@@ -257,7 +257,7 @@ test("uploading failed SARIF run fails when workflow uses a complex upload input
   const actionsWorkflow = createTestWorkflow([
     {
       name: "Checkout repository",
-      uses: "actions/checkout@v3",
+      uses: "actions/checkout@v4",
     },
     {
       name: "Initialize CodeQL",
@@ -288,7 +288,7 @@ test("uploading failed SARIF run fails when workflow does not reference github/c
   const actionsWorkflow = createTestWorkflow([
     {
       name: "Checkout repository",
-      uses: "actions/checkout@v3",
+      uses: "actions/checkout@v4",
     },
   ]);
   const result = await testFailedSarifUpload(t, actionsWorkflow, {

--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -34,5 +34,5 @@ outputs:
   sarif-id:
     description: The ID of the uploaded SARIF file.
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../lib/upload-sarif-action.js'


### PR DESCRIPTION
### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.

-------

## Description and Context:

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to node20 (Node 20). I have also bumped the actions/checkout version to v4 for the same.

Related issue:

https://github.com/actions/runner/pull/2732

----

A major version bump might be needed after the PRs merge.