### PR TITLE
Move `@types/node` to bottom of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,6 @@
     "removeNPMAbsolutePaths": "3.0.1",
     "sinon": "^17.0.1",
     "typescript": "^5.4.3",
-
-
-
     "@types/node": "20.9.0"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@types/adm-zip": "^0.5.5",
     "@types/get-folder-size": "^2.0.0",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "20.9.0",
     "@types/semver": "^7.5.8",
     "@types/sinon": "^17.0.3",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
@@ -73,7 +72,11 @@
     "nock": "^13.5.4",
     "removeNPMAbsolutePaths": "3.0.1",
     "sinon": "^17.0.1",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.3",
+
+
+
+    "@types/node": "20.9.0"
   },
   "overrides": {
     "@actions/tool-cache": {


### PR DESCRIPTION
This will make it less likely for a dependabot update to cause conflicts when backporting from v3 -> v2. It's a little clunky, but should probably work.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
