### PR TITLE
Remove --pr in update-dependencies.yml

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -36,6 +36,6 @@ jobs:
           git push origin "HEAD:$BRANCH"
           echo "Pushed a commit to update the checked-in dependencies." \
             "Please mark the PR as ready for review to trigger PR checks." |
-            gh pr comment --body-file - --repo github/codeql-action --pr "${{ github.event.pull_request.number }}"
-          gh pr ready --undo --repo github/codeql-action --pr "${{ github.event.pull_request.number }}"
+            gh pr comment --body-file - --repo github/codeql-action "${{ github.event.pull_request.number }}"
+          gh pr ready --undo --repo github/codeql-action "${{ github.event.pull_request.number }}"
         fi


### PR DESCRIPTION
This PR fixes the `unknown flag: --pr` error in "Update dependencies" workflow runs.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
