### PR TITLE
CI: Check in new files when rebuilding

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -69,7 +69,8 @@ jobs:
           if [ ! -z "$(git status --porcelain)" ]; then
             git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git config --global user.name "github-actions[bot]"
-            git commit -am "Rebuild"
+            git add --all
+            git commit -m "Rebuild"
             git push origin "HEAD:$BRANCH"
             echo "Pushed a commit to rebuild the Action." \
               "Please mark the PR as ready for review to trigger PR checks." |


### PR DESCRIPTION
Previously the rebuild workflow would not check in new files, since `git commit -a` only adds changes to tracked files.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
