### PR TITLE
Remove Node 16 compilation PR check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,8 +19,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        node-types-version: [16.11, current] # run tests on 16.11 while CodeQL Action v2 is still supported
 
     steps:
       - name: Checkout
@@ -32,33 +30,9 @@ jobs:
 
       - name: Upload sarif
         uses: github/codeql-action/upload-sarif@v3
-        # Only upload SARIF for the latest version of Node.js
-        if: "!cancelled() && matrix.node-types-version == 'current' && !startsWith(github.head_ref, 'dependabot/')"
         with:
           sarif_file: eslint.sarif
           category: eslint
-
-      - name: Update version of @types/node
-        if: matrix.node-types-version != 'current'
-        env:
-          NODE_TYPES_VERSION: ${{ matrix.node-types-version }}
-        run: |
-          # Export `NODE_TYPES_VERSION` so it's available to jq
-          export NODE_TYPES_VERSION="${NODE_TYPES_VERSION}"
-          contents=$(jq '.devDependencies."@types/node" = env.NODE_TYPES_VERSION' package.json)
-          echo "${contents}" > package.json
-          # Usually we run `npm install` on macOS to ensure that we pick up macOS-only dependencies.
-          # However we're not checking in the updated lockfile here, so it's fine to run
-          # `npm install` on Linux.
-          npm install
-
-          if [ ! -z "$(git status --porcelain)" ]; then
-            git config --global user.email "github-actions@github.com"
-            git config --global user.name "github-actions[bot]"
-            # The period in `git add --all .` ensures that we stage deleted files too.
-            git add --all .
-            git commit -m "Use @types/node=${NODE_TYPES_VERSION}"
-          fi
 
       - name: Check generated JS
         run: .github/workflows/script/check-js.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,7 @@ To add a new major version of the Action:
 1. Change the `version` field of `package.json` by running `npm version x.y.z` where `x` is the new major version, and `y` and `z` match the latest minor and patch versions of the last release.
 1. Update appropriate documentation to explain the reasoning behind the releases: see [the diff](https://github.com/github/codeql-action/pull/2677/commits/913d60579d4b560addf53ec3c493d491dd3c1378) in our last major version deprecation for examples on which parts of the documentation should be updated.
 1. Consider the timeline behind deprecating the prior Action version: see [CodeQL Action deprecation documentation](#deprecating-a-codeql-action-major-version-write-access-required)
+1. If the new major version runs on a new version of Node, add a PR check to ensure the codebase continues to compile against the previous version of Node. See [Remove Node 16 compilation PR check](https://github.com/github/codeql-action/pull/2695) for an example.
 
 ## Deprecating a CodeQL Action major version (write access required)
 


### PR DESCRIPTION
Now that we have deprecated v2, we no longer need to maintain compatibility with Node 16.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
