### PR TITLE
Fix bash syntax

### DIFF
--- a/.github/workflows/script/update-node-modules.sh
+++ b/.github/workflows/script/update-node-modules.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-if [ "$1" != "update" && "$1" != "check-only" ]; then
+if [ "$1" != "update" ] && [ "$1" != "check-only" ]; then
     >&2 echo "Failed: Invalid argument. Must be 'update' or 'check-only'"
     exit 1
 fi


### PR DESCRIPTION
This should stop

    .github/workflows/script/update-node-modules.sh: line 1: [: missing `]'
