### PR TITLE
Tests: Update Go to `1.25`

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - id: init
         uses: ./../action/init

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         id: init

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         id: init

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - name: Remove `file` program
         run: |

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         id: init

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         id: init

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - name: Fetch a CodeQL bundle
         shell: bash

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         id: init

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - uses: ./../action/init
         with:

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.0'
+          go-version: 1.25.0-rc.1
           cache: false
       - name: Delete original checkout
         shell: bash

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -117,7 +117,7 @@ for file in (this_dir / 'checks').glob('*.yml'):
             'name': 'Install Go',
             'uses': 'actions/setup-go@v5',
             'with': {
-                'go-version': '>=1.21.0',
+                'go-version': '1.25.0-rc.1',
                 # to avoid potentially misleading autobuilder results where we expect it to download
                 # dependencies successfully, but they actually come from a warm cache
                 'cache': False


### PR DESCRIPTION
This PR updates the version of Go used in the PR test workflows to `1.25`.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
