### PR TITLE
Exclude push-only unit tests job from required PR checks script

### DIFF
--- a/.github/workflows/script/update-required-checks.sh
+++ b/.github/workflows/script/update-required-checks.sh
@@ -28,7 +28,8 @@ fi
 echo "Getting checks for $GITHUB_SHA"
 
 # Ignore any checks with "https://", CodeQL, LGTM, and Update checks.
-CHECKS="$(gh api repos/github/codeql-action/commits/"${GITHUB_SHA}"/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "Dependabot" or . == "check-expected-release-files" or contains("Update") or contains("update") or contains("test-setup-python-scripts") | not)] | unique | sort')"
+# Also ignore the non-matrixed "Unit Tests" job that only runs on pushes to protected branches.
+CHECKS="$(gh api repos/github/codeql-action/commits/"${GITHUB_SHA}"/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "Dependabot" or . == "check-expected-release-files" or . == "Unit Tests" or contains("Update") or contains("update") or contains("test-setup-python-scripts") | not)] | unique | sort')"
 
 echo "$CHECKS" | jq
 


### PR DESCRIPTION
The "Check JS" job and "Unit Test" job are both in the same workflow.  On push, we run the "Check JS" job but skip the "Unit Test" run to save compute.  This results in a skipped (non-matrixed) "Unit Test" job.  This PR makes sure that that "Unit Test" job doesn't get included in the required checks for main and the release branches, which we maintain via a script.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
