### PR TITLE
Unify `token` description for `resolve-environment`, `start-proxy`, and `upload-sarif`

### DIFF
--- a/resolve-environment/action.yml
+++ b/resolve-environment/action.yml
@@ -3,7 +3,7 @@ description: '[Experimental] Attempt to infer a build environment suitable for a
 author: 'GitHub'
 inputs:
   token:
-    description: "GitHub token to use for authenticating with this instance of GitHub. The token needs the `security-events: write` permission."
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission. Most of the time it is advisable to avoid specifying this input so that the workflow falls back to using the default value."
     required: false
     default: ${{ github.token }}
   matrix:

--- a/start-proxy/action.yml
+++ b/start-proxy/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: Base64 encoded JSON configuration for the URLs and credentials of the package registries
     required: false
   token:
-    description: GitHub token to use for authenticating with this instance of GitHub, used to upload debug artifacts.
+    description: "GitHub token to use for authenticating with this instance of GitHub. The token must be the built-in GitHub Actions token, and the workflow must have the `security-events: write` permission. Most of the time it is advisable to avoid specifying this input so that the workflow falls back to using the default value."
     default: ${{ github.token }}
     required: false
   language:


### PR DESCRIPTION
Partially fixes https://github.com/github/codeql-action/security/code-scanning/1050. The `upload-sarif` token description is the most comprehensive so I've used it for `resolve-environment` and `start-proxy`. 


### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
