### PR TITLE
Add C# artifacts to `.gitignore` for `multi-language-repo`

### DIFF
--- a/tests/multi-language-repo/.gitignore
+++ b/tests/multi-language-repo/.gitignore
@@ -1,9 +1,11 @@
 .DS_Store
 /.build
 /Packages
+/obj
 /*.xcodeproj
 xcuserdata/
 DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+multi-language-repo.sln


### PR DESCRIPTION
Since I have C# extensions for VSCode installed, it likes to generate some files in the `multi-language-repo` folder when I have the `codeql-action` workspace open. This updates the `.gitignore` file to ignore those files.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
