### PR TITLE
PR checks: small fixups to `prepare-action`

### DIFF
--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -32,6 +32,14 @@ runs:
       run: |
         set -e # Fail this Action if `gh release list` fails.
 
+        if [[ ${{ inputs.version }} == "linked" ]]; then
+          echo "tools-url=linked" >> "$GITHUB_OUTPUT"
+          exit 0
+        elif [[ ${{ inputs.version }} == "default" ]]; then
+          echo "tools-url=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         if [[ ${{ inputs.version }} == "nightly-latest" ]]; then
           extension="tar.zst"
         else
@@ -60,10 +68,6 @@ runs:
         elif [[ ${{ inputs.version }} == *"stable"* ]]; then
           version=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
           echo "tools-url=https://github.com/github/codeql-action/releases/download/codeql-bundle-$version/$artifact_name" >> $GITHUB_OUTPUT
-        elif [[ ${{ inputs.version }} == "linked" ]]; then
-          echo "tools-url=linked" >> $GITHUB_OUTPUT
-        elif [[ ${{ inputs.version }} == "default" ]]; then
-          echo "tools-url=" >> $GITHUB_OUTPUT
         else
           echo "::error::Unrecognized version specified!"
           exit 1

--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -2,7 +2,7 @@ name: "Prepare test"
 description: Performs some preparation to run tests
 inputs:
   version:
-    description: "The version of the CodeQL CLI to use. Can be 'linked', 'default', 'nightly-latest', 'nightly-YYYY-MM-DD', or 'stable-YYYY-MM-DD'."
+    description: "The version of the CodeQL CLI to use. Can be 'linked', 'default', 'nightly-latest', 'nightly-YYYYMMDD', or 'stable-vX.Y.Z"
     required: true
   use-all-platform-bundle:
     description: "If true, we output a tools URL with codeql-bundle.tar.gz file rather than platform-specific URL"
@@ -56,7 +56,7 @@ runs:
           echo "tools-url=https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/$tag/$artifact_name" >> $GITHUB_OUTPUT
         elif [[ ${{ inputs.version }} == *"nightly"* ]]; then
           version=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
-          echo "tools-url=https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-$version-manual/$artifact_name" >> $GITHUB_OUTPUT
+          echo "tools-url=https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-$version/$artifact_name" >> $GITHUB_OUTPUT
         elif [[ ${{ inputs.version }} == *"stable"* ]]; then
           version=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
           echo "tools-url=https://github.com/github/codeql-action/releases/download/codeql-bundle-$version/$artifact_name" >> $GITHUB_OUTPUT


### PR DESCRIPTION
While working on a version of this for testing on runner images, I noticed some improvements to be made:

- the action now expects stable CLI version inputs as `stable-vX.Y.Z` rather than with dates. Our current PR checks already use this format but the documentation for the input needed to be updated.
- the nightly version format also should expect `nightly-YYYYMMDD` rather than with dashes
- the nightly bundle URL formatting has been corrected to remove the `manual` suffix — eg. the current nightly URLs look like: `https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-20240823/codeql-bundle-linux64.tar.gz`. We haven't caught this because none of our PR checks use the dated nightly bundles.
- when the version is `linked` or `default` we return the appropriate tools input early. 
 
### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
