### PR TITLE
PR Checks: Use `tools: linked` rather than `tools: latest`

### DIFF
--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -2,7 +2,7 @@ name: "Prepare test"
 description: Performs some preparation to run tests
 inputs:
   version:
-    description: "The version of the CodeQL CLI to use. Can be 'latest', 'default', 'nightly-latest', 'nightly-YYYY-MM-DD', or 'stable-YYYY-MM-DD'."
+    description: "The version of the CodeQL CLI to use. Can be 'linked', 'default', 'nightly-latest', 'nightly-YYYY-MM-DD', or 'stable-YYYY-MM-DD'."
     required: true
   use-all-platform-bundle:
     description: "If true, we output a tools URL with codeql-bundle.tar.gz file rather than platform-specific URL"
@@ -50,8 +50,8 @@ runs:
         elif [[ ${{ inputs.version }} == *"stable"* ]]; then
           version=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
           echo "tools-url=https://github.com/github/codeql-action/releases/download/codeql-bundle-$version/$artifact_name" >> $GITHUB_OUTPUT
-        elif [[ ${{ inputs.version }} == "latest" ]]; then
-          echo "tools-url=latest" >> $GITHUB_OUTPUT
+        elif [[ ${{ inputs.version }} == "linked" ]]; then
+          echo "tools-url=linked" >> $GITHUB_OUTPUT
         elif [[ ${{ inputs.version }} == "default" ]]; then
           echo "tools-url=" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
     name: autobuild-action
     permissions:
       contents: read

--- a/.github/workflows/__autobuild-direct-tracing.yml
+++ b/.github/workflows/__autobuild-direct-tracing.yml
@@ -29,9 +29,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: windows-latest

--- a/.github/workflows/__build-mode-none.yml
+++ b/.github/workflows/__build-mode-none.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
     name: Build mode none

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__config-input.yml
+++ b/.github/workflows/__config-input.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
     name: Config input
     permissions:
       contents: read

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: ubuntu-latest

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: ubuntu-latest

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -35,11 +35,11 @@ jobs:
           - os: windows-latest
             version: stable-20230403
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
     name: Extractor ram and threads options test
     permissions:
       contents: read

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -65,11 +65,11 @@ jobs:
           - os: windows-latest
             version: default
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -53,9 +53,9 @@ jobs:
           - os: macos-latest
             version: default
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -53,9 +53,9 @@ jobs:
           - os: macos-latest
             version: default
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -53,9 +53,9 @@ jobs:
           - os: macos-latest
             version: default
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -35,11 +35,11 @@ jobs:
           - os: windows-latest
             version: default
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: ubuntu-latest

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
     name: Language aliases
     permissions:
       contents: read

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -41,7 +41,7 @@ jobs:
           - os: macos-latest
             version: default
           - os: macos-latest
-            version: latest
+            version: linked
           - os: macos-latest
             version: nightly-latest
     name: Multi-language repository

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -65,11 +65,11 @@ jobs:
           - os: windows-latest
             version: default
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -41,11 +41,11 @@ jobs:
           - os: windows-latest
             version: default
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
           - os: macos-latest

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -29,9 +29,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -41,7 +41,7 @@ jobs:
           - os: macos-latest
             version: default
           - os: macos-latest
-            version: latest
+            version: linked
           - os: macos-latest
             version: nightly-latest
     name: Scaling reserved RAM

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -29,9 +29,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: default
           - os: ubuntu-latest

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            version: latest
+            version: linked
           - os: macos-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
     name: Autobuild working directory
     permissions:
       contents: read

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
     name: Proxy test
     permissions:
       contents: read

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-latest
             version: stable-v2.16.6
           - os: macos-latest
-            version: latest
+            version: linked
           - os: macos-latest
             version: default
           - os: macos-latest

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: macos-latest
-            version: latest
+            version: linked
           - os: windows-latest
-            version: latest
+            version: linked
     name: Use a custom `checkout_path`
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
       id: init-latest
       uses: ./init
       with:
-        tools: latest
+        tools: linked
         languages: javascript
     - name: Compare default and latest CodeQL bundle versions
       id: compare
@@ -54,16 +54,16 @@ jobs:
         echo "Default CodeQL bundle version is $CODEQL_VERSION_DEFAULT"
         echo "Latest CodeQL bundle version is $CODEQL_VERSION_LATEST"
 
-        # If we're running on a pull request, run with both bundles, even if `tools: latest` would
+        # If we're running on a pull request, run with both bundles, even if `tools: linked` would
         # be the same as `tools: null`. This allows us to make the job for each of the bundles a
         # required status check.
         #
