### PR TITLE
PR Checks: use semantic versioning for `create-github-app-token`

### DIFF
--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -168,7 +168,7 @@ jobs:
             --draft
 
       - name: Generate token
-        uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2
+        uses: actions/create-github-app-token@v1.11.5
         id: app-token
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -124,7 +124,7 @@ jobs:
       pull-requests: write # needed to create pull request
     steps:
     - name: Generate token
-      uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2
+      uses: actions/create-github-app-token@v1.11.5
       id: app-token
       with:
         app-id: ${{ vars.AUTOMATION_APP_ID }}


### PR DESCRIPTION
Fixes https://github.com/github/codeql-action/security/code-scanning/1163 and https://github.com/github/codeql-action/security/code-scanning/1164. `v1.11.5` matches the existing pinned SHA.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
