### PR TITLE
Use generated token on checkout

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -115,19 +115,21 @@ jobs:
       SOURCE_BRANCH: ${{ needs.prepare.outputs.backport_source_branch }}
       TARGET_BRANCH: ${{ matrix.target_branch }}
     steps:
-    - uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4
+    - name: Generate token
+      uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4
       id: app-token
       with:
         app-id: ${{ vars.AUTOMATION_APP_ID }}
         private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
-    - uses: actions/checkout@v4
+
+    - name: Checkout
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Need full history for calculation of diffs
+        token: ${{ steps.app-token.outputs.token }}
     - uses: ./.github/actions/release-initialise
 
     - name: Update older release branch
-      env:
-        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         echo SOURCE_BRANCH=${SOURCE_BRANCH}
         echo TARGET_BRANCH=${TARGET_BRANCH}


### PR DESCRIPTION
The script `.github/update-release-branch.py` uses the `git` command to push changes. Therefore we need to ensure that `git` authenticates with a token that has the `workflows` write permision.

This change restore the GitHub token used by the script to access the API and applies the `workflows` write permission to the token used by `git`.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
