### PR TITLE
Run some tests against only `latest` and `nightly-latest` CLIs

### DIFF
--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -28,52 +28,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: stable-v2.13.5
-          - os: macos-12
-            version: stable-v2.13.5
-          - os: windows-latest
-            version: stable-v2.13.5
+            version: latest
           - os: ubuntu-latest
-            version: stable-v2.14.6
-          - os: macos-12
-            version: stable-v2.14.6
-          - os: windows-latest
-            version: stable-v2.14.6
-          - os: ubuntu-latest
-            version: stable-v2.15.5
-          - os: macos-latest
-            version: stable-v2.15.5
-          - os: windows-latest
-            version: stable-v2.15.5
-          - os: ubuntu-latest
-            version: stable-v2.16.6
-          - os: macos-latest
-            version: stable-v2.16.6
-          - os: windows-latest
-            version: stable-v2.16.6
-          - os: ubuntu-latest
-            version: stable-v2.17.6
-          - os: macos-latest
-            version: stable-v2.17.6
-          - os: windows-latest
-            version: stable-v2.17.6
-          - os: ubuntu-latest
-            version: default
-          - os: macos-latest
-            version: default
-          - os: windows-latest
-            version: default
-          - os: ubuntu-latest
-            version: linked
-          - os: macos-latest
-            version: linked
-          - os: windows-latest
-            version: linked
-          - os: ubuntu-latest
-            version: nightly-latest
-          - os: macos-latest
-            version: nightly-latest
-          - os: windows-latest
             version: nightly-latest
     name: 'Go: Custom queries'
     permissions:

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
     name: 'Go: Custom queries'

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
     name: Remote config file

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -28,52 +28,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: stable-v2.13.5
-          - os: macos-12
-            version: stable-v2.13.5
-          - os: windows-latest
-            version: stable-v2.13.5
+            version: latest
           - os: ubuntu-latest
-            version: stable-v2.14.6
-          - os: macos-12
-            version: stable-v2.14.6
-          - os: windows-latest
-            version: stable-v2.14.6
-          - os: ubuntu-latest
-            version: stable-v2.15.5
-          - os: macos-latest
-            version: stable-v2.15.5
-          - os: windows-latest
-            version: stable-v2.15.5
-          - os: ubuntu-latest
-            version: stable-v2.16.6
-          - os: macos-latest
-            version: stable-v2.16.6
-          - os: windows-latest
-            version: stable-v2.16.6
-          - os: ubuntu-latest
-            version: stable-v2.17.6
-          - os: macos-latest
-            version: stable-v2.17.6
-          - os: windows-latest
-            version: stable-v2.17.6
-          - os: ubuntu-latest
-            version: default
-          - os: macos-latest
-            version: default
-          - os: windows-latest
-            version: default
-          - os: ubuntu-latest
-            version: linked
-          - os: macos-latest
-            version: linked
-          - os: windows-latest
-            version: linked
-          - os: ubuntu-latest
-            version: nightly-latest
-          - os: macos-latest
-            version: nightly-latest
-          - os: windows-latest
             version: nightly-latest
     name: Remote config file
     permissions:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -28,19 +28,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: stable-v2.13.5
-          - os: ubuntu-latest
-            version: stable-v2.14.6
-          - os: ubuntu-latest
-            version: stable-v2.15.5
-          - os: ubuntu-latest
-            version: stable-v2.16.6
-          - os: ubuntu-latest
-            version: stable-v2.17.6
-          - os: ubuntu-latest
-            version: default
-          - os: ubuntu-latest
-            version: linked
+            version: latest
           - os: ubuntu-latest
             version: nightly-latest
     name: Test unsetting environment variables

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version: latest
+            version: linked
           - os: ubuntu-latest
             version: nightly-latest
     name: Test unsetting environment variables

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -1,5 +1,10 @@
 name: "Go: Custom queries"
 description: "Checks that Go works in conjunction with a config file specifying custom queries"
+operatingSystems:
+  - ubuntu
+versions:
+  - latest
+  - nightly-latest
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -3,7 +3,7 @@ description: "Checks that Go works in conjunction with a config file specifying 
 operatingSystems:
   - ubuntu
 versions:
-  - latest
+  - linked
   - nightly-latest
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -3,7 +3,7 @@ description: "Checks that specifying packages using only a config file works"
 operatingSystems:
   - ubuntu
 versions:
-  - latest
+  - linked
   - nightly-latest
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -1,5 +1,10 @@
 name: "Remote config file"
 description: "Checks that specifying packages using only a config file works"
+operatingSystems:
+  - ubuntu
+versions:
+  - latest
+  - nightly-latest
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -3,7 +3,7 @@ description: "An end-to-end integration test that unsets some environment variab
 operatingSystems:
   - ubuntu
 versions:
-  - latest
+  - linked
   - nightly-latest
 steps:
   - uses: ./../action/init

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -1,7 +1,10 @@
 name: "Test unsetting environment variables"
 description: "An end-to-end integration test that unsets some environment variables"
-operatingSystems: ["ubuntu"]
-
+operatingSystems:
+  - ubuntu
+versions:
+  - latest
+  - nightly-latest
 steps:
   - uses: ./../action/init
     id: init


### PR DESCRIPTION
These features have stabilized so it isn't that helpful to test them against the full range of CLIs.  So let's speed up the PR checks and save some Actions minutes.

Overall, this PR removes 50 jobs, taking the total number down from 306 to 256.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
