### PR TITLE
PR Checks: update artifacts tests

### DIFF
--- a/.github/workflows/debug-artifacts-failure.yml
+++ b/.github/workflows/debug-artifacts-failure.yml
@@ -3,6 +3,7 @@
 name: PR Check - Debug artifacts after failure
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CODEQL_ACTION_ARTIFACT_V4_UPGRADE: true
 on:
   push:
     branches:
@@ -61,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Check expected artifacts exist
         shell: bash
         run: |

--- a/.github/workflows/debug-artifacts-legacy.yml
+++ b/.github/workflows/debug-artifacts-legacy.yml
@@ -1,9 +1,9 @@
 # Checks logs, SARIF, and database bundle debug artifacts exist and are accessible
-# with download-artifact@v4 when CODEQL_ACTION_ARTIFACT_V4_UPGRADE is set to true.
+# with download-artifact@v3 when CODEQL_ACTION_ARTIFACT_V4_UPGRADE is set to false.
 name: PR Check - Debug artifact upload using artifact@v2
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CODEQL_ACTION_ARTIFACT_V4_UPGRADE: true
+  CODEQL_ACTION_ARTIFACT_V4_UPGRADE: false
 on:
   push:
     branches:
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
       - name: Check expected artifacts exist
         shell: bash
         run: |

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -2,6 +2,7 @@
 name: PR Check - Debug artifact upload
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CODEQL_ACTION_ARTIFACT_V4_UPGRADE: true
 on:
   push:
     branches:
@@ -67,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Check expected artifacts exist
         shell: bash
         run: |


### PR DESCRIPTION
We are planning to make the default behavior of the `CODEQL_ACTION_ARTIFACT_V4_UPGRADE` feature flag to be true. This change updates our debug artifact PR checks so that the relevant environment variable is set to `true`, and changes the `debug-artifacts-upgrade` test to `debug-artifacts-legacy` test.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
