### PR TITLE
Add workflow generator option for installing Java

### DIFF
--- a/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
+++ b/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
@@ -21,9 +21,19 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      java-version:
+        type: string
+        description: The version of Java to install
+        required: false
+        default: '17'
   workflow_call:
-    inputs: {}
+    inputs:
+      java-version:
+        type: string
+        description: The version of Java to install
+        required: false
+        default: '17'
 jobs:
   autobuild-direct-tracing-with-working-dir:
     strategy:
@@ -54,6 +64,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java-version || '17' }}
+          distribution: temurin
       - name: Test setup
         shell: bash
         run: |

--- a/.github/workflows/__autobuild-direct-tracing.yml
+++ b/.github/workflows/__autobuild-direct-tracing.yml
@@ -21,9 +21,19 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      java-version:
+        type: string
+        description: The version of Java to install
+        required: false
+        default: '17'
   workflow_call:
-    inputs: {}
+    inputs:
+      java-version:
+        type: string
+        description: The version of Java to install
+        required: false
+        default: '17'
 jobs:
   autobuild-direct-tracing:
     strategy:
@@ -54,6 +64,11 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java-version || '17' }}
+          distribution: temurin
       - name: Set up Java test repo configuration
         shell: bash
         run: |

--- a/pr-checks/checks/autobuild-direct-tracing-with-working-dir.yml
+++ b/pr-checks/checks/autobuild-direct-tracing-with-working-dir.yml
@@ -5,6 +5,7 @@ description: >
   autobuild Action.
 operatingSystems: ["ubuntu", "windows"]
 versions: ["linked", "nightly-latest"]
+installJava: "true"
 env:
   CODEQL_ACTION_AUTOBUILD_BUILD_MODE_DIRECT_TRACING: true
 steps:

--- a/pr-checks/checks/autobuild-direct-tracing.yml
+++ b/pr-checks/checks/autobuild-direct-tracing.yml
@@ -2,6 +2,7 @@ name: "Autobuild direct tracing"
 description: "An end-to-end integration test of a Java repository built using 'build-mode: autobuild', with direct tracing enabled"
 operatingSystems: ["ubuntu", "windows"]
 versions: ["linked", "nightly-latest"]
+installJava: "true"
 env:
   CODEQL_ACTION_AUTOBUILD_BUILD_MODE_DIRECT_TRACING: true
 steps:
@@ -19,7 +20,7 @@ steps:
       db-location: "${{ runner.temp }}/customDbLocation"
       languages: java
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-    
+
   - name: Check that indirect tracing is disabled
     shell: bash
     run: |

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -114,9 +114,7 @@ for file in sorted((this_dir / 'checks').glob('*.yml')):
         },
     ]
 
-    installGo = False
-    if checkSpecification.get('installGo'):
-        installGo = True if checkSpecification['installGo'].lower() == "true" else False
+    installGo = checkSpecification.get('installGo', '').lower() == 'true'
 
     if installGo:
         baseGoVersionExpr = '>=1.21.0'
@@ -138,9 +136,7 @@ for file in sorted((this_dir / 'checks').glob('*.yml')):
             }
         })
 
-    installJava = False
-    if checkSpecification.get('installJava'):
-        installJava = True if checkSpecification['installJava'].lower() == "true" else False
+    installJava = checkSpecification.get('installJava', '').lower() == 'true'
 
     if installJava:
         baseJavaVersionExpr = '17'

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -138,6 +138,28 @@ for file in sorted((this_dir / 'checks').glob('*.yml')):
             }
         })
 
+    installJava = False
+    if checkSpecification.get('installJava'):
+        installJava = True if checkSpecification['installJava'].lower() == "true" else False
+
+    if installJava:
+        baseJavaVersionExpr = '17'
+        workflowInputs['java-version'] = {
+            'type': 'string',
+            'description': 'The version of Java to install',
+            'required': False,
+            'default': baseJavaVersionExpr,
+        }
+
+        steps.append({
+            'name': 'Install Java',
+            'uses': 'actions/setup-java@v4',
+            'with': {
+                'java-version': '${{ inputs.java-version || \'' + baseJavaVersionExpr + '\' }}',
+                'distribution': 'temurin'
+            }
+        })
+
     # If container initialisation steps are present in the check specification,
     # make sure to execute them first.
     if 'container' in checkSpecification and 'container-init-steps' in checkSpecification:


### PR DESCRIPTION
Gradle 9 is now the default version of Gradle on the GHA runners. This seems to cause failures because JDK 8 is the default and Gradle 9 requires JDK 17.

This PR adds a new `installJava` option to the `sync.py` script which behaves exactly the same as `installGo`, except for `setup-java`.

I have added `installJava: "true"` to the two workflows we have seen fail.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
