### PR TITLE
Exclupde `eslint-plugin-import` updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
       # v7 requires ESM
       - dependency-name: "del"
         versions: ["^7.0.0"]
+      # This is broken due to the way configuration files have changed. 
+      # This might be fixed when we move to eslint v9.
+      - dependency-name: "eslint-plugin-import"
+        versions: [">=2.30.0"]
     groups:
       npm:
         patterns:


### PR DESCRIPTION
See https://github.com/github/codeql-action/pull/2510 for reason why.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