-        # If we're running on push or schedule, then we can skip running with `tools: latest` when it would be
+        # If we're running on push or schedule, then we can skip running with `tools: linked` when it would be
         # the same as running with `tools: null`.
         if [[ "$GITHUB_EVENT_NAME" != "pull_request" && "$CODEQL_VERSION_DEFAULT" == "$CODEQL_VERSION_LATEST" ]]; then
           VERSIONS_JSON='[null]'
         else
-          VERSIONS_JSON='[null, "latest"]'
+          VERSIONS_JSON='[null, "linked"]'
         fi
 
         # Output a JSON-encoded list with the distinct versions to test against.

--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -28,9 +28,9 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          version: latest
+          version: linked
         - os: macos-latest
-          version: latest
+          version: linked
         - os: ubuntu-latest
           version: default
         - os: macos-latest

--- a/.github/workflows/debug-artifacts-failure.yml
+++ b/.github/workflows/debug-artifacts-failure.yml
@@ -37,7 +37,7 @@ jobs:
         id: prepare-test
         uses: ./.github/actions/prepare-test
         with:
-          version: latest
+          version: linked
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.13.1

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -32,13 +32,13 @@ jobs:
         - stable-v2.15.5
         - stable-v2.16.6
         - default
-        - latest
+        - linked
         - nightly-latest
     name: Upload debug artifacts
     env:
       CODEQL_ACTION_TEST_MODE: true
     timeout-minutes: 45
-    runs-on: macos-latest # TODO: Switch back to ubuntu for `nightly-latest` and `latest` once CLI v2.17.4 is available.
+    runs-on: macos-latest # TODO: Switch back to ubuntu for `nightly-latest` and `linked` once CLI v2.17.4 is available.
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       - name: Check expected artifacts exist
         shell: bash
         run: |
-          VERSIONS="stable-v2.15.5 stable-v2.16.6 default latest nightly-latest"
+          VERSIONS="stable-v2.15.5 stable-v2.16.6 default linked nightly-latest"
           LANGUAGES="cpp csharp go java javascript python"
           for version in $VERSIONS; do
             pushd "./my-debug-artifacts-${version//./}"

--- a/.github/workflows/expected-queries-runs.yml
+++ b/.github/workflows/expected-queries-runs.yml
@@ -29,7 +29,7 @@ jobs:
       id: prepare-test
       uses: ./.github/actions/prepare-test
       with:
-        version: latest
+        version: linked
     - uses: ./../action/init
       with:
         languages: javascript

--- a/.github/workflows/python312-windows.yml
+++ b/.github/workflows/python312-windows.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Initialize CodeQL
       uses: ./../action/init
       with:
-        tools: latest
+        tools: linked
         languages: python
 
     - name: Analyze

--- a/.github/workflows/query-filters.yml
+++ b/.github/workflows/query-filters.yml
@@ -27,7 +27,7 @@ jobs:
       id: prepare-test
       uses: ./.github/actions/prepare-test
       with:
-        version: latest
+        version: linked
 
     - name: Check SARIF for default queries with Single include, Single exclude
       uses: ./../action/.github/actions/query-filter-test

--- a/.github/workflows/update-bundle.yml
+++ b/.github/workflows/update-bundle.yml
@@ -54,7 +54,7 @@ jobs:
           cli_version=$(jq -r '.cliVersion' src/defaults.json)
           pr_url=$(gh pr create \
             --title "Update default bundle to $cli_version" \
-            --body "This pull request updates the default CodeQL bundle, as used with \`tools: latest\` and on GHES, to $cli_version." \
+            --body "This pull request updates the default CodeQL bundle, as used with \`tools: linked\` and on GHES, to $cli_version." \
             --assignee "$GITHUB_ACTOR" \
             --draft \
           )

--- a/pr-checks/checks/autobuild-action.yml
+++ b/pr-checks/checks/autobuild-action.yml
@@ -1,6 +1,6 @@
 name: "autobuild-action"
 description: "Tests that the C# autobuild action works"
-versions: ["latest"]
+versions: ["linked"]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/autobuild-direct-tracing.yml
+++ b/pr-checks/checks/autobuild-direct-tracing.yml
@@ -1,7 +1,7 @@
 name: "Autobuild direct tracing"
 description: "An end-to-end integration test of a Java repository built using 'build-mode: autobuild', with direct tracing enabled"
 operatingSystems: ["ubuntu", "windows"]
-versions: ["latest", "nightly-latest"]
+versions: ["linked", "nightly-latest"]
 env:
   CODEQL_ACTION_AUTOBUILD_BUILD_MODE_DIRECT_TRACING: true
 steps:

