### PR TITLE
Prepare for CodeQL v2.10.5 deprecation

### DIFF
--- a/lib/codeql.js
+++ b/lib/codeql.js
@@ -77,15 +77,15 @@ const CODEQL_MINIMUM_VERSION = "2.10.5";
 /**
  * This version will shortly become the oldest version of CodeQL that the Action will run with.
  */
-const CODEQL_NEXT_MINIMUM_VERSION = "2.10.5";
+const CODEQL_NEXT_MINIMUM_VERSION = "2.11.6";
 /**
  * This is the version of GHES that was most recently deprecated.
  */
-const GHES_VERSION_MOST_RECENTLY_DEPRECATED = "3.6";
+const GHES_VERSION_MOST_RECENTLY_DEPRECATED = "3.7";
 /**
  * This is the deprecation date for the version of GHES that was most recently deprecated.
  */
-const GHES_MOST_RECENT_DEPRECATION_DATE = "2023-09-12";
+const GHES_MOST_RECENT_DEPRECATION_DATE = "2023-11-08";
 /*
  * Versions of CodeQL that version-flag certain functionality in the Action.
  * For convenience, please keep these in descending order. Once a version

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -298,17 +298,17 @@ const CODEQL_MINIMUM_VERSION = "2.10.5";
 /**
  * This version will shortly become the oldest version of CodeQL that the Action will run with.
  */
-const CODEQL_NEXT_MINIMUM_VERSION = "2.10.5";
+const CODEQL_NEXT_MINIMUM_VERSION = "2.11.6";
 
 /**
  * This is the version of GHES that was most recently deprecated.
  */
-const GHES_VERSION_MOST_RECENTLY_DEPRECATED = "3.6";
+const GHES_VERSION_MOST_RECENTLY_DEPRECATED = "3.7";
 
 /**
  * This is the deprecation date for the version of GHES that was most recently deprecated.
  */
-const GHES_MOST_RECENT_DEPRECATION_DATE = "2023-09-12";
+const GHES_MOST_RECENT_DEPRECATION_DATE = "2023-11-08";
 
 /*
  * Versions of CodeQL that version-flag certain functionality in the Action.


### PR DESCRIPTION
Warn users of CodeQL v2.11.5 and earlier that the next minor release of the CodeQL Action will require CodeQL v2.11.6 or later.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
