### PR TITLE
move use of input variables into env vars

### DIFF
--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -29,24 +29,27 @@ runs:
     - id: get-url
       name: Determine URL
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        USE_ALL_PLATFORM_BUNDLE: ${{ inputs.use-all-platform-bundle }}
       run: |
         set -e # Fail this Action if `gh release list` fails.
 
-        if [[ ${{ inputs.version }} == "linked" ]]; then
+        if [[ "$VERSION" == "linked" ]]; then
           echo "tools-url=linked" >> "$GITHUB_OUTPUT"
           exit 0
-        elif [[ ${{ inputs.version }} == "default" ]]; then
+        elif [[ "$VERSION" == "default" ]]; then
           echo "tools-url=" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        if [[ ${{ inputs.version }} == "nightly-latest" && "$RUNNER_OS" != "Windows" ]]; then
+        if [[ "$VERSION" == "nightly-latest" && "$RUNNER_OS" != "Windows" ]]; then
           extension="tar.zst"
         else
           extension="tar.gz"
         fi
 
-        if [[ ${{ inputs.use-all-platform-bundle }} == "true" ]]; then
+        if [[ "$USE_ALL_PLATFORM_BUNDLE" == "true" ]]; then
           artifact_name="codeql-bundle.$extension"
         elif [[ "$RUNNER_OS" == "Linux" ]]; then
           artifact_name="codeql-bundle-linux64.$extension"
@@ -59,14 +62,14 @@ runs:
           exit 1
         fi
 
-        if [[ ${{ inputs.version }} == "nightly-latest" ]]; then
+        if [[ "$VERSION" == "nightly-latest" ]]; then
           tag=`gh release list --repo dsp-testing/codeql-cli-nightlies -L 1 | cut -f 3`
           echo "tools-url=https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/$tag/$artifact_name" >> $GITHUB_OUTPUT
-        elif [[ ${{ inputs.version }} == *"nightly"* ]]; then
-          version=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
+        elif [[ "$VERSION" == *"nightly"* ]]; then
+          version=`echo "$VERSION" | sed -e 's/^.*\-//'`
           echo "tools-url=https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/codeql-bundle-$version/$artifact_name" >> $GITHUB_OUTPUT
-        elif [[ ${{ inputs.version }} == *"stable"* ]]; then
-          version=`echo ${{ inputs.version }} | sed -e 's/^.*\-//'`
+        elif [[ "$VERSION" == *"stable"* ]]; then
+          version=`echo "$VERSION" | sed -e 's/^.*\-//'`
           echo "tools-url=https://github.com/github/codeql-action/releases/download/codeql-bundle-$version/$artifact_name" >> $GITHUB_OUTPUT
         else
           echo "::error::Unrecognized version specified!"

--- a/.github/actions/release-branches/action.yml
+++ b/.github/actions/release-branches/action.yml
@@ -18,8 +18,11 @@ runs:
   using: "composite"
   steps:
     - id: branches
+      env:
+        MAJOR_VERSION: ${{ inputs.major_version }}
+        LATEST_TAG: ${{ inputs.latest_tag }}
       run: |
         python ${{ github.action_path }}/release-branches.py \
-            --major-version ${{ inputs.major_version }} \
-            --latest-tag ${{ inputs.latest_tag }}
+            --major-version "$MAJOR_VERSION" \
+            --latest-tag "$LATEST_TAG"
       shell: bash


### PR DESCRIPTION
This PR moves a number of uses of `${{ inputs.foo_bar }}` into environment variables for the step in question.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
