### PR TITLE
Go: Bump Go version to 1.23 in tests

### DIFF
--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -87,7 +87,7 @@ jobs:
           setup-kotlin: 'true'
       - uses: actions/setup-go@v5
         with:
-          go-version: ~1.22.0
+          go-version: ~1.23.0
       # to avoid potentially misleading autobuilder results where we expect it to download
       # dependencies successfully, but they actually come from a warm cache
           cache: false

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -87,7 +87,7 @@ jobs:
           setup-kotlin: 'true'
       - uses: actions/setup-go@v5
         with:
-          go-version: ~1.22.0
+          go-version: ~1.23.0
       # to avoid potentially misleading autobuilder results where we expect it to download
       # dependencies successfully, but they actually come from a warm cache
           cache: false

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -87,7 +87,7 @@ jobs:
           setup-kotlin: 'true'
       - uses: actions/setup-go@v5
         with:
-          go-version: ~1.22.0
+          go-version: ~1.23.0
       # to avoid potentially misleading autobuilder results where we expect it to download
       # dependencies successfully, but they actually come from a warm cache
           cache: false

--- a/pr-checks/checks/go-tracing-autobuilder.yml
+++ b/pr-checks/checks/go-tracing-autobuilder.yml
@@ -6,7 +6,7 @@ env:
 steps:
   - uses: actions/setup-go@v5
     with:
-      go-version: "~1.22.0"
+      go-version: "~1.23.0"
       # to avoid potentially misleading autobuilder results where we expect it to download
       # dependencies successfully, but they actually come from a warm cache
       cache: false

--- a/pr-checks/checks/go-tracing-custom-build-steps.yml
+++ b/pr-checks/checks/go-tracing-custom-build-steps.yml
@@ -4,7 +4,7 @@ operatingSystems: ["ubuntu", "macos"]
 steps:
   - uses: actions/setup-go@v5
     with:
-      go-version: "~1.22.0"
+      go-version: "~1.23.0"
       # to avoid potentially misleading autobuilder results where we expect it to download
       # dependencies successfully, but they actually come from a warm cache
       cache: false

--- a/pr-checks/checks/go-tracing-legacy-workflow.yml
+++ b/pr-checks/checks/go-tracing-legacy-workflow.yml
@@ -6,7 +6,7 @@ env:
 steps:
   - uses: actions/setup-go@v5
     with:
-      go-version: "~1.22.0"
+      go-version: "~1.23.0"
       # to avoid potentially misleading autobuilder results where we expect it to download
       # dependencies successfully, but they actually come from a warm cache
       cache: false


### PR DESCRIPTION
This PR updates the version of Go in the PR checks to 1.23. This purely affects the CI on this repository. If you have come here because of an issue with CodeQL and Go 1.23, please open an issue on https://github.com/github/codeql

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
