### PR TITLE
Use gzip bundles in Windows PR checks

### DIFF
--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -40,7 +40,7 @@ runs:
           exit 0
         fi
 
-        if [[ ${{ inputs.version }} == "nightly-latest" ]]; then
+        if [[ ${{ inputs.version }} == "nightly-latest" && "$RUNNER_OS" != "Windows" ]]; then
           extension="tar.zst"
         else
           extension="tar.gz"


### PR DESCRIPTION
Experimentally, gzip bundles extract faster than zstd bundles on Windows with our current setup, so this change speeds up the PR checks in addition to better matching the production environment.

We are also separately looking into whether we can speed up bundle installation on Windows. 

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
