### PR TITLE
Fail `build.sh` if any command in it fails

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -45,6 +45,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'true'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - id: init
         uses: ./../action/init
         with:

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -49,6 +49,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -45,6 +45,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         id: init
         with:

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -49,6 +49,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         id: init
         with:

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -47,9 +47,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
           go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           languages: go

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -45,10 +45,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-      # We need a Go version that ships with statically linked binaries on Linux
           go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           languages: go

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -45,10 +45,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-      # We need a Go version that ships with statically linked binaries on Linux
           go-version: '>=1.21.0'
+          cache: false
       - name: Remove `file` program
         run: |
           echo $(which file)

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -45,10 +45,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-      # We need a Go version that ships with statically linked binaries on Linux
           go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           languages: go

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -75,11 +75,10 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ~1.24.0
-      # to avoid potentially misleading autobuilder results where we expect it to download
-      # dependencies successfully, but they actually come from a warm cache
+          go-version: '>=1.21.0'
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -75,11 +75,10 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ~1.24.0
-      # to avoid potentially misleading autobuilder results where we expect it to download
-      # dependencies successfully, but they actually come from a warm cache
+          go-version: '>=1.21.0'
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -75,11 +75,10 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ~1.24.0
-      # to avoid potentially misleading autobuilder results where we expect it to download
-      # dependencies successfully, but they actually come from a warm cache
+          go-version: '>=1.21.0'
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -75,10 +75,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
           go-version: '>=1.21.0'
-
+          cache: false
       - uses: ./../action/init
         id: init
         with:

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -61,6 +61,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           config-file: .github/codeql/codeql-config-packaging3.yml

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -61,6 +61,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           config-file: .github/codeql/codeql-config-packaging3.yml

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -61,6 +61,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           config-file: .github/codeql/codeql-config-packaging.yml

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -61,6 +61,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           config-file: .github/codeql/codeql-config-packaging2.yml

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -47,6 +47,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -55,6 +55,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           config-file: .github/codeql/codeql-config-packaging3.yml

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -49,6 +49,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         id: init
         with:

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -45,6 +45,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - name: Fetch a CodeQL bundle
         shell: bash
         env:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -47,6 +47,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         id: init
         with:
@@ -54,9 +59,6 @@ jobs:
       # Swift is not supported on Ubuntu so we manually exclude it from the list here
           languages: cpp,csharp,go,java,javascript,python,ruby
           tools: ${{ steps.prepare-test.outputs.tools-url }}
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '>=1.21.0'
       - name: Build code
         shell: bash
         run: env -i PATH="$PATH" HOME="$HOME" ./build.sh

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -49,6 +49,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -49,6 +49,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.21.0'
+          cache: false
       - name: Delete original checkout
         shell: bash
         run: |

--- a/pr-checks/checks/all-platform-bundle.yml
+++ b/pr-checks/checks/all-platform-bundle.yml
@@ -3,12 +3,13 @@ description: "Tests using an all-platform CodeQL Bundle"
 versions: ["nightly-latest"]
 operatingSystems: ["ubuntu"]
 useAllPlatformBundle: "true"
+installGo: "true"
 steps:
   - id: init
     uses: ./../action/init
     with:
       # Swift is not supported on Ubuntu so we manually exclude it from the list here
-      languages: cpp,csharp,go,java,javascript,python,ruby 
+      languages: cpp,csharp,go,java,javascript,python,ruby
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - name: Build code
     shell: bash

--- a/pr-checks/checks/analyze-ref-input.yml
+++ b/pr-checks/checks/analyze-ref-input.yml
@@ -1,6 +1,7 @@
 name: "Analyze: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
 versions: ["default"]
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/build-mode-manual.yml
+++ b/pr-checks/checks/build-mode-manual.yml
@@ -2,6 +2,7 @@ name: "Build mode manual"
 description: "An end-to-end integration test of a Java repository built using 'build-mode: manual'"
 operatingSystems: ["ubuntu"]
 versions: ["nightly-latest"]
+installGo: "true"
 steps:
   - uses: ./../action/init
     id: init

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -1,6 +1,7 @@
 name: "Export file baseline information"
 description: "Tests that file baseline information is exported when the feature is enabled"
 versions: ["nightly-latest"]
+installGo: "true"
 env:
   CODEQL_ACTION_SUBLANGUAGE_FILE_COVERAGE: true
 steps:

--- a/pr-checks/checks/go-custom-queries.yml
+++ b/pr-checks/checks/go-custom-queries.yml
@@ -5,12 +5,10 @@ operatingSystems:
 versions:
   - linked
   - nightly-latest
