### PR TITLE
Run release process using Python 3.12

### DIFF
--- a/.github/actions/release-initialise/action.yml
+++ b/.github/actions/release-initialise/action.yml
@@ -18,12 +18,12 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install PyGithub==1.55 requests
+        pip install PyGithub==2.3.0 requests
       shell: bash
 
     - name: Update git config


### PR DESCRIPTION
We made a change in #2269 that requires Python >=3.9, and we might as well get back on the latest version. 

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
