### PR TITLE
Stop running debug artifacts checks on MacOS

### DIFF
--- a/.github/workflows/debug-artifacts-failure.yml
+++ b/.github/workflows/debug-artifacts-failure.yml
@@ -20,15 +20,12 @@ on:
   workflow_dispatch: {}
 jobs:
   upload-artifacts:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
     name: Upload debug artifacts after failure in analyze
     continue-on-error: true
     env:
       CODEQL_ACTION_TEST_MODE: true
     timeout-minutes: 45
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub event
         run: cat "${GITHUB_EVENT_PATH}"
@@ -67,27 +64,24 @@ jobs:
       - name: Check expected artifacts exist
         shell: bash
         run: |
-          OPERATING_SYSTEMS="ubuntu-latest macos-latest"
           LANGUAGES="cpp csharp go java javascript python"
-          for os in $OPERATING_SYSTEMS; do
-            pushd "./my-debug-artifacts-$os"
-            echo "Artifacts from run on $os:"
-            for language in $LANGUAGES; do
-              echo "- Checking $language"
-              if [[ ! -f "my-db-$language-partial.zip" ]] ; then
-                echo "Missing a partial database bundle for $language"
-                exit 1
-              fi
-              if [[ ! -d "log" ]] ; then
-                echo "Missing database initialization logs"
-                exit 1
-              fi
-              if [[ ! "$language" == "go" ]] && [[ ! -d "$language/log" ]] ; then
-                echo "Missing logs for $language"
-                exit 1
-              fi
-            done
-            popd
+          pushd "./my-debug-artifacts"
+          echo "Artifacts from run:"
+          for language in $LANGUAGES; do
+            echo "- Checking $language"
+            if [[ ! -f "my-db-$language-partial.zip" ]] ; then
+              echo "Missing a partial database bundle for $language"
+              exit 1
+            fi
+            if [[ ! -d "log" ]] ; then
+              echo "Missing database initialization logs"
+              exit 1
+            fi
+            if [[ ! "$language" == "go" ]] && [[ ! -d "$language/log" ]] ; then
+              echo "Missing logs for $language"
+              exit 1
+            fi
           done
+          popd
         env:
           GO111MODULE: auto

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -21,9 +21,6 @@ jobs:
   upload-artifacts:
     strategy:
       matrix:
-        os:
-        - ubuntu-latest
-        - macos-latest
         version:
         - stable-20221211
         - stable-20230418
@@ -36,7 +33,7 @@ jobs:
     env:
       CODEQL_ACTION_TEST_MODE: true
     timeout-minutes: 45
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -48,16 +45,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.13.1
-      - name: Setup Python on MacOS
-        uses: actions/setup-python@v5
-        if: |
-          matrix.os == 'macos-latest' && (
-          matrix.version == 'stable-20221211' ||
-          matrix.version == 'stable-20230418' ||
-          matrix.version == 'stable-v2.13.5' ||
-          matrix.version == 'stable-v2.14.6')
-        with:
-          python-version: '3.11'
       - uses: ./../action/init
         id: init
         with:
@@ -87,26 +74,24 @@ jobs:
           VERSIONS="stable-20221211 stable-20230418 stable-v2.13.5 stable-v2.14.6 default latest nightly-latest"
           LANGUAGES="cpp csharp go java javascript python"
           for version in $VERSIONS; do
-            for os in ubuntu-latest macos-latest; do
-              pushd "./my-debug-artifacts-$os-${version//./}"
-              echo "Artifacts from version $version on $os:"
-              for language in $LANGUAGES; do
-                echo "- Checking $language"
-                if [[ ! -f "$language.sarif" ]] ; then
-                  echo "Missing a SARIF file for $language"
-                  exit 1
-                fi
-                if [[ ! -f "my-db-$language.zip" ]] ; then
-                  echo "Missing a database bundle for $language"
-                  exit 1
-                fi
-                if [[ ! -d "$language/log" ]] ; then
-                  echo "Missing logs for $language"
-                  exit 1
-                fi
-              done
-              popd
+            pushd "./my-debug-artifacts-${version//./}"
+            echo "Artifacts from version $version:"
+            for language in $LANGUAGES; do
+              echo "- Checking $language"
+              if [[ ! -f "$language.sarif" ]] ; then
+                echo "Missing a SARIF file for $language"
+                exit 1
+              fi
+              if [[ ! -f "my-db-$language.zip" ]] ; then
+                echo "Missing a database bundle for $language"
+                exit 1
+              fi
+              if [[ ! -d "$language/log" ]] ; then
+                echo "Missing logs for $language"
+                exit 1
+              fi
             done
+            popd
           done
         env:
           GO111MODULE: auto


### PR DESCRIPTION
These checks take a while, and there's no specific reason to run them on MacOS in particular. We run them only on `ubuntu-latest` instead. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
