### PR TITLE
Fix code injection warnings in `check-codescanning-config` internal Action

### DIFF
--- a/.github/actions/check-codescanning-config/action.yml
+++ b/.github/actions/check-codescanning-config/action.yml
@@ -62,8 +62,7 @@ runs:
     - name: Check config
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" '$EXPECTED_CONFIG_FILE_CONTENTS'
-
+      run: ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" "$EXPECTED_CONFIG_FILE_CONTENTS"
     - name: Clean up
       shell: bash
       if: always()

--- a/.github/actions/check-codescanning-config/action.yml
+++ b/.github/actions/check-codescanning-config/action.yml
@@ -53,6 +53,7 @@ runs:
         db-location: ${{ runner.temp }}/codescanning-config-cli-test
       env:
         CODEQL_ACTION_TEST_MODE: 'true'
+        EXPECTED_CONFIG_FILE_CONTENTS: ${{ inputs.expected-config-file-contents }}
 
     - name: Install dependencies
       shell: bash
@@ -61,7 +62,7 @@ runs:
     - name: Check config
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ts-node ./index.ts "${{ runner.temp }}/user-config.yaml" '${{ inputs.expected-config-file-contents }}'
+      run: ts-node ./index.ts "${{ runner.temp }}/user-config.yaml" '$EXPECTED_CONFIG_FILE_CONTENTS'
 
     - name: Clean up
       shell: bash
@@ -69,3 +70,5 @@ runs:
       run: |
         rm -rf ${{ runner.temp }}/codescanning-config-cli-test
         rm -rf ${{ runner.temp }}/user-config.yaml
+        rm -rf $RUNNER_TEMP/codescanning-config-cli-test
+        rm -rf $RUNNER_TEMP/user-config.yaml

--- a/.github/actions/check-codescanning-config/action.yml
+++ b/.github/actions/check-codescanning-config/action.yml
@@ -53,7 +53,6 @@ runs:
         db-location: ${{ runner.temp }}/codescanning-config-cli-test
       env:
         CODEQL_ACTION_TEST_MODE: 'true'
-        EXPECTED_CONFIG_FILE_CONTENTS: '${{ inputs.expected-config-file-contents }}'
 
     - name: Install dependencies
       shell: bash
@@ -62,7 +61,11 @@ runs:
     - name: Check config
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: echo "$EXPECTED_CONFIG_FILE_CONTENTS"; ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" "$EXPECTED_CONFIG_FILE_CONTENTS"
+      env:
+        EXPECTED_CONFIG_FILE_CONTENTS: '${{ inputs.expected-config-file-contents }}'
+      run: |
+        echo "EXPECTED_CONFIG_FILE_CONTENTS = $EXPECTED_CONFIG_FILE_CONTENTS"
+        ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" "$EXPECTED_CONFIG_FILE_CONTENTS"
     - name: Clean up
       shell: bash
       if: always()

--- a/.github/actions/check-codescanning-config/action.yml
+++ b/.github/actions/check-codescanning-config/action.yml
@@ -53,7 +53,7 @@ runs:
         db-location: ${{ runner.temp }}/codescanning-config-cli-test
       env:
         CODEQL_ACTION_TEST_MODE: 'true'
-        EXPECTED_CONFIG_FILE_CONTENTS: ${{ inputs.expected-config-file-contents }}
+        EXPECTED_CONFIG_FILE_CONTENTS: '${{ inputs.expected-config-file-contents }}'
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/check-codescanning-config/action.yml
+++ b/.github/actions/check-codescanning-config/action.yml
@@ -63,9 +63,7 @@ runs:
       shell: bash
       env:
         EXPECTED_CONFIG_FILE_CONTENTS: '${{ inputs.expected-config-file-contents }}'
-      run: |
-        echo "EXPECTED_CONFIG_FILE_CONTENTS = $EXPECTED_CONFIG_FILE_CONTENTS"
-        ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" "$EXPECTED_CONFIG_FILE_CONTENTS"
+      run: ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" "$EXPECTED_CONFIG_FILE_CONTENTS"
     - name: Clean up
       shell: bash
       if: always()

--- a/.github/actions/check-codescanning-config/action.yml
+++ b/.github/actions/check-codescanning-config/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Check config
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" "$EXPECTED_CONFIG_FILE_CONTENTS"
+      run: echo "$EXPECTED_CONFIG_FILE_CONTENTS"; ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" "$EXPECTED_CONFIG_FILE_CONTENTS"
     - name: Clean up
       shell: bash
       if: always()

--- a/.github/actions/check-codescanning-config/action.yml
+++ b/.github/actions/check-codescanning-config/action.yml
@@ -62,13 +62,11 @@ runs:
     - name: Check config
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ts-node ./index.ts "${{ runner.temp }}/user-config.yaml" '$EXPECTED_CONFIG_FILE_CONTENTS'
+      run: ts-node ./index.ts "$RUNNER_TEMP/user-config.yaml" '$EXPECTED_CONFIG_FILE_CONTENTS'
 
     - name: Clean up
       shell: bash
       if: always()
       run: |
-        rm -rf ${{ runner.temp }}/codescanning-config-cli-test
-        rm -rf ${{ runner.temp }}/user-config.yaml
         rm -rf $RUNNER_TEMP/codescanning-config-cli-test
         rm -rf $RUNNER_TEMP/user-config.yaml

--- a/.github/actions/check-codescanning-config/index.ts
+++ b/.github/actions/check-codescanning-config/index.ts
@@ -8,7 +8,7 @@ const actualConfig = loadActualConfig()
 
 const rawExpectedConfig = process.argv[3].trim()
 if (!rawExpectedConfig) {
-  core.info('No expected configuration provided')
+  core.setFailed('No expected configuration provided')
 } else {
   core.startGroup('Expected generated user config')
   core.info(yaml.dump(JSON.parse(rawExpectedConfig)))

--- a/.github/actions/check-codescanning-config/index.ts
+++ b/.github/actions/check-codescanning-config/index.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert'
 const actualConfig = loadActualConfig()
 
 const rawExpectedConfig = process.argv[3].trim()
+core.info("rawExpectedConfig: " + rawExpectedConfig)
 if (!rawExpectedConfig) {
   core.setFailed('No expected configuration provided')
 } else {

--- a/.github/actions/check-codescanning-config/index.ts
+++ b/.github/actions/check-codescanning-config/index.ts
@@ -7,7 +7,6 @@ import * as assert from 'assert'
 const actualConfig = loadActualConfig()
 
 const rawExpectedConfig = process.argv[3].trim()
-core.info("rawExpectedConfig: " + rawExpectedConfig)
 if (!rawExpectedConfig) {
   core.setFailed('No expected configuration provided')
 } else {


### PR DESCRIPTION
- Use environment variable for `EXPECTED_CONFIG_FILE_CONTENTS` to escape any injected input
- Use `$RUNNER_TEMP` rather than `${{ runner.temp }}` for good measure, even though `runner.temp` should not be user-controlled input anyway.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
