### PR TITLE
Resolve pylint `no-else-return / R1705`

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -145,8 +145,7 @@ def get_truncated_commit_message(commit):
   message = commit.commit.message.split('\n')[0]
   if len(message) > 60:
     return f'{message[:57]}...'
-  else:
-    return message
+  return message
 
 # Converts a commit into the PR that introduced it to the source branch.
 # Returns the PR object, or None if no PR could be found.
@@ -158,8 +157,7 @@ def get_pr_for_commit(commit):
     prs = list(prs)
     sorted_prs = sorted(prs, key=lambda pr: int(pr.number))
     return sorted_prs[0]
-  else:
-    return None
+  return None
 
 # Get the person who merged the pull request.
 # For most cases this will be the same as the author, but for PRs opened


### PR DESCRIPTION
This change resolves the [`no-else-return / R1705`](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html) warning. **No** further problems of this type are reported.
### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.
- ~**High risk:** Changes are not fully under feature flags, have limited visibility and/or cannot be tested outside of production.~

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