+installGo: "true"
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      go-version: ">=1.21.0"
   - uses: ./../action/init
     with:
       languages: go

--- a/pr-checks/checks/go-indirect-tracing-workaround-diagnostic.yml
+++ b/pr-checks/checks/go-indirect-tracing-workaround-diagnostic.yml
@@ -4,11 +4,8 @@ description: "Checks that we emit a diagnostic if Go is changed after the init s
 operatingSystems: ["ubuntu"]
 # pinned to a version which does not support statically linked binaries for indirect tracing
 versions: ["default"]
+installGo: "true"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      # We need a Go version that ships with statically linked binaries on Linux
-      go-version: ">=1.21.0"
   - uses: ./../action/init
     with:
       languages: go

--- a/pr-checks/checks/go-indirect-tracing-workaround-no-file-program.yml
+++ b/pr-checks/checks/go-indirect-tracing-workaround-no-file-program.yml
@@ -4,11 +4,8 @@ description: "Checks that we emit a diagnostic if the `file` program is not inst
 operatingSystems: ["ubuntu"]
 # pinned to a version which does not support statically linked binaries for indirect tracing
 versions: ["default"]
+installGo: "true"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      # We need a Go version that ships with statically linked binaries on Linux
-      go-version: ">=1.21.0"
   - name: Remove `file` program
     run: |
       echo $(which file)

--- a/pr-checks/checks/go-indirect-tracing-workaround.yml
+++ b/pr-checks/checks/go-indirect-tracing-workaround.yml
@@ -4,11 +4,8 @@ description: "Checks that our workaround for indirect tracing for Go 1.21+ on Li
 operatingSystems: ["ubuntu"]
 # pinned to a version which does not support statically linked binaries for indirect tracing
 versions: ["default"]
+installGo: "true"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      # We need a Go version that ships with statically linked binaries on Linux
-      go-version: ">=1.21.0"
   - uses: ./../action/init
     with:
       languages: go

--- a/pr-checks/checks/go-tracing-autobuilder.yml
+++ b/pr-checks/checks/go-tracing-autobuilder.yml
@@ -3,13 +3,8 @@ description: "Checks that Go tracing works when using an autobuilder step"
 operatingSystems: ["ubuntu", "macos"]
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
+installGo: "true"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      go-version: "~1.24.0"
-      # to avoid potentially misleading autobuilder results where we expect it to download
-      # dependencies successfully, but they actually come from a warm cache
-      cache: false
   - uses: ./../action/init
     with:
       languages: go

--- a/pr-checks/checks/go-tracing-custom-build-steps.yml
+++ b/pr-checks/checks/go-tracing-custom-build-steps.yml
@@ -1,13 +1,8 @@
 name: "Go: tracing with custom build steps"
 description: "Checks that Go tracing traces the build when using custom build steps"
 operatingSystems: ["ubuntu", "macos"]
+installGo: "true"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      go-version: "~1.24.0"
-      # to avoid potentially misleading autobuilder results where we expect it to download
-      # dependencies successfully, but they actually come from a warm cache
-      cache: false
   - uses: ./../action/init
     with:
       languages: go

--- a/pr-checks/checks/go-tracing-legacy-workflow.yml
+++ b/pr-checks/checks/go-tracing-legacy-workflow.yml
@@ -3,13 +3,8 @@ description: "Checks that we run the autobuilder in legacy workflows with neithe
 operatingSystems: ["ubuntu", "macos"]
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
+installGo: "true"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      go-version: "~1.24.0"
-      # to avoid potentially misleading autobuilder results where we expect it to download
-      # dependencies successfully, but they actually come from a warm cache
-      cache: false
   - uses: ./../action/init
     with:
       languages: go

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -1,11 +1,8 @@
 name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection for macOS"
 operatingSystems: ["macos", "ubuntu"]
+installGo: "true"
 steps:
-  - uses: actions/setup-go@v5
-    with:
-      go-version: ">=1.21.0"
-
   - uses: ./../action/init
     id: init
     with:

--- a/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
@@ -1,6 +1,7 @@
 name: "Packaging: Config and input passed to the CLI"
 description: "Checks that specifying packages using a combination of a config file and input to the Action works"
 versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-config-inputs-js.yml
@@ -1,6 +1,7 @@
 name: "Packaging: Config and input"
 description: "Checks that specifying packages using a combination of a config file and input to the Action works"
 versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-config-js.yml
