### PR TITLE
Add details of supported versions for GHES 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ To provide the best experience to customers using older versions of GitHub Enter
 
 For more information, see "[Code scanning: deprecation of CodeQL Action v2](https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/)."
 
-## Supported versions of the CodeQL CLI and GitHub Enterprise Server
+## Supported versions of the CodeQL Bundle and GitHub Enterprise Server
 
-We typically release new minor versions of the CodeQL Action and CLI when a new minor version of GitHub Enterprise Server (GHES) is released. When a version of GHES is deprecated, the CodeQL Action and CLI releases that shipped with it are deprecated as well.
+We typically release new minor versions of the CodeQL Action and Bundle when a new minor version of GitHub Enterprise Server (GHES) is released. When a version of GHES is deprecated, the CodeQL Action and Bundle releases that shipped with it are deprecated as well.
 
-| Recommended CodeQL Action | Recommended CodeQL CLI Version | GitHub Environment |
+| Recommended CodeQL Action | Recommended CodeQL Bundle Version | GitHub Environment |
 |---------|----------|--------------|
 | `v3` | default (do not pass a `tools` input) | GitHub.com |
-| `v3.25.11` | `v2.17.6` | Enterprise Server 3.14 |
-| `v3.24.11` | `v2.16.6` | Enterprise Server 3.13 |
-| `3.22.12` | `2.15.5` | Enterprise Server 3.12 |
-| `2.22.1` | `2.14.6` | Enterprise Server 3.11 |
-| `2.20.3` | `2.13.5` | Enterprise Server 3.10 |
+| `v3.25.11` | `2.17.6` | Enterprise Server 3.14 |
+| `v3.24.11` | `2.16.6` | Enterprise Server 3.13 |
+| `v3.22.12` | `2.15.5` | Enterprise Server 3.12 |
+| `v2.22.1` | `2.14.6` | Enterprise Server 3.11 |
+| `v2.20.3` | `2.13.5` | Enterprise Server 3.10 |
 
 CodeQL Action `v2` will stop receiving updates when GHES 3.11 is deprecated.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ We typically release new minor versions of the CodeQL Action and CLI when a new 
 | Recommended CodeQL Action | Recommended CodeQL CLI Version | GitHub Environment |
 |---------|----------|--------------|
 | `v3` | default (do not pass a `tools` input) | GitHub.com |
+| `v3.25.11` | `v2.17.6` | Enterprise Server 3.14 |
 | `v3.24.11` | `v2.16.6` | Enterprise Server 3.13 |
 | `3.22.12` | `2.15.5` | Enterprise Server 3.12 |
 | `2.22.1` | `2.14.6` | Enterprise Server 3.11 |


### PR DESCRIPTION
The release candidate is [now out](https://github.blog/changelog/2024-08-07-the-github-enterprise-server-3-14-release-candidate-is-available/).

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
