### PR TITLE
Remove ESLint from required checks

### DIFF
--- a/.github/workflows/script/update-required-checks.sh
+++ b/.github/workflows/script/update-required-checks.sh
@@ -27,8 +27,8 @@ fi
 
 echo "Getting checks for $GITHUB_SHA"
 
-# Ignore any checks with "https://", CodeQL, LGTM, and Update checks.
-CHECKS="$(gh api repos/github/codeql-action/commits/"${GITHUB_SHA}"/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs.[] | select(.conclusion != "skipped") | .name | select(contains("https://") or . == "CodeQL" or . == "Dependabot" or . == "check-expected-release-files" or contains("Update") or contains("update") or contains("test-setup-python-scripts") | not)] | unique | sort')"
+# Ignore any checks with "https://", CodeQL, LGTM, Update, and ESLint checks.
+CHECKS="$(gh api repos/github/codeql-action/commits/"${GITHUB_SHA}"/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs.[] | select(.conclusion != "skipped") | .name | select(contains("https://") or . == "CodeQL" or . == "Dependabot" or . == "check-expected-release-files" or contains("Update") or contains("ESLint") or contains("update") or contains("test-setup-python-scripts") | not)] | unique | sort')"
 
 echo "$CHECKS" | jq
 


### PR DESCRIPTION
Dependabot does not upload eslint alerts, so the check is never created.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