+++ b/pr-checks/checks/packaging-config-js.yml
@@ -1,6 +1,7 @@
 name: "Packaging: Config file"
 description: "Checks that specifying packages using only a config file works"
 versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/packaging-inputs-js.yml
+++ b/pr-checks/checks/packaging-inputs-js.yml
@@ -1,6 +1,7 @@
 name: "Packaging: Action input"
 description: "Checks that specifying packages using the input to the Action works"
 versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -5,6 +5,7 @@ operatingSystems:
 versions:
   - linked
   - nightly-latest
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/split-workflow.yml
+++ b/pr-checks/checks/split-workflow.yml
@@ -2,6 +2,7 @@ name: "Split workflow"
 description: "Tests a split-up workflow in which we first build a database and later analyze it"
 operatingSystems: ["ubuntu", "macos"]
 versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -2,6 +2,7 @@ name: "Swift analysis using a custom build command"
 description: "Tests creation of a Swift database using custom build"
 versions: ["linked", "default", "nightly-latest"]
 operatingSystems: ["macos"]
+installGo: "true"
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:

--- a/pr-checks/checks/test-local-codeql.yml
+++ b/pr-checks/checks/test-local-codeql.yml
@@ -2,6 +2,7 @@ name: "Local CodeQL bundle"
 description: "Tests using a CodeQL bundle from a local file rather than a URL"
 versions: ["nightly-latest"]
 operatingSystems: ["ubuntu"]
+installGo: "true"
 steps:
   - name: Fetch a CodeQL bundle
     shell: bash

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -5,17 +5,15 @@ operatingSystems:
 versions:
   - linked
   - nightly-latest
+installGo: "true"
 steps:
   - uses: ./../action/init
     id: init
     with:
       db-location: ${{ runner.temp }}/customDbLocation
       # Swift is not supported on Ubuntu so we manually exclude it from the list here
-      languages: cpp,csharp,go,java,javascript,python,ruby 
+      languages: cpp,csharp,go,java,javascript,python,ruby
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - uses: actions/setup-go@v5
-    with:
-      go-version: '>=1.21.0'
   - name: Build code
     shell: bash
     run: env -i PATH="$PATH" HOME="$HOME" ./build.sh

--- a/pr-checks/checks/upload-ref-sha-input.yml
+++ b/pr-checks/checks/upload-ref-sha-input.yml
@@ -1,6 +1,7 @@
 name: "Upload-sarif: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
 versions: ["default"]
+installGo: "true"
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -1,6 +1,7 @@
 name: "Use a custom `checkout_path`"
 description: "Checks that a custom `checkout_path` will find the proper commit_oid"
 versions: ["linked"]
+installGo: "true"
 steps:
   # This ensures we don't accidentally use the original checkout for any part of the test.
   - name: Delete original checkout

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -108,6 +108,22 @@ for file in (this_dir / 'checks').glob('*.yml'):
         },
     ]
 
+    installGo = False
+    if checkSpecification.get('installGo'):
+        installGo = True if checkSpecification['installGo'].lower() == "true" else False
+
+    if installGo:
+        steps.append({
+            'name': 'Install Go',
+            'uses': 'actions/setup-go@v5',
+            'with': {
+                'go-version': '>=1.21.0',
+                # to avoid potentially misleading autobuilder results where we expect it to download
+                # dependencies successfully, but they actually come from a warm cache
+                'cache': False
+            }
+        })
+
     # If container initialisation steps are present in the check specification,
     # make sure to execute them first.
     if 'container' in checkSpecification and 'container-init-steps' in checkSpecification:

--- a/tests/multi-language-repo/build.sh
+++ b/tests/multi-language-repo/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 gcc -o main main.c
 


### PR DESCRIPTION
This PR updates `build.sh` so that it fails if any step in the script fails. Previously, the script would continue running and thus mask unexpected failures. For example, Go is no longer available by default on runners and so an explicit `setup-go` step was required. However, because the script didn't fail, we didn't notice that failure until now.

To address the Go issue, I updated `sync.sh` to understand a new `installGo` input that injects the `setup-go` step into the workflow.

I tried adding it to the local `prepare-test` action first, but this resulted in a number of further issues:

- Adding `setup-go` there, which has a post-action, forced the entire `prepare-test` action to have a post-action, which caused problems because the workflow also moves the location of the `prepare-test` action to outside of the workspace.
- Moving the local actions back to the workspace then caused a bunch of further issues with workflows not expecting there to be a meaningful `.github` folder in the workspace.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
