### PR TITLE
Update ignored version number in GHES versions automation

### DIFF
--- a/.github/workflows/update-supported-enterprise-server-versions/update.py
+++ b/.github/workflows/update-supported-enterprise-server-versions/update.py
@@ -17,8 +17,8 @@ def main():
 	releases = json.loads(_RELEASE_FILE_PATH.read_text())
 
 	# Remove GHES version using a previous version numbering scheme.
-	if "11.10.340" in releases:
-		del releases["11.10.340"]
+	if "11.10" in releases:
+		del releases["11.10"]
 
 	oldest_supported_release = None
 	newest_supported_release = semver.VersionInfo.parse(api_compatibility_data["maximumVersion"] + ".0")


### PR DESCRIPTION
The GHES versions automation looks up the GHES versions from an internal JSON file.  This contains a single version number from a previous numbering scheme, which we want to ignore as it is older than the 2.* and 3.* series.  Recently it was changed from 11.10.340 to 11.10, prompting the automation to open [a spurious update PR](https://github.com/github/codeql-action/pull/1878).

This PR updates the ignored version number to fix the automation.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
