### PR TITLE
PR Checks: disable tests for Swift on Linux until CLI 2.17.4

### DIFF
--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -28,36 +28,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            version: stable-20230403
           - os: macos-12
             version: stable-20230403
-          - os: ubuntu-latest
-            version: stable-v2.13.5
           - os: macos-12
             version: stable-v2.13.5
-          - os: ubuntu-latest
-            version: stable-v2.14.6
           - os: macos-12
             version: stable-v2.14.6
-          - os: ubuntu-latest
-            version: stable-v2.15.5
           - os: macos-latest
             version: stable-v2.15.5
-          - os: ubuntu-latest
-            version: stable-v2.16.6
           - os: macos-latest
             version: stable-v2.16.6
-          - os: ubuntu-latest
-            version: default
           - os: macos-latest
             version: default
-          - os: ubuntu-latest
-            version: latest
           - os: macos-latest
             version: latest
-          - os: ubuntu-latest
-            version: nightly-latest
           - os: macos-latest
             version: nightly-latest
     name: Multi-language repository

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -28,36 +28,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            version: stable-20230403
           - os: macos-12
             version: stable-20230403
-          - os: ubuntu-latest
-            version: stable-v2.13.5
           - os: macos-12
             version: stable-v2.13.5
-          - os: ubuntu-latest
-            version: stable-v2.14.6
           - os: macos-12
             version: stable-v2.14.6
-          - os: ubuntu-latest
-            version: stable-v2.15.5
           - os: macos-latest
             version: stable-v2.15.5
-          - os: ubuntu-latest
-            version: stable-v2.16.6
           - os: macos-latest
             version: stable-v2.16.6
-          - os: ubuntu-latest
-            version: default
           - os: macos-latest
             version: default
-          - os: ubuntu-latest
-            version: latest
           - os: macos-latest
             version: latest
-          - os: ubuntu-latest
-            version: nightly-latest
           - os: macos-latest
             version: nightly-latest
     name: Scaling reserved RAM

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -28,16 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            version: latest
           - os: macos-latest
             version: latest
-          - os: ubuntu-latest
-            version: default
           - os: macos-latest
             version: default
-          - os: ubuntu-latest
-            version: nightly-latest
           - os: macos-latest
             version: nightly-latest
     name: Swift analysis using a custom build command

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -28,21 +28,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: macos-12
             version: stable-20230403
-          - os: ubuntu-latest
+          - os: macos-12
             version: stable-v2.13.5
-          - os: ubuntu-latest
+          - os: macos-12
             version: stable-v2.14.6
-          - os: ubuntu-latest
+          - os: macos-latest
             version: stable-v2.15.5
-          - os: ubuntu-latest
+          - os: macos-latest
             version: stable-v2.16.6
-          - os: ubuntu-latest
+          - os: macos-latest
             version: default
-          - os: ubuntu-latest
+          - os: macos-latest
             version: latest
