### PR TITLE
VSCode settings: set default formatter for TS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,8 @@
   "git.ignoreLimitWarning": true,
   // Use the vendored TypeScript version to have a consistent development experience across
   // machines.
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
 }


### PR DESCRIPTION
Tell VSCode to format TypeScript code with Prettier, since that's the same tool we use to check the format with `npm run lint`.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
