### PR TITLE
Fix `hasActionsWorkflows` throwing an exception if the workflows folder doesn't exist

### DIFF
--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -87169,7 +87169,7 @@ async function getSupportedLanguageMap(codeql) {
 var baseWorkflowsPath = ".github/workflows";
 function hasActionsWorkflows(sourceRoot) {
   const workflowsPath = path10.resolve(sourceRoot, baseWorkflowsPath);
-  const stats = fs9.lstatSync(workflowsPath);
+  const stats = fs9.lstatSync(workflowsPath, { throwIfNoEntry: false });
   return stats !== void 0 && stats.isDirectory() && fs9.readdirSync(workflowsPath).length > 0;
 }
 async function getRawLanguagesInRepo(repository, sourceRoot, logger) {

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -1755,3 +1755,9 @@ for (const language in KnownLanguage) {
     },
   );
 }
+
+test("hasActionsWorkflows doesn't throw if workflows folder doesn't exist", async (t) => {
+  return withTmpDir(async (tmpDir) => {
+    t.notThrows(() => configUtils.hasActionsWorkflows(tmpDir));
+  });
+});

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -341,7 +341,7 @@ const baseWorkflowsPath = ".github/workflows";
  */
 export function hasActionsWorkflows(sourceRoot: string): boolean {
   const workflowsPath = path.resolve(sourceRoot, baseWorkflowsPath);
-  const stats = fs.lstatSync(workflowsPath);
+  const stats = fs.lstatSync(workflowsPath, { throwIfNoEntry: false });
   return (
     stats !== undefined &&
     stats.isDirectory() &&


### PR DESCRIPTION
This problem was introduced in https://github.com/github/codeql-action/pull/3009 since `lstatSync` throws an exception by default if the filesystem object doesn't exist. 

We likely didn't come across this because it requires both of the following conditions to hold:

- There is no `.github/workflows` folder
- And there is no input to `languages`

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