--- a/pr-checks/checks/build-mode-none.yml
+++ b/pr-checks/checks/build-mode-none.yml
@@ -1,7 +1,7 @@
 name: "Build mode none"
 description: "An end-to-end integration test of a Java repository built using 'build-mode: none'"
 operatingSystems: ["ubuntu"]
-versions: ["latest", "nightly-latest"]
+versions: ["linked", "nightly-latest"]
 steps:
   - uses: ./../action/init
     id: init

--- a/pr-checks/checks/config-export.yml
+++ b/pr-checks/checks/config-export.yml
@@ -1,6 +1,6 @@
 name: "Config export"
 description: "Tests that the code scanning configuration file is exported to SARIF correctly."
-versions: ["latest", "nightly-latest"]
+versions: ["linked", "nightly-latest"]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/config-input.yml
+++ b/pr-checks/checks/config-input.yml
@@ -1,7 +1,7 @@
 name: "Config input"
 description: "Tests specifying configuration using the config input"
 operatingSystems: ["ubuntu"]
-versions: ["latest"]
+versions: ["linked"]
 steps:
   - name: Copy queries into workspace
     run: |

--- a/pr-checks/checks/cpp-deptrace-disabled.yml
+++ b/pr-checks/checks/cpp-deptrace-disabled.yml
@@ -1,7 +1,7 @@
 name: "C/C++: disabling autoinstalling dependencies (Linux)"
 description: "Checks that running C/C++ autobuild with autoinstalling dependencies explicitly disabled works"
 operatingSystems: ["ubuntu"]
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with CLIs < 2.15.0
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with CLIs < 2.15.0
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:

--- a/pr-checks/checks/cpp-deptrace-enabled.yml
+++ b/pr-checks/checks/cpp-deptrace-enabled.yml
@@ -1,7 +1,7 @@
 name: "C/C++: autoinstalling dependencies (Linux)"
 description: "Checks that running C/C++ autobuild with autoinstalling dependencies works"
 operatingSystems: ["ubuntu"]
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with CLIs < 2.15.0
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with CLIs < 2.15.0
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:

--- a/pr-checks/checks/diagnostics-export.yml
+++ b/pr-checks/checks/diagnostics-export.yml
@@ -2,7 +2,7 @@ name: "Diagnostic export"
 description: "Tests that manually added diagnostics are correctly exported to SARIF."
 # Test on 2.12.6 (which requires a workaround in the Action), the latest release, and the latest
 # nightly.
-versions: ["stable-20230403", "latest", "nightly-latest"]
+versions: ["stable-20230403", "linked", "nightly-latest"]
 env:
   CODEQL_ACTION_EXPORT_DIAGNOSTICS: true
 steps:

--- a/pr-checks/checks/extractor-ram-threads.yml
+++ b/pr-checks/checks/extractor-ram-threads.yml
@@ -1,6 +1,6 @@
 name: "Extractor ram and threads options test"
 description: "Tests passing RAM and threads limits to extractors"
-versions: ["latest"]
+versions: ["linked"]
 operatingSystems: ["ubuntu"]
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/init-with-registries.yml
+++ b/pr-checks/checks/init-with-registries.yml
@@ -7,7 +7,7 @@ description: "Checks that specifying a registries block and associated auth work
 versions: [
     # This feature is not compatible with older CLIs
     "default",
-    "latest",
+    "linked",
     "nightly-latest",
 ]
 

--- a/pr-checks/checks/javascript-source-root.yml
+++ b/pr-checks/checks/javascript-source-root.yml
@@ -1,6 +1,6 @@
 name: "Custom source root"
 description: "Checks that the argument specifying a non-default source root works"
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 operatingSystems: ["ubuntu"]
 steps:
   - name: Move codeql-action

--- a/pr-checks/checks/language-aliases.yml
+++ b/pr-checks/checks/language-aliases.yml
@@ -1,6 +1,6 @@
 name: "Language aliases"
 description: "Tests that language aliases are resolved correctly"
-versions: ["latest"]
+versions: ["linked"]
 operatingSystems: ["ubuntu"]
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Config and input passed to the CLI"
 description: "Checks that specifying packages using a combination of a config file and input to the Action works"
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-config-inputs-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Config and input"
 description: "Checks that specifying packages using a combination of a config file and input to the Action works"
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-config-js.yml
+++ b/pr-checks/checks/packaging-config-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Config file"
 description: "Checks that specifying packages using only a config file works"
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-inputs-js.yml
+++ b/pr-checks/checks/packaging-inputs-js.yml
@@ -1,6 +1,6 @@
 name: "Packaging: Action input"
 description: "Checks that specifying packages using the input to the Action works"
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/resolve-environment-action.yml
+++ b/pr-checks/checks/resolve-environment-action.yml
@@ -1,6 +1,6 @@
 name: "Resolve environment"
 description: "Tests that the resolve-environment action works for Go and JavaScript/TypeScript"
