### PR TITLE
Add Copilot instructions for release PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,18 +8,14 @@ GitHub Actions workflows in the `.github/workflows` directory whose filenames st
 
 ## Release process
 
-- Do not review PRs that match any of the following release-PR patterns:
+- A release-PR is a PR which matches all of the following patterns:
   - PR title starts with the exact prefix: `Merge main into releases/v`
     - Equivalent regex: `^Merge main into releases\/v`
-  - OR head (source) branch matches the update-branch pattern:
+  - AND head (source) branch matches the update-branch pattern:
     - Regex: `^update-v[0-9]+(?:\.[0-9]+)*(?:-[a-f0-9]+)?` (e.g. `update-v3.29.9-cc722e476`)
-  - OR base (target) branch matches a release branch:
+  - AND base (target) branch matches a release branch:
     - Regex: `^releases\/v` (e.g. `releases/v3`)
 
-- In PRs that match the release-PR patterns above:
-  - Review only the following files:
+- Consider all files in release-PRs to have already been reviewed and do not review them, except for the following two files:
     - `CHANGELOG.md`
     - `package.json`
-  - Do not review other files in those PRs (these are considered mechanically generated updates).
-
-- If a PR matches the release-PR patterns but includes changes outside the two files above, do not attempt a full review of the generated changes — treat non-`CHANGELOG.md`/`package.json` edits as not requiring review.


### PR DESCRIPTION
I wrote some notes for this and then let Copilot edit them.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
