### PR TITLE
Do some just+pre-commit tweaking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: local
     hooks:
+      - id: lint-ts
+        name: Lint typescript code
+        files: \.ts$
+        language: system
+        entry: npm run lint -- --fix
       - id: compile-ts
         name: Compile typescript
         files: \.[tj]s$
         language: system
         entry: npm run build
         pass_filenames: false
-      - id: lint-ts
-        name: Lint typescript code
-        files: \.ts$
-        language: system
-        entry: npm run lint -- --fix
       - id: pr-checks-sync
         name: Synchronize PR check workflows
         files: ^.github/workflows/__.*\.yml$|^pr-checks

--- a/justfile
+++ b/justfile
@@ -1,3 +1,10 @@
+# Perform all working copy cleanup operations
+all: lint sync
+
+# Lint source typescript
+lint:
+    npm run lint -- --fix
+
 # Sync generated files (javascript and PR checks)
 sync: build update-pr-checks
 


### PR DESCRIPTION
* pre-commit: move the linting check ahead of the compiling one, as a typescript lint can change the compiled javascript, so you can end up in a situation where the pre-commit check fails twice in a row, while now one run should always work
* just: add linting and make the default to run all

### Merge / deployment checklist

- [X] Confirm this change is backwards compatible with existing workflows.
- [X] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [X] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
