### PR TITLE
add note on versioning approach to changelog

### DIFF
--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -133,8 +133,8 @@ jobs:
           # Update the version number ready for the next release
           npm version patch --no-git-tag-version
 
-          # Update the changelog
-          perl -i -pe 's/^/## \[UNRELEASED\]\n\nNo user facing changes.\n\n/ if($.==5)' CHANGELOG.md
+          # Update the changelog, adding a new version heading directly above the most recent existing one
+          awk '!f && /##/{print "'"## [UNRELEASED]\n\nNo user facing changes.\n"'"; f=1}1' CHANGELOG.md > temp && mv temp CHANGELOG.md
           git add .
           git commit -m "Update changelog and version after ${VERSION}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See the [releases page](https://github.com/github/codeql-action/releases) for the relevant changes to the CodeQL CLI and language packs.
 
-Note that for the CodeQL Action we use the major version number to mark a change in the node version used, while the minor & patch numbers indicate releases that support the same features across node versions. For example `3.22.11` is the first `v3` release and is functionally identical to `2.22.11`, which was released while we continue to support `v2`. This approach ensures an easy way to track exactly which features are included in different versions.
+Note that the only difference between `v2` and `v3` of the CodeQL Action is the node version they support, with `v3` running on node 20 while we continue to release `v2` to support running on node 16. This approach ensures an easy way to track exactly which features are included in different versions, indicated by the minor and patch version numbers.
 
 ## [UNRELEASED]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 See the [releases page](https://github.com/github/codeql-action/releases) for the relevant changes to the CodeQL CLI and language packs.
 
+Note that for the CodeQL Action we use the major version number to mark a change in the node version used, while the minor & patch numbers indicate releases that support the same features across node versions. For example `3.22.11` is the first `v3` release and is functionally identical to `2.22.11`, which was released while we continue to support `v2`. This approach ensures an easy way to track exactly which features are included in different versions.
+
 ## [UNRELEASED]
 
 No user facing changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See the [releases page](https://github.com/github/codeql-action/releases) for the relevant changes to the CodeQL CLI and language packs.
 
-Note that the only difference between `v2` and `v3` of the CodeQL Action is the node version they support, with `v3` running on node 20 while we continue to release `v2` to support running on node 16. This approach ensures an easy way to track exactly which features are included in different versions, indicated by the minor and patch version numbers.
+Note that the only difference between `v2` and `v3` of the CodeQL Action is the node version they support, with `v3` running on node 20 while we continue to release `v2` to support running on node 16. For example `3.22.11` was the first `v3` release and is functionally identical to `2.22.11`. This approach ensures an easy way to track exactly which features are included in different versions, indicated by the minor and patch version numbers.
 
 ## [UNRELEASED]
 


### PR DESCRIPTION
This PR adds a short explanation of our approach to version numbering at the top of the changelog.

It also ensures any change to the opening text is handled in the mergeback scripting, by anchoring the insertion of the new section to the existing `##` heading rather than the previous hardcoded line number.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
