### PR TITLE
build: sync some utility just instructions I had locally

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ all: lint sync
 
 # Lint source typescript
 lint:
-    npm run lint -- --fix
+    npm run lint-fix
 
 # Sync generated files (javascript and PR checks)
 sync: build update-pr-checks
@@ -15,3 +15,19 @@ update-pr-checks:
 # Transpile typescript code into javascript
 build:
     npm run build
+
+# Build then run all the tests
+test: build
+    npm run test
+
+# Run the tests for a single file
+test_file filename: build
+    npx ava --verbose {{filename}}
+
+# FOTIS: This shouldn't really be needed, as it's covered by `sync`,
+# however, I recall having messed my environment such that this was the
+# only solution, so keeping it here for convenience & docs.
+[doc("Refresh the lib directory (the .js build artefacts)")]
+[confirm]
+refresh-lib:
+    rm -rf lib && npm run build

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ test_file filename: build
 # FOTIS: This shouldn't really be needed, as it's covered by `sync`,
 # however, I recall having messed my environment such that this was the
 # only solution, so keeping it here for convenience & docs.
-[doc("Refresh the lib directory (the .js build artefacts)")]
+[doc("Refresh the .js build artefacts in the lib directory")]
 [confirm]
 refresh-lib:
     rm -rf lib && npm run build

--- a/justfile
+++ b/justfile
@@ -24,9 +24,6 @@ test: build
 test_file filename: build
     npx ava --verbose {{filename}}
 
-# FOTIS: This shouldn't really be needed, as it's covered by `sync`,
-# however, I recall having messed my environment such that this was the
-# only solution, so keeping it here for convenience & docs.
 [doc("Refresh the .js build artefacts in the lib directory")]
 [confirm]
 refresh-lib:


### PR DESCRIPTION
## Description

This PR is adding some utility `just` instructions that I had in a local file that I was using, before we added the current one.

The changes here are merely for convenience/documentation of maintainers - they don't (normally) affect users.


### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.