### PR TITLE
Remove "experimental" designation from `packs` input

### DIFF
--- a/init/action.yml
+++ b/init/action.yml
@@ -78,7 +78,7 @@ inputs:
     required: false
   packs:
     description: >-
-      [Experimental] Comma-separated list of packs to run. Reference a pack in the format `scope/name[@version]`. If `version` is not
+      Comma-separated list of packs to run. Reference a pack in the format `scope/name[@version]`. If `version` is not
       specified, then the latest version of the pack is used. By default, this overrides the same setting in a
       configuration file; prefix with "+" to use both sets of packs.
 


### PR DESCRIPTION
The `packs` input to `init` is no longer experimental.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
