### PR TITLE
Add the action stub

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'CodeQL: Stub'
-description: "Stub: Don\'t use this action directly. Read [the documentation](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) instead."
+description: "Stub: Don't use this action directly. Read [the documentation](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) instead."
 author: 'GitHub'
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,11 @@
+name: 'CodeQL: Stub'
+description: "Stub: Don\'t use this action directly. Read [the documentation](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) instead."
+author: 'GitHub'
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Stub'
+      run: |
+        echo 'This is a stub. Read [the documentation](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) instead.'
+        exit 1
+      shell: bash


### PR DESCRIPTION
This is required for the migration of the codeql-action to an immutable action.

We can delete this after the migration is done, or just keep it so people have an extra way to understand how to use the action.

### Merge / deployment checklist

- [n/a] Confirm this change is backwards compatible with existing workflows.
- [n/a] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [n/a] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
