### PR TITLE
Update docs for `build-mode: autobuild`

### DIFF
--- a/init/action.yml
+++ b/init/action.yml
@@ -36,10 +36,7 @@ inputs:
       - `none`:      The database will be created without building the source code.
                      Available for all interpreted languages and some compiled languages.
       - `autobuild`: The database will be created by attempting to automatically build the source
-                     code.
-                     To use this build mode, ensure that your workflow calls the `autobuild` action
-                     between the `init` and `analyze` steps.
-                     Available for all compiled languages.
+                     code. Available for all compiled languages.
       - `manual`:   The database will be created by building the source code using a manually
                      specified build command. To use this build mode, specify manual build steps in
                      your workflow between the `init` and `analyze` steps. Available for all


### PR DESCRIPTION
The `autobuild` Action is no longer needed or recommended when a build mode is specified.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
