### PR TITLE
Minor cleanup

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
+++ b/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__autobuild-direct-tracing.yml
+++ b/.github/workflows/__autobuild-direct-tracing.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__build-mode-autobuild.yml
+++ b/.github/workflows/__build-mode-autobuild.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__build-mode-none.yml
+++ b/.github/workflows/__build-mode-none.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__build-mode-rollback.yml
+++ b/.github/workflows/__build-mode-rollback.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__cleanup-db-cluster-dir.yml
+++ b/.github/workflows/__cleanup-db-cluster-dir.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__config-input.yml
+++ b/.github/workflows/__config-input.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__job-run-uuid-sarif.yml
+++ b/.github/workflows/__job-run-uuid-sarif.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:
@@ -146,7 +146,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check language autodetect for Swift on MacOS
+      - name: Check language autodetect for Swift on macOS
         if: runner.os == 'macOS'
         shell: bash
         run: |

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:
@@ -84,7 +84,7 @@ jobs:
         uses: ./../action/.github/actions/check-sarif
         with:
           sarif-file: ${{ runner.temp }}/results/javascript.sarif
-          queries-run: 
+          queries-run:
             javascript/example/empty-or-one-block,javascript/example/empty-or-one-block,javascript/example/other-query-block,javascript/example/two-block
           queries-not-run: foo,bar
 

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:
@@ -84,7 +84,7 @@ jobs:
         uses: ./../action/.github/actions/check-sarif
         with:
           sarif-file: ${{ runner.temp }}/results/javascript.sarif
-          queries-run: 
+          queries-run:
             javascript/example/empty-or-one-block,javascript/example/empty-or-one-block,javascript/example/other-query-block,javascript/example/two-block
           queries-not-run: foo,bar
 

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:
@@ -83,7 +83,7 @@ jobs:
         uses: ./../action/.github/actions/check-sarif
         with:
           sarif-file: ${{ runner.temp }}/results/javascript.sarif
-          queries-run: 
+          queries-run:
             javascript/example/empty-or-one-block,javascript/example/empty-or-one-block,javascript/example/other-query-block,javascript/example/two-block
           queries-not-run: foo,bar
 

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:
@@ -83,7 +83,7 @@ jobs:
         uses: ./../action/.github/actions/check-sarif
         with:
           sarif-file: ${{ runner.temp }}/results/javascript.sarif
-          queries-run: 
+          queries-run:
             javascript/example/empty-or-one-block,javascript/example/empty-or-one-block,javascript/example/other-query-block,javascript/example/two-block
           queries-not-run: foo,bar
 

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:
@@ -88,7 +88,7 @@ jobs:
           language: javascript-typescript
 
       - name: Fail if JavaScript/TypeScript configuration present
-        if: 
+        if:
           fromJSON(steps.resolve-environment-js.outputs.environment).configuration.javascript
         run: exit 1
     env:

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__zstd-bundle-streaming.yml
+++ b/.github/workflows/__zstd-bundle-streaming.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/__zstd-bundle-streaming.yml
+++ b/.github/workflows/__zstd-bundle-streaming.yml
@@ -59,7 +59,9 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const codeqlPath = path.join(process.env['RUNNER_TOOL_CACHE'], 'CodeQL');
-            fs.rmdirSync(codeqlPath, { recursive: true });
+            if (codeqlPath !== undefined) {
+              fs.rmdirSync(codeqlPath, { recursive: true });
+            }
       - id: init
         uses: ./../action/init
         with:

--- a/.github/workflows/__zstd-bundle.yml
+++ b/.github/workflows/__zstd-bundle.yml
@@ -61,7 +61,9 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const codeqlPath = path.join(process.env['RUNNER_TOOL_CACHE'], 'CodeQL');
-            fs.rmdirSync(codeqlPath, { recursive: true });
+            if (codeqlPath !== undefined) {
+              fs.rmdirSync(codeqlPath, { recursive: true });
+            }
       - id: init
         uses: ./../action/init
         with:

--- a/.github/workflows/__zstd-bundle.yml
+++ b/.github/workflows/__zstd-bundle.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Python on MacOS
+      - name: Setup Python on macOS
         uses: actions/setup-python@v5
         if: runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'
         with:

--- a/.github/workflows/debug-artifacts-failure.yml
+++ b/.github/workflows/debug-artifacts-failure.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./build.sh
       - uses: ./../action/analyze
         id: analysis
-        env: 
+        env:
           # Forces a failure in this step.
           CODEQL_ACTION_EXTRA_OPTIONS: '{ "database": { "finalize": ["--invalid-option"] } }'
         with:

