### PR TITLE
Check compiled code on each push

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,6 @@ name: PR Checks
 
 on:
   push:
-    branches: [main, releases/v*]
   pull_request:
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.
@@ -53,6 +52,7 @@ jobs:
         run: .github/workflows/script/check-js.sh
 
   check-node-modules:
+    if: github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases/v')
     name: Check modules up to date
     runs-on: macos-latest
     timeout-minutes: 45
@@ -63,6 +63,7 @@ jobs:
         run: .github/workflows/script/check-node-modules.sh
 
   check-file-contents:
+    if: github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases/v')
     name: Check file contents
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -87,6 +88,7 @@ jobs:
         run: .github/workflows/script/verify-pr-checks.sh
 
   npm-test:
+    if: github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases/v')
     name: Unit Test
     needs: [check-js, check-node-modules]
     strategy:
@@ -106,7 +108,7 @@ jobs:
           npm test
 
   check-node-version:
-    if: ${{ github.event.pull_request }}
+    if: github.event.pull_request
     name: Check Action Node versions
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
A common mistake is forgetting to compile the code. Ideally, this wouldn't be necessary, but in the meantime, this change gives a visible indication on the commit when the code hasn't been recompiled.

Caveat: we will run duplicate "Check JS" jobs for `push` and `pull_request` when the commit is part of a pull request. 

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
