### PR TITLE
Swift: recreate a default Swift package to fix test

### DIFF
--- a/tests/multi-language-repo/.gitignore
+++ b/tests/multi-language-repo/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/tests/multi-language-repo/Package.swift
+++ b/tests/multi-language-repo/Package.swift
@@ -1,26 +1,15 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "helloWorld",
-    products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
-        .library(
-            name: "helloWorld",
-            targets: ["helloWorld"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    name: "multi-language-repo",
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "helloWorld",
-            path: "swift-custom-build/helloWorld"
-        )
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "multi-language-repo",
+            path: "Sources"),
     ]
 )

--- a/tests/multi-language-repo/Sources/main.swift
+++ b/tests/multi-language-repo/Sources/main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world!")


### PR DESCRIPTION
It seems like the `Package.swift` trying to reuse the source code of the xcode project is not buildable by Swift 5.8.1 (or 5.9.2 for what matters). This just generates an independent default executable package with `swift package init` (using swift 5.8.1).

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
