### PR TITLE
Avoid uploading eslint sarif for dependabot PR

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Upload sarif
         uses: github/codeql-action/upload-sarif@v3
         # Only upload SARIF for the latest version of Node.js
-        if: "always() && matrix.node-types-version == 'current'"
+        if: "always() && matrix.node-types-version == 'current' && !startsWith(github.head_ref, 'dependabot/')"
         with:
           sarif_file: eslint.sarif
           category: eslint

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Upload sarif
         uses: github/codeql-action/upload-sarif@v3
         # Only upload SARIF for the latest version of Node.js
-        if: "always() && matrix.node-types-version == 'current' && !startsWith(github.head_ref, 'dependabot/')"
+        if: "!cancelled() && matrix.node-types-version == 'current' && !startsWith(github.head_ref, 'dependabot/')"
         with:
           sarif_file: eslint.sarif
           category: eslint


### PR DESCRIPTION
Dependabot does not have `security-events: write` permission.

See https://github.com/github/codeql-action/pull/2485