### PR TITLE
Add `workflow_dispatch` manual trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
   schedule:
     # Weekly on Sunday.
     - cron: '30 1 * * 0'
+  workflow_dispatch:
 
 env:
   CODEQL_ACTION_TESTING_ENVIRONMENT: codeql-action-pr-checks


### PR DESCRIPTION
I'd like to be able to trigger this workflow manually, rather than wait for its scheduled instance or open a PR. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
