### PR TITLE
Add workflow for updating release used by `start-proxy`

### DIFF
--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -29,6 +29,13 @@ jobs:
             exit 1
           fi
 
+      - name: Check that the release exists
+        shell: bash
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          (gh release view --repo ${{ github.event.repository.full_name }} --json "assets" "$RELEASE_TAG" && echo "Release found.") || exit 1
+
       - name: Install Node
         uses: actions/setup-node@v4
 

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -exu
-          pr_title="Update release used by `start-proxy` to $RELEASE_TAG"
+          pr_title="Update release used by \`start-proxy\` to $RELEASE_TAG"
           pr_body=$(cat << EOF
             This PR updates the `start-proxy` action to use the private registry proxy binaries that
             are attached as release assets to the `$RELEASE_TAG` release.

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -1,5 +1,8 @@
 name: Update dependency proxy release assets
 on:
+  push:
+    branches:
+      - mbg/update-proxy-binaries # for testing
   workflow_dispatch:
     inputs:
       tag:
@@ -16,7 +19,7 @@ jobs:
       contents: write # needed to push the updated files
       pull-requests: write # needed to create the PR
     env:
-      RELEASE_TAG: ${{ inputs.tag }}
+      RELEASE_TAG: ${{ inputs.tag || 'codeql-bundle-v2.22.0' }}
     steps:
       - name: Install Node
         uses: actions/setup-node@v4

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Push changes and open PR
         shell: bash
         env:
-          BRANCH: "dependency-proxy/$RELEASE_TAG"
+          BRANCH: "dependency-proxy/${{ env.RELEASE_TAG }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -exu

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         run: |
           NOW=$(date +"%Y%m%d%H%M%S") # only used to make sure we don't fetch stale binaries from the toolcache
-          sed -i '' "s|https://github.com/github/codeql-action/releases/download/codeql-bundle-[0-9.]*/|https://github.com/github/codeql-action/releases/download/$RELEASE_TAG/|g" ./src/start-proxy-action.ts
+          sed -i '' "s|https://github.com/github/codeql-action/releases/download/codeql-bundle-v[0-9.]*/|https://github.com/github/codeql-action/releases/download/$RELEASE_TAG/|g" ./src/start-proxy-action.ts
           sed -i '' "s/\"v2.0.[0-9]*\"/\"v2.0.$NOW\"/g" ./src/start-proxy-action.ts
 
       - name: Push changes and open PR

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # ensure we have all tags and can push commits
+          ref: main
 
       - name: Update git config
         shell: bash

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: write # needed to push the updated files
       pull-requests: write # needed to create the PR
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
     steps:
       - name: Install Node
         uses: actions/setup-node@v4
@@ -34,20 +36,20 @@ jobs:
         shell: bash
         run: |
           NOW=$(date +"%Y%m%d%H%M%S") # only used to make sure we don't fetch stale binaries from the toolcache
-          sed -i '' 's|https://github.com/github/codeql-action/releases/download/codeql-bundle-[0-9.]*/|https://github.com/github/codeql-action/releases/download/${{ inputs.tag }}/|g' ./src/start-proxy-action.ts
+          sed -i '' "s|https://github.com/github/codeql-action/releases/download/codeql-bundle-[0-9.]*/|https://github.com/github/codeql-action/releases/download/$RELEASE_TAG/|g" ./src/start-proxy-action.ts
           sed -i '' "s/\"v2.0.[0-9]*\"/\"v2.0.$NOW\"/g" ./src/start-proxy-action.ts
 
       - name: Push changes and open PR
         shell: bash
         env:
-          BRANCH: "dependency-proxy/${{ inputs.tag }}"
+          BRANCH: "dependency-proxy/$RELEASE_TAG"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -exu
-          pr_title="Update release used by `start-proxy` to ${{ inputs.tag }}"
+          pr_title="Update release used by `start-proxy` to $RELEASE_TAG"
           pr_body=$(cat << EOF
             This PR updates the `start-proxy` action to use the private registry proxy binaries that
-            are attached as release assets to the `${{ inputs.tag }}` release.
+            are attached as release assets to the `$RELEASE_TAG` release.
 
 
             Please do the following before merging:

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -51,13 +51,13 @@ jobs:
           set -exu
           pr_title="Update release used by \`start-proxy\` to \`$RELEASE_TAG\`"
           pr_body=$(cat << EOF
-            This PR updates the `start-proxy` action to use the private registry proxy binaries that
-            are attached as release assets to the `$RELEASE_TAG` release.
+            This PR updates the \`start-proxy\` action to use the private registry proxy binaries that
+            are attached as release assets to the \`$RELEASE_TAG\` release.
 
 
             Please do the following before merging:
 
-              - [ ] Verify that the changes to the code are correct.
+            - [ ] Verify that the changes to the code are correct.
           EOF
           )
 

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -exu
-          pr_title="Update release used by \`start-proxy\` to $RELEASE_TAG"
+          pr_title="Update release used by \`start-proxy\` to \`$RELEASE_TAG\`"
           pr_body=$(cat << EOF
             This PR updates the `start-proxy` action to use the private registry proxy binaries that
             are attached as release assets to the `$RELEASE_TAG` release.

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -87,6 +87,7 @@ jobs:
             Please do the following before merging:
 
             - [ ] Verify that the changes to the code are correct.
+            - [ ] Mark the PR as ready for review to trigger the CI.
           EOF
           )
 

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -14,7 +14,7 @@ jobs:
   update:
     name: Update code and create PR
     timeout-minutes: 15
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: write # needed to push the updated files
       pull-requests: write # needed to create the PR

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -22,12 +22,15 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag || 'codeql-bundle-v2.22.0' }}
     steps:
       - name: Check release tag format
+        id: checks
         shell: bash
         run: |
           if ! [[ $RELEASE_TAG =~ ^codeql-bundle-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid release tag: expected a CodeQL bundle tag in the 'codeql-bundle-vM.N.P' format."
             exit 1
           fi
+
+          echo "target_branch=dependency-proxy/$RELEASE_TAG" >> $GITHUB_OUTPUT
 
       - name: Check that the release exists
         shell: bash
@@ -61,7 +64,6 @@ jobs:
       - name: Push changes and open PR
         shell: bash
         env:
-          BRANCH: "dependency-proxy/${{ env.RELEASE_TAG }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -exu
@@ -77,16 +79,16 @@ jobs:
           EOF
           )
 
-          git checkout -b "$BRANCH"
+          git checkout -b "${{ steps.checks.outputs.target_branch }}"
 
           npm run build
           git add ./src/start-proxy-action.ts
           git add ./lib
           git commit -m "$pr_title"
 
-          git push origin "$BRANCH"
+          git push origin "${{ steps.checks.outputs.target_branch }}"
           gh pr create \
-            --head "$BRANCH" \
+            --head "${{ steps.checks.outputs.target_branch }}" \
             --base "main" \
             --title "${pr_title}" \
             --body "${pr_body}" \

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          (gh release view --repo ${{ github.event.repository.full_name }} --json "assets" "$RELEASE_TAG" && echo "Release found.") || exit 1
+          (gh release view --repo "$GITHUB_REPOSITORY" --json "assets" "$RELEASE_TAG" && echo "Release found.") || exit 1
 
       - name: Install Node
         uses: actions/setup-node@v4
@@ -63,9 +63,11 @@ jobs:
 
       - name: Compile TypeScript and commit changes
         shell: bash
+        env:
+          TARGET_BRANCH: ${{ steps.checks.outputs.target_branch }}
         run: |
           set -exu
-          git checkout -b "${{ steps.checks.outputs.target_branch }}"
+          git checkout -b "$TARGET_BRANCH"
 
           npm run build
           git add ./src/start-proxy-action.ts
@@ -76,6 +78,8 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          TARGET_BRANCH: ${{ steps.checks.outputs.target_branch }}
+          PR_FLAG: ${{ (github.event_name == 'workflow_dispatch' && '--draft') || '--dry-run' }}
         run: |
           set -exu
           pr_title="Update release used by \`start-proxy\` to \`$RELEASE_TAG\`"
@@ -91,10 +95,10 @@ jobs:
           EOF
           )
 
-          git push origin "${{ steps.checks.outputs.target_branch }}"
+          git push origin "$TARGET_BRANCH"
           gh pr create \
-            --head "${{ steps.checks.outputs.target_branch }}" \
+            --head "$TARGET_BRANCH" \
             --base "main" \
             --title "${pr_title}" \
             --body "${pr_body}" \
-            ${{ (github.event_name == 'workflow_dispatch' && '--draft') || '--dry-run' }}
+            $PR_FLAG

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -61,6 +61,17 @@ jobs:
           sed -i "s|https://github.com/github/codeql-action/releases/download/codeql-bundle-v[0-9.]\+/|https://github.com/github/codeql-action/releases/download/$RELEASE_TAG/|g" ./src/start-proxy-action.ts
           sed -i "s/\"v2.0.[0-9]\+\"/\"v2.0.$NOW\"/g" ./src/start-proxy-action.ts
 
+      - name: Compile TypeScript and commit changes
+        shell: bash
+        run: |
+          set -exu
+          git checkout -b "${{ steps.checks.outputs.target_branch }}"
+
+          npm run build
+          git add ./src/start-proxy-action.ts
+          git add ./lib
+          git commit -m "Update release used by \`start-proxy\` action"
+
       - name: Push changes and open PR
         shell: bash
         env:
@@ -79,17 +90,10 @@ jobs:
           EOF
           )
 
-          git checkout -b "${{ steps.checks.outputs.target_branch }}"
-
-          npm run build
-          git add ./src/start-proxy-action.ts
-          git add ./lib
-          git commit -m "$pr_title"
-
           git push origin "${{ steps.checks.outputs.target_branch }}"
           gh pr create \
             --head "${{ steps.checks.outputs.target_branch }}" \
             --base "main" \
             --title "${pr_title}" \
             --body "${pr_body}" \
-            --draft
+            ${{ (github.event_name == 'workflow_dispatch' && '--draft') || '--dry-run' }}

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -1,0 +1,72 @@
+name: Update dependency proxy release assets
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The tag of CodeQL Bundle release that contains the proxy binaries as release assets"
+        type: string
+        required: true
+
+jobs:
+  update:
+    name: Update code and create PR
+    timeout-minutes: 15
+    runs-on: macos-latest
+    permissions:
+      contents: write # needed to push the updated files
+      pull-requests: write # needed to create the PR
+    steps:
+      - name: Install Node
+        uses: actions/setup-node@v4
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # ensure we have all tags and can push commits
+
+      - name: Update git config
+        shell: bash
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Update release tag and version
+        shell: bash
+        run: |
+          NOW=$(date +"%Y%m%d%H%M%S") # only used to make sure we don't fetch stale binaries from the toolcache
+          sed -i '' 's|https://github.com/github/codeql-action/releases/download/codeql-bundle-[0-9.]*/|https://github.com/github/codeql-action/releases/download/${{ inputs.tag }}/|g' ./src/start-proxy-action.ts
+          sed -i '' "s/\"v2.0.[0-9]*\"/\"v2.0.$NOW\"/g" ./src/start-proxy-action.ts
+
+      - name: Push changes and open PR
+        shell: bash
+        env:
+          BRANCH: "dependency-proxy/${{ inputs.tag }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          set -exu
+          pr_title="Update release used by `start-proxy` to ${{ inputs.tag }}"
+          pr_body=$(cat << EOF
+            This PR updates the `start-proxy` action to use the private registry proxy binaries that
+            are attached as release assets to the `${{ inputs.tag }}` release.
+
+
+            Please do the following before merging:
+
+              - [ ] Verify that the changes to the code are correct.
+          EOF
+          )
+
+          git checkout -b "$BRANCH"
+
+          npm run build
+          git add ./src/start-proxy-action.ts
+          git add ./lib
+          git commit -m "$pr_title"
+
+          git push origin "$BRANCH"
+          gh pr create \
+            --head "$BRANCH" \
+            --base "main" \
+            --title "${pr_title}" \
+            --body "${pr_body}" \
+            --draft

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -1,8 +1,5 @@
 name: Update dependency proxy release assets
 on:
-  push:
-    branches:
-      - mbg/update-proxy-binaries # for testing
   workflow_dispatch:
     inputs:
       tag:
@@ -19,7 +16,7 @@ jobs:
       contents: write # needed to push the updated files
       pull-requests: write # needed to create the PR
     env:
-      RELEASE_TAG: ${{ inputs.tag || 'codeql-bundle-v2.22.0' }}
+      RELEASE_TAG: ${{ inputs.tag }}
     steps:
       - name: Check release tag format
         id: checks

--- a/.github/workflows/update-proxy-release.yml
+++ b/.github/workflows/update-proxy-release.yml
@@ -21,6 +21,14 @@ jobs:
     env:
       RELEASE_TAG: ${{ inputs.tag || 'codeql-bundle-v2.22.0' }}
     steps:
+      - name: Check release tag format
+        shell: bash
+        run: |
+          if ! [[ $RELEASE_TAG =~ ^codeql-bundle-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: expected a CodeQL bundle tag in the 'codeql-bundle-vM.N.P' format."
+            exit 1
+          fi
+
       - name: Install Node
         uses: actions/setup-node@v4
 
@@ -40,8 +48,8 @@ jobs:
         shell: bash
         run: |
           NOW=$(date +"%Y%m%d%H%M%S") # only used to make sure we don't fetch stale binaries from the toolcache
-          sed -i '' "s|https://github.com/github/codeql-action/releases/download/codeql-bundle-v[0-9.]*/|https://github.com/github/codeql-action/releases/download/$RELEASE_TAG/|g" ./src/start-proxy-action.ts
-          sed -i '' "s/\"v2.0.[0-9]*\"/\"v2.0.$NOW\"/g" ./src/start-proxy-action.ts
+          sed -i "s|https://github.com/github/codeql-action/releases/download/codeql-bundle-v[0-9.]\+/|https://github.com/github/codeql-action/releases/download/$RELEASE_TAG/|g" ./src/start-proxy-action.ts
+          sed -i "s/\"v2.0.[0-9]\+\"/\"v2.0.$NOW\"/g" ./src/start-proxy-action.ts
 
       - name: Push changes and open PR
         shell: bash


### PR DESCRIPTION
This PR adds a new workflow which automates the creation of PRs that update which release is used by the `start-proxy` action to pull binaries of the `update-job-proxy` from. 

Previously, I manually created PRs [such as this one](https://github.com/github/codeql-action/pull/2869) for that. The new workflow here creates similar ones, [such as this example](https://github.com/github/codeql-action/pull/2944).

This PR currently contains a commit that adds a `push` trigger (limited to this branch) for testing, which should be removed before merging this PR.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
