### PR TITLE
 Only run custom checkout path tests against a single CodeQL version 

### DIFF
--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -26,47 +26,11 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          version: stable-20221211
-        - os: macos-latest
-          version: stable-20221211
-        - os: windows-latest
-          version: stable-20221211
-        - os: ubuntu-latest
-          version: stable-20230418
-        - os: macos-latest
-          version: stable-20230418
-        - os: windows-latest
-          version: stable-20230418
-        - os: ubuntu-latest
-          version: stable-v2.13.5
-        - os: macos-latest
-          version: stable-v2.13.5
-        - os: windows-latest
-          version: stable-v2.13.5
-        - os: ubuntu-latest
-          version: stable-v2.14.6
-        - os: macos-latest
-          version: stable-v2.14.6
-        - os: windows-latest
-          version: stable-v2.14.6
-        - os: ubuntu-latest
-          version: default
-        - os: macos-latest
-          version: default
-        - os: windows-latest
-          version: default
-        - os: ubuntu-latest
           version: latest
         - os: macos-latest
           version: latest
         - os: windows-latest
           version: latest
-        - os: ubuntu-latest
-          version: nightly-latest
-        - os: macos-latest
-          version: nightly-latest
-        - os: windows-latest
-          version: nightly-latest
     name: Use a custom `checkout_path`
     permissions:
       contents: read

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -84,7 +84,6 @@ jobs:
       # it's enough to test one compiled language and one interpreted language
         languages: csharp,javascript
         source-root: x/y/z/some-path/tests/multi-language-repo
-        debug: true
 
     - name: Build code
       shell: bash

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -1,5 +1,6 @@
 name: "Use a custom `checkout_path`"
 description: "Checks that a custom `checkout_path` will find the proper commit_oid"
+versions: ["latest"]
 steps:
   # This ensures we don't accidentally use the original checkout for any part of the test.
   - name: Delete original checkout

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -23,7 +23,6 @@ steps:
       # it's enough to test one compiled language and one interpreted language
       languages: csharp,javascript
       source-root: x/y/z/some-path/tests/multi-language-repo
-      debug: true
 
   - name: Build code
     shell: bash


### PR DESCRIPTION
These tests do not depend on the CodeQL version.

Also disable debug mode in checkout path tests.  This avoids uploading debug artifacts, which takes a while.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
