### PR TITLE
Add workflow to rebuild the Action on a label

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,0 +1,58 @@
+name: Rebuild Action
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  rebuild:
+    name: Rebuild Action
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Rebuild'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Remove label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit --repo github/codeql-action "$PR_NUMBER" \
+            --remove-label "Rebuild"
+
+      - name: Compile TypeScript
+        run: |
+          npm install
+          npm run lint -- --fix
+          npm run build
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Generate workflows
+        run: |
+          cd pr-checks
+          python -m pip install --upgrade pip
+          pip install ruamel.yaml==0.17.31
+          python3 sync.py
+
+      - name: Check for changes and push
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ ! -z "$(git status --porcelain)" ]; then
+            git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+            git commit -am "Rebuild"
+            git push origin "HEAD:$BRANCH"
+            echo "Pushed a commit to rebuild the Action." \
+              "Please mark the PR as ready for review to trigger PR checks." |
+              gh pr comment --body-file - --repo github/codeql-action "$PR_NUMBER"
+            gh pr ready --undo --repo github/codeql-action "$PR_NUMBER"
+          fi


### PR DESCRIPTION
Reduce friction when applying suggestions or handling merge conflicts via the GitHub UI.  Previously we needed to go back into the developer environment and rebuild.  Now we can apply a label and have Actions do it for us.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
