### PR TITLE
Remove macOS 11 check and add macOS 14

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,3 +97,5 @@ jobs:
       run: ${{steps.init.outputs.codeql-path}} version --format=json
     - name: Perform CodeQL Analysis
       uses: ./analyze
+      with:
+        category: "/language:javascript"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04,ubuntu-22.04,windows-2019,windows-2022,macos-11,macos-12,macos-13]
+        os: [ubuntu-20.04,ubuntu-22.04,windows-2019,windows-2022,macos-12,macos-13,macos-14]
         tools: ${{ fromJson(needs.check-codeql-versions.outputs.versions) }}
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The macOS 11 runner image is deprecated on Dotcom.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
