### PR TITLE
Dependabot: Remove deprecated `reviewers` config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
-    reviewers:
-      - "github/codeql-production-shield"
     schedule:
       interval: weekly
     labels:
@@ -26,8 +24,6 @@ updates:
           - "*"
   - package-ecosystem: github-actions
     directory: "/"
-    reviewers:
-      - "github/codeql-production-shield"
     schedule:
       interval: weekly
     groups:
@@ -36,8 +32,6 @@ updates:
           - "*"
   - package-ecosystem: github-actions
     directory: "/.github/actions/setup-swift/" # All subdirectories outside of "/.github/workflows" must be explicitly included.
-    reviewers:
-      - "github/codeql-production-shield"
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
This field will soon be ignored.  We could add the production shield as codeowner instead, but that might be noisy.  I think if it's a pain point, we create an automation to add a comment to the current production shield issue with any Dependabot PRs.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
