### PR TITLE
Add permissions to pr-checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,6 +13,9 @@ jobs:
     name: Check JS
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Without this, I get: https://github.com/check-spelling-sandbox/github-codeql-action/actions/runs/11429827970/job/31796641932

```
Run github/codeql-action/upload-sarif@v3
Warning: Resource not accessible by integration
Uploading results
  Processing sarif files: ["eslint.sarif"]
  Validating eslint.sarif
  Combining SARIF files using the CodeQL CLI
  Adding fingerprints to SARIF file. See https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs for more information.
  Uploading results
  Warning: Resource not accessible by integration
  Error: Resource not accessible by integration
  Warning: Resource not accessible by integration
```

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
