### PR TITLE
Prepare `build-mode` input help

### DIFF
--- a/init/action.yml
+++ b/init/action.yml
@@ -18,20 +18,22 @@ inputs:
     required: false
   build-mode:
     description: >-
-      [Experimental, for internal testing only] The build mode that will be used to analyze the language.
-      This input is only available in single-language analyses.
+      The build mode that will be used to analyze the language. This input is only available when
+      analyzing a single CodeQL language per job, for example using a matrix.
 
       Available build modes will differ based on the language being analyzed. One of: 
 
-      - none:      The database will be created without building the source code.
-                   Available for all interpreted languages and some compiled languages.
-      - autobuild: The database will be created by attempting to automatically build the source code.
-                   To use this build mode, ensure that your workflow calls the `autobuild` action
-                   between the `init` and `analyze` steps.
-                   Available for all compiled languages.
-      - manual:    The database will be created by building the source code using a manually specified
-                   build command. To use this build mode, specify manual build steps in your workflow
-                   between the `init` and `analyze` steps. Available for all compiled languages.
+      - `none`:      The database will be created without building the source code.
+                     Available for all interpreted languages and some compiled languages.
+      - `autobuild`: The database will be created by attempting to automatically build the source
+                     code.
+                     To use this build mode, ensure that your workflow calls the `autobuild` action
+                     between the `init` and `analyze` steps.
+                     Available for all compiled languages.
+      - `manual`:   The database will be created by building the source code using a manually
+                     specified build command. To use this build mode, specify manual build steps in
+                     your workflow between the `init` and `analyze` steps. Available for all
+                     compiled languages.
     required: false
   token:
     description: GitHub token to use for authenticating with this instance of GitHub. To download custom packs from multiple registries, use the registries input.

--- a/init/action.yml
+++ b/init/action.yml
@@ -8,7 +8,13 @@ inputs:
     # If not specified the Action will check in several places until it finds the CodeQL tools.
   languages:
     description: |
-      A comma-separated value of the languages to be analysed e.g. python,javascript
+      A comma-separated list of CodeQL languages to analyze.
+
+      Due to the performance benefit of parallelizing builds, we recommend specifying languages to
+      analyze using a matrix and providing `${{ matrix.language }}` as this input.
+
+      For more information, see
+      https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed.
     required: false
   build-mode:
     description: >-


### PR DESCRIPTION
Remove the experimental qualifiers in preparation for this to be used more widely.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
