### PR TITLE
Add changelog entry for v3.28.20 backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ No user facing changes.
 - Update default CodeQL bundle version to 2.22.0. [#2925](https://github.com/github/codeql-action/pull/2925)
 - Bump minimum CodeQL bundle version to 2.16.6. [#2912](https://github.com/github/codeql-action/pull/2912)
 
+## 3.28.20 - 21 July 2025
+
+- Remove support for combining SARIF files from a single upload for GHES 3.18, see [the changelog post](https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload/). [#2959](https://github.com/github/codeql-action/pull/2959)
+
 ## 3.28.19 - 03 Jun 2025
 
 - The CodeQL Action no longer includes its own copy of the extractor for the `actions` language, which is currently in public preview.


### PR DESCRIPTION
This adds the changelog entry for the v3.28.20 release into the changelog on `main`.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [x] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
