### PR TITLE
Dump soon to be uploaded SARIF on request

### DIFF
--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -95612,6 +95612,10 @@ async function uploadSpecifiedFiles(sarifPaths, checkoutPath, category, features
   validateUniqueCategory(sarif, uploadTarget.sentinelPrefix);
   logger.debug(`Serializing SARIF for upload`);
   const sarifPayload = JSON.stringify(sarif);
+  const dumpDir = process.env["CODEQL_ACTION_SARIF_DUMP_DIR" /* SARIF_DUMP_DIR */];
+  if (dumpDir) {
+    dumpSarifFile(sarifPayload, dumpDir, logger, uploadTarget);
+  }
   logger.debug(`Compressing serialized SARIF`);
   const zippedSarif = import_zlib.default.gzipSync(sarifPayload).toString("base64");
   const checkoutURI = url.pathToFileURL(checkoutPath).href;
@@ -95649,6 +95653,21 @@ async function uploadSpecifiedFiles(sarifPaths, checkoutPath, category, features
     },
     sarifID
   };
+}
+function dumpSarifFile(sarifPayload, outputDir, logger, uploadTarget) {
+  if (!fs18.existsSync(outputDir)) {
+    fs18.mkdirSync(outputDir, { recursive: true });
+  } else if (!fs18.lstatSync(outputDir).isDirectory()) {
+    throw new ConfigurationError(
+      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`
+    );
+  }
+  const outputFile = path18.resolve(
+    outputDir,
+    `upload${uploadTarget.sarifExtension}`
+  );
+  logger.info(`Dumping processed SARIF file to ${outputFile}`);
+  fs18.writeFileSync(outputFile, sarifPayload);
 }
 var STATUS_CHECK_FREQUENCY_MILLISECONDS = 5 * 1e3;
 var STATUS_CHECK_TIMEOUT_MILLISECONDS = 2 * 60 * 1e3;

--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -95659,7 +95659,7 @@ function dumpSarifFile(sarifPayload, outputDir, logger, uploadTarget) {
     fs18.mkdirSync(outputDir, { recursive: true });
   } else if (!fs18.lstatSync(outputDir).isDirectory()) {
     throw new ConfigurationError(
-      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`
+      `The path specified by the ${"CODEQL_ACTION_SARIF_DUMP_DIR" /* SARIF_DUMP_DIR */} environment variable exists and is not a directory: ${outputDir}`
     );
   }
   const outputFile = path18.resolve(

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -92468,7 +92468,7 @@ function dumpSarifFile(sarifPayload, outputDir, logger, uploadTarget) {
     fs13.mkdirSync(outputDir, { recursive: true });
   } else if (!fs13.lstatSync(outputDir).isDirectory()) {
     throw new ConfigurationError(
-      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`
+      `The path specified by the ${"CODEQL_ACTION_SARIF_DUMP_DIR" /* SARIF_DUMP_DIR */} environment variable exists and is not a directory: ${outputDir}`
     );
   }
   const outputFile = path14.resolve(

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -92421,6 +92421,10 @@ async function uploadSpecifiedFiles(sarifPaths, checkoutPath, category, features
   validateUniqueCategory(sarif, uploadTarget.sentinelPrefix);
   logger.debug(`Serializing SARIF for upload`);
   const sarifPayload = JSON.stringify(sarif);
+  const dumpDir = process.env["CODEQL_ACTION_SARIF_DUMP_DIR" /* SARIF_DUMP_DIR */];
+  if (dumpDir) {
+    dumpSarifFile(sarifPayload, dumpDir, logger, uploadTarget);
+  }
   logger.debug(`Compressing serialized SARIF`);
   const zippedSarif = import_zlib.default.gzipSync(sarifPayload).toString("base64");
   const checkoutURI = url.pathToFileURL(checkoutPath).href;
@@ -92458,6 +92462,21 @@ async function uploadSpecifiedFiles(sarifPaths, checkoutPath, category, features
     },
     sarifID
   };
+}
+function dumpSarifFile(sarifPayload, outputDir, logger, uploadTarget) {
+  if (!fs13.existsSync(outputDir)) {
+    fs13.mkdirSync(outputDir, { recursive: true });
+  } else if (!fs13.lstatSync(outputDir).isDirectory()) {
+    throw new ConfigurationError(
+      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`
+    );
+  }
+  const outputFile = path14.resolve(
+    outputDir,
+    `upload${uploadTarget.sarifExtension}`
+  );
+  logger.info(`Dumping processed SARIF file to ${outputFile}`);
+  fs13.writeFileSync(outputFile, sarifPayload);
 }
 var STATUS_CHECK_FREQUENCY_MILLISECONDS = 5 * 1e3;
 var STATUS_CHECK_TIMEOUT_MILLISECONDS = 2 * 60 * 1e3;

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93169,7 +93169,7 @@ function dumpSarifFile(sarifPayload, outputDir, logger, uploadTarget) {
     fs14.mkdirSync(outputDir, { recursive: true });
   } else if (!fs14.lstatSync(outputDir).isDirectory()) {
     throw new ConfigurationError(
-      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`
+      `The path specified by the ${"CODEQL_ACTION_SARIF_DUMP_DIR" /* SARIF_DUMP_DIR */} environment variable exists and is not a directory: ${outputDir}`
     );
   }
   const outputFile = path15.resolve(

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93122,6 +93122,10 @@ async function uploadSpecifiedFiles(sarifPaths, checkoutPath, category, features
   validateUniqueCategory(sarif, uploadTarget.sentinelPrefix);
   logger.debug(`Serializing SARIF for upload`);
   const sarifPayload = JSON.stringify(sarif);
+  const dumpDir = process.env["CODEQL_ACTION_SARIF_DUMP_DIR" /* SARIF_DUMP_DIR */];
+  if (dumpDir) {
+    dumpSarifFile(sarifPayload, dumpDir, logger, uploadTarget);
+  }
   logger.debug(`Compressing serialized SARIF`);
   const zippedSarif = import_zlib.default.gzipSync(sarifPayload).toString("base64");
   const checkoutURI = url.pathToFileURL(checkoutPath).href;
@@ -93159,6 +93163,21 @@ async function uploadSpecifiedFiles(sarifPaths, checkoutPath, category, features
     },
     sarifID
   };
+}
+function dumpSarifFile(sarifPayload, outputDir, logger, uploadTarget) {
+  if (!fs14.existsSync(outputDir)) {
+    fs14.mkdirSync(outputDir, { recursive: true });
+  } else if (!fs14.lstatSync(outputDir).isDirectory()) {
+    throw new ConfigurationError(
+      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`
+    );
+  }
+  const outputFile = path15.resolve(
+    outputDir,
+    `upload${uploadTarget.sarifExtension}`
+  );
+  logger.info(`Dumping processed SARIF file to ${outputFile}`);
+  fs14.writeFileSync(outputFile, sarifPayload);
 }
 var STATUS_CHECK_FREQUENCY_MILLISECONDS = 5 * 1e3;
 var STATUS_CHECK_TIMEOUT_MILLISECONDS = 2 * 60 * 1e3;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -119,4 +119,10 @@ export enum EnvVar {
    * Whether to enable experimental extractors for CodeQL.
    */
   EXPERIMENTAL_FEATURES = "CODEQL_ENABLE_EXPERIMENTAL_FEATURES",
+
+  /**
+   * Whether and where to dump the processed SARIF file that would be uploaded, regardless of
+   * whether the upload is disabled. This is intended for testing and debugging purposes.
+   */
+  SARIF_DUMP_DIR = "CODEQL_ACTION_SARIF_DUMP_DIR",
 }

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -696,6 +696,12 @@ export async function uploadSpecifiedFiles(
   validateUniqueCategory(sarif, uploadTarget.sentinelPrefix);
   logger.debug(`Serializing SARIF for upload`);
   const sarifPayload = JSON.stringify(sarif);
+
+  const dumpDir = process.env[EnvVar.SARIF_DUMP_DIR];
+  if (dumpDir) {
+    dumpSarifFile(sarifPayload, dumpDir, logger, uploadTarget);
+  }
+
   logger.debug(`Compressing serialized SARIF`);
   const zippedSarif = zlib.gzipSync(sarifPayload).toString("base64");
   const checkoutURI = url.pathToFileURL(checkoutPath).href;
@@ -740,6 +746,30 @@ export async function uploadSpecifiedFiles(
     },
     sarifID,
   };