--- a/.github/workflows/debug-artifacts-legacy.yml
+++ b/.github/workflows/debug-artifacts-legacy.yml
@@ -56,7 +56,7 @@ jobs:
           debug-artifact-name: my-debug-artifacts
           debug-database-name: my-db
           # We manually exclude Swift from the languages list here, as it is not supported on Ubuntu
-          languages: cpp,csharp,go,java,javascript,python,ruby 
+          languages: cpp,csharp,go,java,javascript,python,ruby
       - name: Build code
         shell: bash
         run: ./build.sh

--- a/.github/workflows/debug-artifacts.yml
+++ b/.github/workflows/debug-artifacts.yml
@@ -55,7 +55,7 @@ jobs:
           debug-artifact-name: my-debug-artifacts
           debug-database-name: my-db
           # We manually exclude Swift from the languages list here, as it is not supported on Ubuntu
-          languages: cpp,csharp,go,java,javascript,python,ruby 
+          languages: cpp,csharp,go,java,javascript,python,ruby
       - name: Build code
         shell: bash
         run: ./build.sh

--- a/.github/workflows/expected-queries-runs.yml
+++ b/.github/workflows/expected-queries-runs.yml
@@ -22,6 +22,9 @@ jobs:
       CODEQL_ACTION_TEST_MODE: true
     timeout-minutes: 45
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
     - name: Check out repository
       uses: actions/checkout@v4

--- a/.github/workflows/publish-immutable-action.yml
+++ b/.github/workflows/publish-immutable-action.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Publish
         if: steps.check.outputs.is-action-release == 'true'
         id: publish
-        uses: actions/publish-immutable-action@0.0.3
+        uses: actions/publish-immutable-action@v0.0.4

--- a/.github/workflows/script/check-js.sh
+++ b/.github/workflows/script/check-js.sh
@@ -7,7 +7,7 @@ if [ ! -z "$(git status --porcelain)" ]; then
     >&2 echo "Failed: Repo should be clean before testing!"
     exit 1
 fi
-# Wipe the lib directory incase there are extra unnecessary files in there
+# Wipe the lib directory in case there are extra unnecessary files in there
 rm -rf lib
 # Generate the JavaScript files
 npm run-script build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,12 +57,12 @@ No user facing changes.
 
 ## 3.26.5 - 23 Aug 2024
 
