### PR TITLE
backport checks changes to v2 branch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
+    strategy:
+      matrix:
+        node-types-version: [16.11, current] # we backport this matrix job in order to maintain the same check names
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +26,30 @@ jobs:
       - name: Lint
         run: npm run-script lint
 
+      - name: Update version of @types/node
+        if: matrix.node-types-version != 'current'
+        env:
+          NODE_TYPES_VERSION: ${{ matrix.node-types-version }}
+        run: |
+          # Export `NODE_TYPES_VERSION` so it's available to jq
+          export NODE_TYPES_VERSION="${NODE_TYPES_VERSION}"
+          contents=$(jq '.devDependencies."@types/node" = env.NODE_TYPES_VERSION' package.json)
+          echo "${contents}" > package.json
+          # Usually we run `npm install` on macOS to ensure that we pick up macOS-only dependencies.
+          # However we're not checking in the updated lockfile here, so it's fine to run
+          # `npm install` on Linux.
+          npm install
+
+          if [ ! -z "$(git status --porcelain)" ]; then
+            git config --global user.email "github-actions@github.com"
+            git config --global user.name "github-actions[bot]"
+            # The period in `git add --all .` ensures that we stage deleted files too.
+            git add --all .
+            git commit -m "Use @types/node=${NODE_TYPES_VERSION}"
+          fi
+
       - name: Check generated JS
+        if: matrix.node-types-version != 'current' # we do not need to test the newer node on the v2 branch
         run: .github/workflows/script/check-js.sh
 
   check-node-modules:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,9 @@ Since the `codeql-action` runs most of its testing through individual Actions wo
 
 1. By default, this script retrieves the checks from the latest SHA on `main`, so make sure that your `main` branch is up to date.
 2. Run the script. If there's a reason to, you can pass in a different SHA as a CLI argument.
-3. After running, go to the [branch protection rules settings page](https://github.com/github/codeql-action/settings/branches) and validate that the rules for `main`, `v1`, and `v2` have been updated.
+3. After running, go to the [branch protection rules settings page](https://github.com/github/codeql-action/settings/branches) and validate that the rules for `main`, `v2`, and `v3` have been updated.
+
+Note that any updates to checks need to be backported to the `releases/v2` branch, in order to maintain the same set of names for required checks.
 
 ## Deprecating a CodeQL version (write access required)
 
@@ -111,7 +113,7 @@ To deprecate an older version of the Action:
    - Add a changelog note announcing the deprecation.
    - Implement an Actions warning for customers using the deprecated version.
 1. Wait for the deprecation period to pass.
-1. Upgrade the Actions warning for customers using the deprecated version to a non-fatal error, and mention that this version of the Action is no longer supported. 
+1. Upgrade the Actions warning for customers using the deprecated version to a non-fatal error, and mention that this version of the Action is no longer supported.
 1. Make a PR to bump the `OLDEST_SUPPORTED_MAJOR_VERSION` in [release-branches.py](.github/actions/release-branches/release-branches.py).  Once this PR is merged, the release process will no longer backport changes to the deprecated release version.
 
 ## Resources


### PR DESCRIPTION
In order to keep alignment of check names across all the maintained branches, we backport the matrix job to the `releases/v2` branch.

The check runs on node 16 and skips for the current version (node 20).

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
