### PR TITLE
Fail `analyze` step in PR check by passing an invalid option to `database finalize`

### DIFF
--- a/.github/workflows/debug-artifacts-failure.yml
+++ b/.github/workflows/debug-artifacts-failure.yml
@@ -50,9 +50,11 @@ jobs:
         run: ./build.sh
       - uses: ./../action/analyze
         id: analysis
+        env: 
+          # Forces a failure in this step.
+          CODEQL_ACTION_EXTRA_OPTIONS: '{ "database": { "finalize": ["--invalid-option"] } }'
         with:
           expect-error: true
-          ram: 1
   download-and-check-artifacts:
     name: Download and check debug artifacts after failure in analyze
     needs: upload-artifacts


### PR DESCRIPTION
The `ram: 1` trick won't work anymore with recent updates to the CLI, so we need to find an alternate way to fail the `analyze` step here. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