+}
+
+/**
+ * Dumps the given processed SARIF file contents to `outputDir`.
+ */
+function dumpSarifFile(
+  sarifPayload: string,
+  outputDir: string,
+  logger: Logger,
+  uploadTarget: analyses.AnalysisConfig,
+) {
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  } else if (!fs.lstatSync(outputDir).isDirectory()) {
+    throw new ConfigurationError(
+      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`,
+    );
+  }
+  const outputFile = path.resolve(
+    outputDir,
+    `upload${uploadTarget.sarifExtension}`,
+  );
+  logger.info(`Dumping processed SARIF file to ${outputFile}`);
+  fs.writeFileSync(outputFile, sarifPayload);
 }
 
 const STATUS_CHECK_FREQUENCY_MILLISECONDS = 5 * 1000;

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -761,7 +761,7 @@ function dumpSarifFile(
     fs.mkdirSync(outputDir, { recursive: true });
   } else if (!fs.lstatSync(outputDir).isDirectory()) {
     throw new ConfigurationError(
-      `The path specified by the CODEQL_ACTION_SARIF_DUMP_DIR environment variable exists and is not a directory: ${outputDir}`,
+      `The path specified by the ${EnvVar.SARIF_DUMP_DIR} environment variable exists and is not a directory: ${outputDir}`,
     );
   }
   const outputFile = path.resolve(


### PR DESCRIPTION
This introduces a new internal environment variable flag (`CODEQL_ACTION_SARIF_DUMP_DIR`) that, when set to `true`, causes the SARIF file that will be uploaded to be dumped to the specified directory. The filename will be `upload.sarif` or `upload.quality.sarif` depending on the upload target.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
