### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: local
+    hooks:
+      - id: compile-ts
+        name: Compile typescript
+        files: \.[tj]s$
+        language: system
+        entry: npm run build
+        pass_filenames: false
+      - id: lint-ts
+        name: Lint typescript code
+        files: \.ts$
+        language: system
+        entry: npm run lint -- --fix
+      - id: pr-checks-sync
+        name: Synchronize PR check workflows
+        files: ^.github/workflows/__.*\.yml$|^pr-checks
+        language: system
+        entry: python3 pr-checks/sync.py
+        pass_filenames: false

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
+
 import ruamel.yaml
 from ruamel.yaml.scalarstring import FoldedScalarString
-import os
+import pathlib
 import textwrap
 
 # The default set of CodeQL Bundle versions to use for the PR checks.
@@ -47,9 +49,11 @@ def writeHeader(checkStream):
 yaml = ruamel.yaml.YAML()
 yaml.Representer = NonAliasingRTRepresenter
 
+this_dir = pathlib.Path(__file__).resolve().parent
+
 allJobs = {}
-for file in os.listdir('checks'):
-    with open(f"checks/{file}", 'r') as checkStream:
+for file in (this_dir / 'checks').glob('*.yml'):
+    with open(file, 'r') as checkStream:
         checkSpecification = yaml.load(checkStream)
 
     matrix = []
@@ -126,9 +130,9 @@ for file in os.listdir('checks'):
     checkJob['env'] = checkJob.get('env', {})
     if 'CODEQL_ACTION_TEST_MODE' not in checkJob['env']:
         checkJob['env']['CODEQL_ACTION_TEST_MODE'] = True
-    checkName = file[:len(file) - 4]
+    checkName = file.stem
 
-    with open(f"../.github/workflows/__{checkName}.yml", 'w') as output_stream:
+    with open(this_dir.parent / ".github" / "workflows" / f"__{checkName}.yml", 'w') as output_stream:
         writeHeader(output_stream)
         yaml.dump({
             'name': f"PR Check - {checkSpecification['name']}",


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is a framework for easy set-up of pre-commit hooks.

This adds configuration for it to run:
* ts compilation
* ts linting
* pr-checks synchronization

The latter required the `sync.py` to be callable from the project root.

`pre-commit` can be enabled with
```
python3 -m pip install pre-commit
pre-commit install
```

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
