### PR TITLE
Use the correct action input parameter

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -46,7 +46,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -44,6 +44,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -52,7 +52,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -50,6 +50,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -80,6 +80,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -82,7 +82,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -66,7 +66,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -64,6 +64,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -66,7 +66,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -64,6 +64,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -66,7 +66,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -64,6 +64,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -53,7 +53,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -51,6 +51,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -66,7 +66,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -64,6 +64,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -52,7 +52,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -50,6 +50,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -52,7 +52,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -50,6 +50,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -52,7 +52,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -50,6 +50,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -52,7 +52,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -50,6 +50,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -80,6 +80,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -82,7 +82,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -58,7 +58,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -56,6 +56,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -46,7 +46,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -44,6 +44,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -66,7 +66,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -64,6 +64,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -46,7 +46,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -44,6 +44,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -46,7 +46,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -44,6 +44,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -36,7 +36,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -34,6 +34,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -50,7 +50,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -48,6 +48,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -40,7 +40,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -96,27 +96,42 @@ jobs:
         )
       shell: bash
       run: echo "CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT=true" >> $GITHUB_ENV
+    - name: Delete original checkout
+      shell: bash
+      run: |
+        # delete the original checkout so we don't accidentally use it.
+        # Actions does not support deleting the current working directory, so we
+        # delete the contents of the directory instead.
+        rm -rf ./* .github .git
+  # Check out the actions repo again, but at a different location.
+  # choose an arbitrary SHA so that we can later test that the commit_oid is not from main
     - uses: actions/checkout@v4
       with:
         ref: 474bbf07f9247ffe1856c6a0f94aeeb10e7afee6
         path: x/y/z/some-path
+
     - uses: ./../action/init
       with:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
       # it's enough to test one compiled language and one interpreted language
         languages: csharp,javascript
-        source-path: x/y/z/some-path/tests/multi-language-repo
+        source-root: x/y/z/some-path/tests/multi-language-repo
         debug: true
+
     - name: Build code (non-windows)
       shell: bash
       if: ${{ runner.os != 'Windows' }}
+      working-directory: x/y/z/some-path/tests/multi-language-repo
       run: |
-        $CODEQL_RUNNER x/y/z/some-path/tests/multi-language-repo/build.sh
+        $CODEQL_RUNNER ./build.sh
+
     - name: Build code (windows)
       shell: bash
       if: ${{ runner.os == 'Windows' }}
+      working-directory: x/y/z/some-path/tests/multi-language-repo
       run: |
-        x/y/z/some-path/tests/multi-language-repo/build.sh
+        ./build.sh
+
     - uses: ./../action/analyze
       with:
         checkout_path: x/y/z/some-path/tests/multi-language-repo

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -134,16 +134,8 @@ jobs:
         source-root: x/y/z/some-path/tests/multi-language-repo
         debug: true
 
-    - name: Build code (non-windows)
+    - name: Build code
       shell: bash
-      if: ${{ runner.os != 'Windows' }}
-      working-directory: x/y/z/some-path/tests/multi-language-repo
-      run: |
-        $CODEQL_RUNNER ./build.sh
-
-    - name: Build code (windows)
-      shell: bash
-      if: ${{ runner.os == 'Windows' }}
       working-directory: x/y/z/some-path/tests/multi-language-repo
       run: |
         ./build.sh

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: >-
         matrix.os == 'macos-latest' && (
 

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -80,6 +80,11 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Prepare test

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -82,7 +82,18 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: >-
+        matrix.os == 'macos-latest' && (
+
+        matrix.version == 'stable-20220908' ||
+
+        matrix.version == 'stable-20221211' ||
+
+        matrix.version == 'stable-20230418' ||
+
+        matrix.version == 'stable-v2.13.5' ||
+
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
     - name: Check out repository

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,7 +71,13 @@ jobs:
     steps:
       - name: Setup Python on MacOS
         uses: actions/setup-python@v2
-        if: matrix.os == 'macos-latest'
+        if: |
+          matrix.os == 'macos-latest' && (
+          matrix.version == 'stable-20220908' ||
+          matrix.version == 'stable-20221211' ||
+          matrix.version == 'stable-20230418' ||
+          matrix.version == 'stable-v2.13.5' ||
+          matrix.version == 'stable-v2.14.6')
         with:
           python-version: '3.11'
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,6 +69,12 @@ jobs:
     timeout-minutes: 45
 
     steps:
+      - name: Setup Python on MacOS
+        uses: actions/setup-python@v2
+        if: matrix.os == 'macos-latest'
+        with:
+          python-version: '3.11'
+
       - uses: actions/checkout@v4
       - name: npm test
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Setup Python on MacOS
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         if: |
           matrix.os == 'macos-latest' && (
           matrix.version == 'stable-20220908' ||

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -36,6 +36,12 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python_version }}
 
     steps:
+    - name: Setup Python on MacOS
+      uses: actions/setup-python@v2
+      if: matrix.os == 'macos-latest'
+      with:
+        python-version: '3.11'
+
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -38,7 +38,13 @@ jobs:
     steps:
     - name: Setup Python on MacOS
       uses: actions/setup-python@v2
-      if: matrix.os == 'macos-latest'
+      if: |
+        matrix.os == 'macos-latest' && (
+        matrix.version == 'stable-20220908' ||
+        matrix.version == 'stable-20221211' ||
+        matrix.version == 'stable-20230418' ||
+        matrix.version == 'stable-v2.13.5' ||
+        matrix.version == 'stable-v2.14.6')
       with:
         python-version: '3.11'
 

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Setup Python on MacOS
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: |
         matrix.os == 'macos-latest' && (
         matrix.version == 'stable-20220908' ||

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -1,29 +1,43 @@
 name: "Use a custom `checkout_path`"
 description: "Checks that a custom `checkout_path` will find the proper commit_oid"
 steps:
+  # This ensures we don't accidentally use the original checkout for any part of the test.
+  - name: Delete original checkout
+    shell: bash
+    run: |
+      # delete the original checkout so we don't accidentally use it.
+      # Actions does not support deleting the current working directory, so we
+      # delete the contents of the directory instead.
+      rm -rf ./* .github .git
   # Check out the actions repo again, but at a different location.
   # choose an arbitrary SHA so that we can later test that the commit_oid is not from main
   - uses: actions/checkout@v4
     with:
       ref: 474bbf07f9247ffe1856c6a0f94aeeb10e7afee6
       path: x/y/z/some-path
+
   - uses: ./../action/init
     with:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
       # it's enough to test one compiled language and one interpreted language
       languages: csharp,javascript
-      source-path: x/y/z/some-path/tests/multi-language-repo
+      source-root: x/y/z/some-path/tests/multi-language-repo
       debug: true
+
   - name: Build code (non-windows)
     shell: bash
     if: ${{ runner.os != 'Windows' }}
+    working-directory: x/y/z/some-path/tests/multi-language-repo
     run: |
-      $CODEQL_RUNNER x/y/z/some-path/tests/multi-language-repo/build.sh
+      $CODEQL_RUNNER ./build.sh
+
   - name: Build code (windows)
     shell: bash
     if: ${{ runner.os == 'Windows' }}
+    working-directory: x/y/z/some-path/tests/multi-language-repo
     run: |
-      x/y/z/some-path/tests/multi-language-repo/build.sh
+      ./build.sh
+
   - uses: ./../action/analyze
     with:
       checkout_path: x/y/z/some-path/tests/multi-language-repo

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -24,16 +24,8 @@ steps:
       source-root: x/y/z/some-path/tests/multi-language-repo
       debug: true
 
-  - name: Build code (non-windows)
+  - name: Build code
     shell: bash
-    if: ${{ runner.os != 'Windows' }}
-    working-directory: x/y/z/some-path/tests/multi-language-repo
-    run: |
-      $CODEQL_RUNNER ./build.sh
-
-  - name: Build code (windows)
-    shell: bash
-    if: ${{ runner.os == 'Windows' }}
     working-directory: x/y/z/some-path/tests/multi-language-repo
     run: |
       ./build.sh

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -76,7 +76,7 @@ for file in (this_dir / 'checks').glob('*.yml'):
     steps = [
         {
             'name': 'Setup Python on MacOS',
-            'uses': 'actions/setup-python@v2',
+            'uses': 'actions/setup-python@v4',
             # Ensure that this is serialized as a folded (`>`) string to preserve the readability
             # of the generated workflow.
             'if': FoldedScalarString(textwrap.dedent('''

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -75,6 +75,14 @@ for file in (this_dir / 'checks').glob('*.yml'):
 
     steps = [
         {
+            'name': 'Setup Python on MacOS',
+            'uses': 'actions/setup-python@v2',
+            'if': 'matrix.os == \'macos-latest\'',
+            'with': {
+                'python-version': '3.11'
+            }
+        },
+        {
             'name': 'Check out repository',
             'uses': 'actions/checkout@v4'
         },

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -77,7 +77,16 @@ for file in (this_dir / 'checks').glob('*.yml'):
         {
             'name': 'Setup Python on MacOS',
             'uses': 'actions/setup-python@v2',
-            'if': 'matrix.os == \'macos-latest\'',
+            # Ensure that this is serialized as a folded (`>`) string to preserve the readability
+            # of the generated workflow.
+            'if': FoldedScalarString(textwrap.dedent('''
+                    matrix.os == 'macos-latest' && (
+                    matrix.version == 'stable-20220908' ||
+                    matrix.version == 'stable-20221211' ||
+                    matrix.version == 'stable-20230418' ||
+                    matrix.version == 'stable-v2.13.5' ||
+                    matrix.version == 'stable-v2.14.6')
+            ''').strip()),
             'with': {
                 'python-version': '3.11'
             }


### PR DESCRIPTION
Fixes an integration test that isn't quite testing what we think it is.

Also, ensures that all macos tests run on python 3.11. See separate commits.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
