### PR TITLE
Use `merge=union` for `package.json`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,10 @@
 lib/*.js linguist-generated=true
 .github/workflows/__* linguist-generated=true
 
-# Reduce incidence of needless merge conflicts on CHANGELOG.md
+# Reduce incidence of needless merge conflicts on CHANGELOG.md and package.json
 # The man page at
 # https://mirrors.edge.kernel.org/pub/software/scm/git/docs/gitattributes.html
 # suggests that this might interleave lines arbitrarily, but empirically
 # it keeps added chunks contiguous
 CHANGELOG.md                merge=union
+package.json                merge=union


### PR DESCRIPTION
Occasionally the v3 -> v2 mergeback script for releases fails due to a merge conflict in `package.json`.

Specifically, when the line below "@types/node" (currently "@types/semver") is [bumped in the Action](https://github.com/github/codeql-action/blob/294b6df61d4812e7497e15a9d0f240a97f453b45/package.json#L60) by Dependabot, there is a merge conflict between v3 and v2 because node should be version 20 for v3 and version 16 for v2.

Then the call to `npm version` [in the release script](https://github.com/github/codeql-action/blob/1aae1e7090c64083768b852cc5f59346312fb276/.github/update-release-branch.py#L377) fails because the file is no longer valid JSON due to the merge conflict; so the mergeback PR is not created at all and the release conductor needs to resolve the conflict and restart the script locally.

This change adds `merge=union` as a git attribute for `package.json` so that if there is a merge conflict, both changes will be included. This will prevent parsing errors in `package.json` — at least it will be valid JSON — when `npm version` is run (the release conductor will need to manually edit the file to resolve the merge conflict, but that's already part of the autogenerated checklist that's created in the associated PR. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
