### PR TITLE
Accept `git_source` registry configurations for Go

### DIFF
--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -47823,7 +47823,7 @@ var LANGUAGE_TO_REGISTRY_TYPE = {
   python: ["python_index"],
   ruby: ["rubygems_server"],
   rust: ["cargo_registry"],
-  go: ["goproxy_server"]
+  go: ["goproxy_server", "git_source"]
 };
 function isDefined(value) {
   return value !== void 0 && value !== null;

--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -47817,13 +47817,13 @@ function parseLanguage(language) {
   return void 0;
 }
 var LANGUAGE_TO_REGISTRY_TYPE = {
-  java: "maven_repository",
-  csharp: "nuget_feed",
-  javascript: "npm_registry",
-  python: "python_index",
-  ruby: "rubygems_server",
-  rust: "cargo_registry",
-  go: "goproxy_server"
+  java: ["maven_repository"],
+  csharp: ["nuget_feed"],
+  javascript: ["npm_registry"],
+  python: ["python_index"],
+  ruby: ["rubygems_server"],
+  rust: ["cargo_registry"],
+  go: ["goproxy_server"]
 };
 function isDefined(value) {
   return value !== void 0 && value !== null;
@@ -47870,7 +47870,7 @@ function getCredentials(logger, registrySecrets, registriesCredentials, language
         "Invalid credentials - must specify host or url"
       );
     }
-    if (registryTypeForLanguage && e.type !== registryTypeForLanguage) {
+    if (registryTypeForLanguage && !registryTypeForLanguage.some((t) => t === e.type)) {
       continue;
     }
     const isPrintable2 = (str2) => {

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -55,14 +55,14 @@ export function parseLanguage(language: string): KnownLanguage | undefined {
   return undefined;
 }
 
-const LANGUAGE_TO_REGISTRY_TYPE: Partial<Record<KnownLanguage, string>> = {
-  java: "maven_repository",
-  csharp: "nuget_feed",
-  javascript: "npm_registry",
-  python: "python_index",
-  ruby: "rubygems_server",
-  rust: "cargo_registry",
-  go: "goproxy_server",
+const LANGUAGE_TO_REGISTRY_TYPE: Partial<Record<KnownLanguage, string[]>> = {
+  java: ["maven_repository"],
+  csharp: ["nuget_feed"],
+  javascript: ["npm_registry"],
+  python: ["python_index"],
+  ruby: ["rubygems_server"],
+  rust: ["cargo_registry"],
+  go: ["goproxy_server"],
 } as const;
 
 /**
@@ -140,7 +140,10 @@ export function getCredentials(
 
     // Filter credentials based on language if specified. `type` is the registry type.
     // E.g., "maven_feed" for Java/Kotlin, "nuget_repository" for C#.
-    if (registryTypeForLanguage && e.type !== registryTypeForLanguage) {
+    if (
+      registryTypeForLanguage &&
+      !registryTypeForLanguage.some((t) => t === e.type)
+    ) {
       continue;
     }
 

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -62,7 +62,7 @@ const LANGUAGE_TO_REGISTRY_TYPE: Partial<Record<KnownLanguage, string[]>> = {
   python: ["python_index"],
   ruby: ["rubygems_server"],
   rust: ["cargo_registry"],
-  go: ["goproxy_server"],
+  go: ["goproxy_server", "git_source"],
 } as const;
 
 /**


### PR DESCRIPTION
This allows `git_source` registry configurations for Go. 

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
