### PR TITLE
Disable `fail-fast` for PR checks

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   all-platform-bundle:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   analyze-ref-input:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   autobuild-action:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__autobuild-direct-tracing.yml
+++ b/.github/workflows/__autobuild-direct-tracing.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   autobuild-direct-tracing:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__build-mode-autobuild.yml
+++ b/.github/workflows/__build-mode-autobuild.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   build-mode-autobuild:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   build-mode-manual:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__build-mode-none.yml
+++ b/.github/workflows/__build-mode-none.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   build-mode-none:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__build-mode-rollback.yml
+++ b/.github/workflows/__build-mode-rollback.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   build-mode-rollback:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   config-export:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__config-input.yml
+++ b/.github/workflows/__config-input.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   config-input:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   cpp-deptrace-disabled:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   cpp-deptrace-enabled-on-macos:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   cpp-deptrace-enabled:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   diagnostics-export:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   export-file-baseline-information:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   extractor-ram-threads:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   go-custom-queries:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   go-indirect-tracing-workaround-diagnostic:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   go-indirect-tracing-workaround-no-file-program:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   go-indirect-tracing-workaround:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   go-tracing-autobuilder:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   go-tracing-custom-build-steps:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   go-tracing-legacy-workflow:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   init-with-registries:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   javascript-source-root:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   language-aliases:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   multi-language-autodetect:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   packaging-codescanning-config-inputs-js:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   packaging-config-inputs-js:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   packaging-config-js:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   packaging-inputs-js:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   remote-config:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   resolve-environment-action:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   rubocop-multi-language:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   ruby:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   scaling-reserved-ram:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   split-workflow:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   submit-sarif-failure:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   swift-custom-build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   test-autobuild-working-dir:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   test-local-codeql:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   test-proxy:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   unset-environment:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   upload-ref-sha-input:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   with-checkout-path:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,6 +73,7 @@ jobs:
   build:
     needs: [check-codeql-versions]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04,ubuntu-22.04,windows-2019,windows-2022,macos-11,macos-12,macos-13]
         tools: ${{ fromJson(needs.check-codeql-versions.outputs.versions) }}

--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -24,6 +24,7 @@ jobs:
     continue-on-error: true
 
     strategy:
+      fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   upload-artifacts:
     strategy:
+      fail-fast: false
       matrix:
         version:
         - stable-20230403

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         node-types-version: [16.11, current] # run tests on 16.11 while CodeQL Action v2 is still supported
 
@@ -89,6 +90,7 @@ jobs:
     name: Unit Test
     needs: [check-js, check-node-modules]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-codeql-bundle-all.yml
+++ b/.github/workflows/test-codeql-bundle-all.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   test-codeql-bundle-all:
     strategy:
+      fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -117,6 +117,7 @@ for file in (this_dir / 'checks').glob('*.yml'):
 
     checkJob = {
         'strategy': {
+            'fail-fast': False,
             'matrix': {
                 'include': matrix
             }


### PR DESCRIPTION
We have found `fail-fast` has been getting in the way more than it's been helping recently.  For example:

- Sometimes only a particular set of versions or OSes are broken, and we want to let the other checks complete so we can know the full set.
- We see quite a large degree of parallelism when running the checks, so most of the jobs have nearly finished anyway when they are cancelled by `fail-fast`.
- `fail-fast` deals better with transient failures.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
