### PR TITLE
PR check generator: add `excludeOsAndVersionCombination`

### DIFF
--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -39,9 +39,15 @@ jobs:
             version: stable-v2.16.6
           - os: macos-latest
             version: default
+          - os: ubuntu-latest
+            version: default
           - os: macos-latest
             version: linked
+          - os: ubuntu-latest
+            version: linked
           - os: macos-latest
+            version: nightly-latest
+          - os: ubuntu-latest
             version: nightly-latest
     name: Multi-language repository
     permissions:

--- a/.github/workflows/__scaling-reserved-ram.yml
+++ b/.github/workflows/__scaling-reserved-ram.yml
@@ -39,9 +39,15 @@ jobs:
             version: stable-v2.16.6
           - os: macos-latest
             version: default
+          - os: ubuntu-latest
+            version: default
           - os: macos-latest
             version: linked
+          - os: ubuntu-latest
+            version: linked
           - os: macos-latest
+            version: nightly-latest
+          - os: ubuntu-latest
             version: nightly-latest
     name: Scaling reserved RAM
     permissions:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -29,9 +29,15 @@ jobs:
         include:
           - os: macos-latest
             version: linked
+          - os: ubuntu-latest
+            version: linked
           - os: macos-latest
             version: default
+          - os: ubuntu-latest
+            version: default
           - os: macos-latest
+            version: nightly-latest
+          - os: ubuntu-latest
             version: nightly-latest
     name: Swift analysis using a custom build command
     permissions:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -27,17 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-12
-            version: stable-v2.14.6
-          - os: macos-latest
-            version: stable-v2.15.5
-          - os: macos-latest
-            version: stable-v2.16.6
-          - os: macos-latest
-            version: linked
-          - os: macos-latest
+          - os: ubuntu-latest
             version: default
-          - os: macos-latest
+          - os: ubuntu-latest
+            version: linked
+          - os: ubuntu-latest
             version: nightly-latest
     name: Test unsetting environment variables
     permissions:

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -22,12 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-        # TODO: Once CLI v2.17.4 is available and the platform is switched back to ubuntu,
-        #       stable-20230403, stable-v2.13.5, and stable-v2.14.6 can be added back to this matrix,
-        #       and the VERSIONS variable in the bash script below. 
-        #       Prior to CLI v2.15.1, ARM runners were not supported by the build tracer.
+        - stable-20230403
+        - stable-v2.13.5
+        - stable-v2.14.6
         - stable-v2.15.5
-        - stable-v2.16.6
         - default
         - linked
         - nightly-latest
@@ -35,7 +33,7 @@ jobs:
     env:
       CODEQL_ACTION_TEST_MODE: true
     timeout-minutes: 45
-    runs-on: macos-latest # TODO: Switch back to ubuntu for `nightly-latest` and `linked` once CLI v2.17.4 is available.
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -73,7 +71,7 @@ jobs:
       - name: Check expected artifacts exist
         shell: bash
         run: |
-          VERSIONS="stable-v2.15.5 stable-v2.16.6 default linked nightly-latest"
+          VERSIONS="stable-20230403 stable-v2.13.5 stable-v2.14.6 stable-v2.15.5 default linked nightly-latest"
           LANGUAGES="cpp csharp go java javascript python"
           for version in $VERSIONS; do
             pushd "./my-debug-artifacts-${version//./}"

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -1,7 +1,14 @@
 name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
-# TODO: Add ubuntu back for `nightly-latest` and `latest` once CLI v2.17.4 is available.
-operatingSystems: ["macos"] 
+operatingSystems: ["macos", "ubuntu"]
+excludeOsAndVersionCombination: [ 
+  # Known failure for Swift on Linux before CLI v2.17.4.
+  [ "ubuntu", "stable-20230403" ], 
+  [ "ubuntu", "stable-v2.13.5" ], 
+  [ "ubuntu", "stable-v2.14.6" ], 
+  [ "ubuntu", "stable-v2.15.5" ],
+  [ "ubuntu", "stable-v2.16.6" ],
+]
 steps:
   - uses: actions/setup-go@v5
     with:

--- a/pr-checks/checks/scaling-reserved-ram.yml
+++ b/pr-checks/checks/scaling-reserved-ram.yml
@@ -1,7 +1,14 @@
 name: "Scaling reserved RAM"
 description: "An end-to-end integration test of a multi-language repository with the scaling_reserved_ram feature flag enabled"
