### PR TITLE
target new releases/v3 branch for required checks

### DIFF
--- a/.github/workflows/script/update-required-checks.sh
+++ b/.github/workflows/script/update-required-checks.sh
@@ -29,7 +29,7 @@ echo "$CHECKS" | jq
 
 echo "{\"contexts\": ${CHECKS}}" > checks.json
 
-for BRANCH in main releases/v2; do
+for BRANCH in main releases/v2 releases/v3; do
   echo "Updating $BRANCH"
   gh api --silent -X "PATCH" "repos/github/codeql-action/branches/$BRANCH/protection/required_status_checks" --input checks.json
 done


### PR DESCRIPTION

This PR adds `releases/v3` to the script that ensures required checks are kept up to date.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
