### PR TITLE
Fix failing workflows

### DIFF
--- a/.github/workflows/debug-artifacts-failure.yml
+++ b/.github/workflows/debug-artifacts-failure.yml
@@ -42,6 +42,17 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ^1.13.1
+      - name: Setup Python on MacOS
+        uses: actions/setup-python@v4
+        if: |
+          matrix.os == 'macos-latest' && (
+          matrix.version == 'stable-20220908' ||
+          matrix.version == 'stable-20221211' ||
+          matrix.version == 'stable-20230418' ||
+          matrix.version == 'stable-v2.13.5' ||
+          matrix.version == 'stable-v2.14.6')
+        with:
+          python-version: '3.11'
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}
@@ -52,7 +63,7 @@ jobs:
         shell: bash
         run: ./build.sh
       - uses: ./../action/analyze
-        id: analysis  
+        id: analysis
         with:
           expect-error: true
           ram: 1

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -49,6 +49,17 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ^1.13.1
+      - name: Setup Python on MacOS
+        uses: actions/setup-python@v4
+        if: |
+          matrix.os == 'macos-latest' && (
+          matrix.version == 'stable-20220908' ||
+          matrix.version == 'stable-20221211' ||
+          matrix.version == 'stable-20230418' ||
+          matrix.version == 'stable-v2.13.5' ||
+          matrix.version == 'stable-v2.14.6')
+        with:
+          python-version: '3.11'
       - uses: ./../action/init
         id: init
         with:
@@ -63,7 +74,7 @@ jobs:
         shell: bash
         run: ./build.sh
       - uses: ./../action/analyze
-        id: analysis  
+        id: analysis
   download-and-check-artifacts:
     name: Download and check debug artifacts
     needs: upload-artifacts


### PR DESCRIPTION
Ensure that pythion 3.11 is used for older CLIs on windows.

Similar to https://github.com/github/codeql-action/pull/1928.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