-# TODO: Add ubuntu back for `nightly-latest` and `latest` once CLI v2.17.4 is available.
-operatingSystems: ["macos"]
+operatingSystems: ["macos", "ubuntu"]
+excludeOsAndVersionCombination: [ 
+  # Known failure for Swift on Linux before CLI v2.17.4.
+  [ "ubuntu", "stable-20230403" ], 
+  [ "ubuntu", "stable-v2.13.5" ], 
+  [ "ubuntu", "stable-v2.14.6" ], 
+  [ "ubuntu", "stable-v2.15.5" ],
+  [ "ubuntu", "stable-v2.16.6" ],
+]
 env:
   CODEQL_ACTION_SCALING_RESERVED_RAM: true
 steps:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -1,8 +1,7 @@
 name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
 versions: ["linked", "default", "nightly-latest"]
-# TODO: Add ubuntu back for `nightly-latest` and `latest` once CLI v2.17.4 is available.
-operatingSystems: ["macos"] 
+operatingSystems: ["macos", "ubuntu"]
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -1,8 +1,15 @@
 name: "Test unsetting environment variables"
 description: "An end-to-end integration test that unsets some environment variables"
-# TODO: Switch back to all versions once CLI v2.17.4 is available and running on ubuntu again.
-versions: ["stable-v2.14.6", "stable-v2.15.5", "stable-v2.16.6", "linked", "default", "nightly-latest"] 
-operatingSystems: ["macos"] # TODO: Switch back to ubuntu for `nightly-latest` and `latest` once CLI v2.17.4 is available.
+operatingSystems: ["ubuntu"]
+excludeOsAndVersionCombination: [ 
+  # Known failure for Swift on Linux before CLI v2.17.4.
+  [ "ubuntu", "stable-20230403" ], 
+  [ "ubuntu", "stable-v2.13.5" ], 
+  [ "ubuntu", "stable-v2.14.6" ], 
+  [ "ubuntu", "stable-v2.15.5" ],
+  [ "ubuntu", "stable-v2.16.6" ],
+]
+
 steps:
   - uses: ./../action/init
     id: init

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -27,7 +27,7 @@ defaultTestVersions = [
     "nightly-latest"
 ]
 
-def is_os_and_version_excluded(version, os, exclude_params):
+def is_os_and_version_excluded(os, version, exclude_params):
     for exclude_param in exclude_params:
         if exclude_param[0] == os and exclude_param[1] == version:
             return True
@@ -73,7 +73,7 @@ for file in (this_dir / 'checks').glob('*.yml'):
 
             for runnerImage in runnerImagesForOs:
                 # Skip appending this combination to the matrix if it is explicitly excluded.
-                if is_os_and_version_excluded(version, operatingSystem, excludedOsesAndVersions):
+                if is_os_and_version_excluded(operatingSystem, version, excludedOsesAndVersions):
                     continue
 
                 # Prior to CLI v2.15.1, ARM runners were not supported by the build tracer.

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -27,7 +27,7 @@ defaultTestVersions = [
     "nightly-latest"
 ]
 
-def is_version_and_os_excluded(version, os, exclude_params):
+def is_os_and_version_excluded(version, os, exclude_params):
     for exclude_param in exclude_params:
         if exclude_param[0] == os and exclude_param[1] == version:
             return True
@@ -63,7 +63,7 @@ for file in (this_dir / 'checks').glob('*.yml'):
     with open(file, 'r') as checkStream:
         checkSpecification = yaml.load(checkStream)
     matrix = []
-    excludedVersionsAndOses = checkSpecification.get('excludeOsAndVersionCombination', [])
+    excludedOsesAndVersions = checkSpecification.get('excludeOsAndVersionCombination', [])
     for version in checkSpecification.get('versions', defaultTestVersions):
         runnerImages = ["ubuntu-latest", "macos-latest", "windows-latest"]            
         operatingSystems = checkSpecification.get('operatingSystems', ["ubuntu", "macos", "windows"])
@@ -73,7 +73,7 @@ for file in (this_dir / 'checks').glob('*.yml'):
 
             for runnerImage in runnerImagesForOs:
                 # Skip appending this combination to the matrix if it is explicitly excluded.
-                if is_version_and_os_excluded(version, operatingSystem, excludedVersionsAndOses):
+                if is_os_and_version_excluded(version, operatingSystem, excludedOsesAndVersions):
                     continue
 
                 # Prior to CLI v2.15.1, ARM runners were not supported by the build tracer.


### PR DESCRIPTION
We often need to exclude specific combinations of CLI versions + operating systems. Previously there was no easy way to do this: we would run all CLI versions specified against all operating systems specified. This change adds the `excludeOsAndVersionCombination` parameter to do just that!

To test, I re-enabled Swift on Linux for CLI v >= 2.17.4, which remained as a to-do item after we disabled those checks in https://github.com/github/codeql-action/pull/2299. Note that `default`, `linked`, and `nightly-latest` are all now current enough to re-enable those. The new generator script allows us to exclude all older CLI versions on Linux. 

I'll update the required PR checks once this PR is approved ✅ 

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