-versions: ["stable-v2.13.4", "default", "latest", "nightly-latest"]
+versions: ["stable-v2.13.4", "default", "linked", "nightly-latest"]
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/ruby.yml
+++ b/pr-checks/checks/ruby.yml
@@ -1,6 +1,6 @@
 name: "Ruby analysis"
 description: "Tests creation of a Ruby database"
-versions: ["latest", "default", "nightly-latest"]
+versions: ["linked", "default", "nightly-latest"]
 operatingSystems: ["ubuntu", "macos"]
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/split-workflow.yml
+++ b/pr-checks/checks/split-workflow.yml
@@ -1,7 +1,7 @@
 name: "Split workflow"
 description: "Tests a split-up workflow in which we first build a database and later analyze it"
 operatingSystems: ["ubuntu", "macos"]
-versions: ["latest", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/submit-sarif-failure.yml
+++ b/pr-checks/checks/submit-sarif-failure.yml
@@ -1,6 +1,6 @@
 name: Submit SARIF after failure
 description: Check that a SARIF file is submitted for the workflow run if it fails
-versions: ["latest", "default", "nightly-latest"]
+versions: ["linked", "default", "nightly-latest"]
 operatingSystems: ["ubuntu"]
 
 env:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -1,6 +1,6 @@
 name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
-versions: ["latest", "default", "nightly-latest"]
+versions: ["linked", "default", "nightly-latest"]
 # TODO: Add ubuntu back for `nightly-latest` and `latest` once CLI v2.17.4 is available.
 operatingSystems: ["macos"] 
 env:

--- a/pr-checks/checks/test-autobuild-working-dir.yml
+++ b/pr-checks/checks/test-autobuild-working-dir.yml
@@ -1,6 +1,6 @@
 name: "Autobuild working directory"
 description: "Tests working-directory input of autobuild action"
-versions: ["latest"]
+versions: ["linked"]
 operatingSystems: ["ubuntu"]
 steps:
   - name: Test setup

--- a/pr-checks/checks/test-proxy.yml
+++ b/pr-checks/checks/test-proxy.yml
@@ -1,6 +1,6 @@
 name: "Proxy test"
 description: "Tests using a proxy specified by the https_proxy environment variable"
-versions: ["latest"]
+versions: ["linked"]
 operatingSystems: ["ubuntu"]
 container:
   image: ubuntu:22.04

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -1,7 +1,7 @@
 name: "Test unsetting environment variables"
 description: "An end-to-end integration test that unsets some environment variables"
 # TODO: Switch back to all versions once CLI v2.17.4 is available and running on ubuntu again.
-versions: ["stable-v2.14.6", "stable-v2.15.5", "stable-v2.16.6", "latest", "default", "nightly-latest"] 
+versions: ["stable-v2.14.6", "stable-v2.15.5", "stable-v2.16.6", "linked", "default", "nightly-latest"] 
 operatingSystems: ["macos"] # TODO: Switch back to ubuntu for `nightly-latest` and `latest` once CLI v2.17.4 is available.
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -1,6 +1,6 @@
 name: "Use a custom `checkout_path`"
 description: "Checks that a custom `checkout_path` will find the proper commit_oid"
-versions: ["latest"]
+versions: ["linked"]
 steps:
   # This ensures we don't accidentally use the original checkout for any part of the test.
   - name: Delete original checkout

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -22,7 +22,7 @@ defaultTestVersions = [
     # The version of CodeQL shipped with the Action in `defaults.json`. During the release process
     # for a new CodeQL release, there will be a period of time during which this will be newer than
     # the default version on Dotcom.
-    "latest",
+    "linked",
     # A nightly build directly from the our private repo, built in the last 24 hours.
     "nightly-latest"
 ]


### PR DESCRIPTION
As of https://github.com/github/codeql-action/pull/2281, we introduced `linked` as a more descriptive value for the `tools` input. This PR updates our own PR checks and workflows with the new value and changes the input/output in the `prepare-test` Action to use `linked`.

All of the required PR checks that had `latest` in their names, for `main` have been updated. As we release `v3` and `v2` we'll want to do the same for those branches.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
