### PR TITLE
Add backticks around branch in update-release-branch PR template

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -60,7 +60,7 @@ def open_pr(
 
   # Start constructing the body text
   body = []
-  body.append(f'Merging {source_branch_short_sha} into {target_branch}.')
+  body.append(f'Merging {source_branch_short_sha} into `{target_branch}`.')
 
   body.append('')
   body.append(f'Conductor for this PR is @{conductor}.')
@@ -92,7 +92,7 @@ def open_pr(
       'branch to resolve the merge conflicts.')
   body.append(' - [ ] Ensure the CHANGELOG displays the correct version and date.')
   body.append(' - [ ] Ensure the CHANGELOG includes all relevant, user-facing changes since the last release.')
-  body.append(f' - [ ] Check that there are not any unexpected commits being merged into the {target_branch} branch.')
+  body.append(f' - [ ] Check that there are not any unexpected commits being merged into the `{target_branch}` branch.')
   body.append(' - [ ] Ensure the docs team is aware of any documentation changes that need to be released.')
 
   if not is_primary_release:


### PR DESCRIPTION
Most of the replaced content generated by this script are links (SHAs, users, PRs). In general, it's really helpful for non-boilerplate content to be easily recognizable, and links are a good way to do that. As branches come and go, it isn't practical to use links for that purpose, but it is possible to use backticks to call out the branch name.

With these changes, https://github.com/github/codeql-action/pull/2131#issue-2132405833 would have looked like this:

> Merging [c79c360](https://github.com/github/codeql-action/commit/c79c360e02b1d0dbe91a088f7cf6de2c9f8c85b9) into `releases/v3`.
> 
> Conductor for this PR is ....
> 
> Contains the following pull requests:
> 
> ...
> 
> Please do the following:
> 
> * [x]  Ensure the CHANGELOG displays the correct version and date.
> * [x]  Ensure the CHANGELOG includes all relevant, user-facing changes since the last release.
> * [x]  Check that there are not any unexpected commits being merged into the `releases/v3` branch.
> * [x]  Ensure the docs team is aware of any documentation changes that need to be released.
> * [x]  Mark the PR as ready for review to trigger the full set of PR checks.
> * [x]  Approve and merge this PR. Make sure `Create a merge commit` is selected rather than `Squash and merge` or `Rebase and merge`.
> * [x]  Merge the mergeback PR that will automatically be created once this PR is merged.
> * [ ]  Merge all backport PRs to older release branches, that will automatically be created once this PR is merged.

And I think that's much more readable -- it's very easy to see that `releases/v3` is a branch and interesting as opposed to just prose.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
