### PR TITLE
Fix changelog entry section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ Note that the only difference between `v2` and `v3` of the CodeQL Action is the 
 
 ## [UNRELEASED]
 
-No user facing changes.
+- Add `codeql-version` to outputs. [#2368](https://github.com/github/codeql-action/pull/2368)
 
 ## 3.25.12 - 12 Jul 2024
 
 - Improve the reliability and performance of analyzing code when analyzing a compiled language with the `autobuild` [build mode](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#codeql-build-modes) on GitHub Enterprise Server. This feature is already available to GitHub.com users. [#2353](https://github.com/github/codeql-action/pull/2353)
-- Add `codeql-version` to outputs. [#2368](https://github.com/github/codeql-action/pull/2368)
 - Update default CodeQL bundle version to 2.18.0. [#2364](https://github.com/github/codeql-action/pull/2364)
 
 ## 3.25.11 - 28 Jun 2024


### PR DESCRIPTION
I just noticed that the changelog entry for https://github.com/github/codeql-action/pull/2368 is in the wrong section — this PR fixes that.  It's a common mistake with automatic merge resolution in that file — we should consider dropping unreleased changelog entries in a folder instead like we do for the CLI.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