-          - os: ubuntu-latest
+          - os: macos-latest
             version: nightly-latest
     name: Test unsetting environment variables
     permissions:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -79,6 +79,9 @@ jobs:
       - uses: ./../action/.github/actions/setup-swift
         with:
           codeql-path: ${{ steps.init.outputs.codeql-path }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
       - name: Build code
         shell: bash
     # Disable Kotlin analysis while it's incompatible with Kotlin 1.8, until we find a

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -29,19 +29,15 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            version: stable-20230403
-          - os: macos-12
-            version: stable-v2.13.5
-          - os: macos-12
             version: stable-v2.14.6
           - os: macos-latest
             version: stable-v2.15.5
           - os: macos-latest
             version: stable-v2.16.6
           - os: macos-latest
-            version: default
-          - os: macos-latest
             version: latest
+          - os: macos-latest
+            version: default
           - os: macos-latest
             version: nightly-latest
     name: Test unsetting environment variables

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -26,7 +26,8 @@ jobs:
       matrix:
         version:
         # TODO: Once CLI v2.17.4 is available and the platform is switched back to ubuntu,
-        #       stable-20230403, stable-v2.13.5, and stable-v2.14.6 can be added back to this matrix.
+        #       stable-20230403, stable-v2.13.5, and stable-v2.14.6 can be added back to this matrix,
+        #       and the VERSIONS variable in the bash script below. 
         #       Prior to CLI v2.15.1, ARM runners were not supported by the build tracer.
         - stable-v2.15.5
         - stable-v2.16.6
@@ -75,7 +76,7 @@ jobs:
       - name: Check expected artifacts exist
         shell: bash
         run: |
-          VERSIONS="stable-20230403 stable-v2.13.5 stable-v2.14.6 stable-v2.15.5 stable-v2.16.6 default latest nightly-latest"
+          VERSIONS="stable-v2.15.5 stable-v2.16.6 default latest nightly-latest"
           LANGUAGES="cpp csharp go java javascript python"
           for version in $VERSIONS; do
             pushd "./my-debug-artifacts-${version//./}"

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -25,9 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-        - stable-20230403
-        - stable-v2.13.5
-        - stable-v2.14.6
+        # TODO: Once CLI v2.17.4 is available and the platform is switched back to ubuntu,
+        #       stable-20230403, stable-v2.13.5, and stable-v2.14.6 can be added back to this matrix.
+        #       Prior to CLI v2.15.1, ARM runners were not supported by the build tracer.
         - stable-v2.15.5
         - stable-v2.16.6
         - default

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       CODEQL_ACTION_TEST_MODE: true
     timeout-minutes: 45
-    runs-on: ubuntu-latest
+    runs-on: macos-latest # TODO: Switch back to ubuntu for `nightly-latest` and `latest` once CLI v2.17.4 is available.
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -1,6 +1,7 @@
 name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
-operatingSystems: ["ubuntu", "macos"]
+# TODO: Add ubuntu back for `nightly-latest` and `latest` once CLI v2.17.4 is available.
+operatingSystems: ["macos"] 
 steps:
   - uses: actions/setup-go@v5
     with:

--- a/pr-checks/checks/scaling-reserved-ram.yml
+++ b/pr-checks/checks/scaling-reserved-ram.yml
@@ -1,6 +1,7 @@
 name: "Scaling reserved RAM"
 description: "An end-to-end integration test of a multi-language repository with the scaling_reserved_ram feature flag enabled"
-operatingSystems: ["ubuntu", "macos"]
+# TODO: Add ubuntu back for `nightly-latest` and `latest` once CLI v2.17.4 is available.
+operatingSystems: ["macos"]
 env:
   CODEQL_ACTION_SCALING_RESERVED_RAM: true
 steps:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -1,7 +1,8 @@
 name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
 versions: ["latest", "default", "nightly-latest"]
-operatingSystems: ["ubuntu", "macos"]
+# TODO: Add ubuntu back for `nightly-latest` and `latest` once CLI v2.17.4 is available.
+operatingSystems: ["macos"] 
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -1,5 +1,7 @@
 name: "Test unsetting environment variables"
 description: "An end-to-end integration test that unsets some environment variables"
+# TODO: Switch back to all versions once CLI v2.17.4 is available and running on ubuntu again.
+versions: ["stable-v2.14.6", "stable-v2.15.5", "stable-v2.16.6", "latest", "default", "nightly-latest"] 
 operatingSystems: ["macos"] # TODO: Switch back to ubuntu for `nightly-latest` and `latest` once CLI v2.17.4 is available.
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -1,6 +1,6 @@
 name: "Test unsetting environment variables"
 description: "An end-to-end integration test that unsets some environment variables"
-operatingSystems: ["ubuntu"]
+operatingSystems: ["macos"] # TODO: Switch back to ubuntu for `nightly-latest` and `latest` once CLI v2.17.4 is available.
 steps:
   - uses: ./../action/init
     id: init

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -10,6 +10,9 @@ steps:
   - uses: ./../action/.github/actions/setup-swift
     with:
       codeql-path: ${{ steps.init.outputs.codeql-path }}
+  - uses: actions/setup-go@v5
+    with:
+      go-version: '>=1.21.0'
   - name: Build code
     shell: bash
     # Disable Kotlin analysis while it's incompatible with Kotlin 1.8, until we find a


### PR DESCRIPTION
With the new Linux runner image rollout and CLI versions <= 2.17.3, all PR checks with Swift are failing. This PR disables those tests to unblock CI for now. When CLI version 2.17.4 makes it to `nightly-latest` and `latest`, we will re-enable these tests.

The failing PR checks that were previously running on both `ubuntu` and `macos` have been updated to only run on `macos` for now. The failing PR checks that were previously running on only `ubuntu` have also been updated to only run on `macos` for now, so that we are at least covering these checks on one operating system. 

Now that the debug artifacts check runs on `macos` instead of `ubuntu`, old versions of the CLI <2.15.1 are experiencing the known build tracer bug on ARM Macs, so those are disabled for now as well. We programmatically disabled those for the generated PR checks in https://github.com/github/codeql-action/pull/2261. 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