-- Fix an issue where the `csrutil` system call used for telemetry would fail on MacOS ARM machines with System Integrity Protection disabled. [#2441](https://github.com/github/codeql-action/pull/2441)
+- Fix an issue where the `csrutil` system call used for telemetry would fail on macOS ARM machines with System Integrity Protection disabled. [#2441](https://github.com/github/codeql-action/pull/2441)
 
 ## 3.26.4 - 21 Aug 2024
 
 - _Deprecation:_ The `add-snippets` input on the `analyze` Action is deprecated and will be removed in the first release in August 2025. [#2436](https://github.com/github/codeql-action/pull/2436)
-- Fix an issue where the disk usage system call used for telemetry would fail on MacOS ARM machines with System Integrity Protection disabled, and then surface a warning. The system call is now disabled for these machines. [#2434](https://github.com/github/codeql-action/pull/2434)
+- Fix an issue where the disk usage system call used for telemetry would fail on macOS ARM machines with System Integrity Protection disabled, and then surface a warning. The system call is now disabled for these machines. [#2434](https://github.com/github/codeql-action/pull/2434)
 
 ## 3.26.3 - 19 Aug 2024
 
@@ -140,7 +140,7 @@ No user facing changes.
 ## 3.25.3 - 25 Apr 2024
 
 - Update default CodeQL bundle version to 2.17.1. [#2247](https://github.com/github/codeql-action/pull/2247)
-- Workflows running on `macos-latest` using CodeQL CLI versions before v2.15.1 will need to either upgrade their CLI version to v2.15.1 or newer, or change the platform to an Intel MacOS runner, such as `macos-12`. ARM machines with SIP disabled, including the newest `macos-latest` image, are unsupported for CLI versions before 2.15.1. [#2261](https://github.com/github/codeql-action/pull/2261)
+- Workflows running on `macos-latest` using CodeQL CLI versions before v2.15.1 will need to either upgrade their CLI version to v2.15.1 or newer, or change the platform to an Intel macOS runner, such as `macos-12`. ARM machines with SIP disabled, including the newest `macos-latest` image, are unsupported for CLI versions before 2.15.1. [#2261](https://github.com/github/codeql-action/pull/2261)
 
 ## 3.25.2 - 22 Apr 2024
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -44,7 +44,7 @@ var EnvVar;
     /** Whether the init action has been run. */
     EnvVar["INIT_ACTION_HAS_RUN"] = "CODEQL_ACTION_INIT_HAS_RUN";
     /**
-     * For MacOS. Result of `csrutil status` to determine whether System Integrity
+     * For macOS. Result of `csrutil status` to determine whether System Integrity
      * Protection is enabled.
      */
     EnvVar["IS_SIP_ENABLED"] = "CODEQL_ACTION_IS_SIP_ENABLED";

--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -330,13 +330,13 @@ async function run() {
         if ((0, caching_utils_1.shouldRestoreCache)(config.dependencyCachingEnabled)) {
             await (0, dependency_caching_1.downloadDependencyCaches)(config.languages, logger);
         }
-        // For CLI versions <2.15.1, build tracing caused errors in MacOS ARM machines with
+        // For CLI versions <2.15.1, build tracing caused errors in macOS ARM machines with
         // System Integrity Protection (SIP) disabled.
         if (!(await (0, util_1.codeQlVersionAtLeast)(codeql, "2.15.1")) &&
             process.platform === "darwin" &&
             (process.arch === "arm" || process.arch === "arm64") &&
             !(await (0, util_1.checkSipEnablement)(logger))) {
-            logger.warning("CodeQL versions 2.15.0 and lower are not supported on MacOS ARM machines with System Integrity Protection (SIP) disabled.");
+            logger.warning("CodeQL versions 2.15.0 and lower are not supported on macOS ARM machines with System Integrity Protection (SIP) disabled.");
         }
         // From 2.16.0 the default for the python extractor is to not perform any
         // dependency extraction. For versions before that, you needed to set this flag to

--- a/lib/tracer-config.js
+++ b/lib/tracer-config.js
@@ -92,7 +92,7 @@ async function getCombinedTracerConfig(codeql, config) {
     // If the CLI doesn't yet support setting the CODEQL_RUNNER environment variable to
     // the runner executable path, we set it here in the Action.
     if (!(await codeql.supportsFeature(tools_features_1.ToolsFeature.SetsCodeqlRunnerEnvVar))) {
-        // On MacOS when System Integrity Protection is enabled, it's necessary to prefix
+        // On macOS when System Integrity Protection is enabled, it's necessary to prefix
         // the build command with the runner executable for indirect tracing, so we expose
         // it here via the CODEQL_RUNNER environment variable.
         // The executable also exists and works for other platforms so we unconditionally

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -1,5 +1,5 @@
 name: "Multi-language repository"
-description: "An end-to-end integration test of a multi-language repository using automatic language detection for MacOS"
+description: "An end-to-end integration test of a multi-language repository using automatic language detection for macOS"
 operatingSystems: ["macos", "ubuntu"]
 steps:
   - uses: actions/setup-go@v5
@@ -67,7 +67,7 @@ steps:
         exit 1
       fi
 
-  - name: Check language autodetect for Swift on MacOS
+  - name: Check language autodetect for Swift on macOS
     if: runner.os == 'macOS'
     shell: bash
     run: |

--- a/pr-checks/checks/zstd-bundle-streaming.yml
+++ b/pr-checks/checks/zstd-bundle-streaming.yml
@@ -16,7 +16,9 @@ steps:
         const fs = require('fs');
         const path = require('path');
         const codeqlPath = path.join(process.env['RUNNER_TOOL_CACHE'], 'CodeQL');
-        fs.rmdirSync(codeqlPath, { recursive: true });
+        if (codeqlPath !== undefined) {
+          fs.rmdirSync(codeqlPath, { recursive: true });
+        }
   - id: init
     uses: ./../action/init
     with:

--- a/pr-checks/checks/zstd-bundle.yml
+++ b/pr-checks/checks/zstd-bundle.yml
@@ -16,7 +16,9 @@ steps:
         const fs = require('fs');
         const path = require('path');
         const codeqlPath = path.join(process.env['RUNNER_TOOL_CACHE'], 'CodeQL');
-        fs.rmdirSync(codeqlPath, { recursive: true });
+        if (codeqlPath !== undefined) {
+          fs.rmdirSync(codeqlPath, { recursive: true });
+        }
   - id: init
     uses: ./../action/init
     with:

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -4,6 +4,7 @@ import ruamel.yaml
 from ruamel.yaml.scalarstring import FoldedScalarString, SingleQuotedScalarString
 import pathlib
 import textwrap
+import os
 
 # The default set of CodeQL Bundle versions to use for the PR checks.
 defaultTestVersions = [
@@ -153,7 +154,8 @@ for file in (this_dir / 'checks').glob('*.yml'):
         checkJob['env']['CODEQL_ACTION_TEST_MODE'] = True
     checkName = file.stem
 
-    with open(this_dir.parent / ".github" / "workflows" / f"__{checkName}.yml", 'w') as output_stream:
+    raw_file = this_dir.parent / ".github" / "workflows" / f"__{checkName}.yml.raw"
+    with open(raw_file, 'w') as output_stream:
         writeHeader(output_stream)
         yaml.dump({
             'name': f"PR Check - {checkSpecification['name']}",
@@ -175,3 +177,9 @@ for file in (this_dir / 'checks').glob('*.yml'):
                 checkName: checkJob
             }
         }, output_stream)
+
+    with open(raw_file, 'r') as input_stream:
+        with open(this_dir.parent / ".github" / "workflows" / f"__{checkName}.yml", 'w') as output_stream:
+            content = input_stream.read()
+            output_stream.write("\n".join(list(map(lambda x:x.rstrip(), content.splitlines()))+['']))
+    os.remove(raw_file)

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -98,7 +98,7 @@ for file in (this_dir / 'checks').glob('*.yml'):
 
     steps = [
         {
-            'name': 'Setup Python on MacOS',
+            'name': 'Setup Python on macOS',
             'uses': 'actions/setup-python@v5',
             'if': "runner.os == 'macOS' && matrix.version == 'stable-v2.14.6'",
             'with': {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -51,7 +51,7 @@ export enum EnvVar {
   INIT_ACTION_HAS_RUN = "CODEQL_ACTION_INIT_HAS_RUN",
 
   /**
-   * For MacOS. Result of `csrutil status` to determine whether System Integrity
+   * For macOS. Result of `csrutil status` to determine whether System Integrity
    * Protection is enabled.
    */
   IS_SIP_ENABLED = "CODEQL_ACTION_IS_SIP_ENABLED",

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -566,7 +566,7 @@ async function run() {
       await downloadDependencyCaches(config.languages, logger);
     }
 
-    // For CLI versions <2.15.1, build tracing caused errors in MacOS ARM machines with
+    // For CLI versions <2.15.1, build tracing caused errors in macOS ARM machines with
     // System Integrity Protection (SIP) disabled.
     if (
       !(await codeQlVersionAtLeast(codeql, "2.15.1")) &&
@@ -575,7 +575,7 @@ async function run() {
       !(await checkSipEnablement(logger))
     ) {
       logger.warning(
-        "CodeQL versions 2.15.0 and lower are not supported on MacOS ARM machines with System Integrity Protection (SIP) disabled.",
+        "CodeQL versions 2.15.0 and lower are not supported on macOS ARM machines with System Integrity Protection (SIP) disabled.",
       );
     }
 

--- a/src/tracer-config.ts
+++ b/src/tracer-config.ts
@@ -111,7 +111,7 @@ export async function getCombinedTracerConfig(
   // If the CLI doesn't yet support setting the CODEQL_RUNNER environment variable to
   // the runner executable path, we set it here in the Action.
   if (!(await codeql.supportsFeature(ToolsFeature.SetsCodeqlRunnerEnvVar))) {
-    // On MacOS when System Integrity Protection is enabled, it's necessary to prefix
+    // On macOS when System Integrity Protection is enabled, it's necessary to prefix
     // the build command with the runner executable for indirect tracing, so we expose
     // it here via the CODEQL_RUNNER environment variable.
     // The executable also exists and works for other platforms so we unconditionally


### PR DESCRIPTION
- Split from #2578 

* [spelling: in case](https://github.com/github/codeql-action/commit/16e8ccc657ef085eca5d8e25b9d7603be751eae3) -- grammatical fix
* [spelling: macos](https://github.com/github/codeql-action/commit/f93ba4122b0afb0e997ec381f8385f494b39fe84) -- branding fix
* [Strip trailing whitespace generated by ruamel-yaml](https://github.com/github/codeql-action/commit/4be2e2d7116ac2f0fea0b787725ea0cdb8fc8689) -- quality of life change -- editors do not like trailing whitespace and have a tendency to strip them (which is problematic given that there's a second related file) -- ruamel-yaml is currently pinned to an out-of-date version, but at some point, I'd be inclined to file a bug against it if I could reproduce this behavior in the current version
* [Give expected-queries-runs permissions](https://github.com/github/codeql-action/commit/7606bdffa796b53d99cd02cfa3cb69fa51576927)
* [Fix publish-immutable-action version](https://github.com/github/codeql-action/commit/b857595207f0c784596531bbf8787781f2a458ed) -- This is odd, I filed https://github.com/actions/publish-immutable-action/issues/212 about it
* [Conditionally clear runner cache](https://github.com/github/codeql-action/commit/2ec63d2cb9c4cd036765f5f37649859a14dd37f3) -- This relates to making nektos/act happy (there's a second bigger bug that means that act doesn't work at all, I've poked it)


### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
