### PR TITLE
Fix incorrect documentation about the `token` input to the Actions.

### DIFF
--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -74,7 +74,7 @@ inputs:
     required: true
     default: "true"
   token:
-    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission."
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission. Most of the time it is advisable to avoid specifying this input so that the workflow falls back to using the default value."
     required: false
     default: ${{ github.token }}
   matrix:

--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -74,7 +74,7 @@ inputs:
     required: true
     default: "true"
   token:
-    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow should have the `security-events: write` permission."
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission."
     required: false
     default: ${{ github.token }}
   matrix:

--- a/analyze/action.yml
+++ b/analyze/action.yml
@@ -74,7 +74,7 @@ inputs:
     required: true
     default: "true"
   token:
-    description: "GitHub token to use for authenticating with this instance of GitHub. The token needs the `security-events: write` permission."
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow should have the `security-events: write` permission."
     required: false
     default: ${{ github.token }}
   matrix:

--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "The sha of the HEAD of the ref where results will be uploaded. If not provided, the Action will use the GITHUB_SHA environment variable. If provided, the ref input must be provided as well. This input is ignored for pull requests from forks."
     required: false
   token:
-    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission."
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission. Most of the time it is advisable to avoid specifying this input so that the workflow falls back to using the default value."
     required: false
     default: ${{ github.token }}
   matrix:

--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "The sha of the HEAD of the ref where results will be uploaded. If not provided, the Action will use the GITHUB_SHA environment variable. If provided, the ref input must be provided as well. This input is ignored for pull requests from forks."
     required: false
   token:
-    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow should have the `security-events: write` permission."
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission."
     required: false
     default: ${{ github.token }}
   matrix:

--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "The sha of the HEAD of the ref where results will be uploaded. If not provided, the Action will use the GITHUB_SHA environment variable. If provided, the ref input must be provided as well. This input is ignored for pull requests from forks."
     required: false
   token:
-    description: "GitHub token to use for authenticating with this instance of GitHub. The token needs the `security-events: write` permission."
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow should have the `security-events: write` permission."
     required: false
     default: ${{ github.token }}
   matrix:


### PR DESCRIPTION
This documentation is currently misleading as it implies you can use any token here. In reality, this Action calls API endpoints that only accept tokens from the GitHub Actions app, so you should basically never override it.

I believe all the other Actions in this repository will work with an arbitrary token if one needs to be provided for cross-repository access, but these two call the SARIF upload endpoint which requires an Actions token.