### PR TITLE
Fix `runInterpretResultsFor` using the wrong `AnalysisConfig` for Code Quality `category` fix

### DIFF
--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -93706,7 +93706,7 @@ async function runQueries(sarifFolder, memoryFlag, addSnippetsFlag, threadsFlag,
   async function runInterpretResultsFor(analysis, language, queries, enableDebugLogging) {
     logger.info(`Interpreting ${analysis.name} results for ${language}`);
     let category = automationDetailsId;
-    if (dbAnalysisConfig.kind === "code-quality" /* CodeQuality */) {
+    if (analysis.kind === "code-quality" /* CodeQuality */) {
       category = fixCodeQualityCategory(logger, automationDetailsId);
     }
     const sarifFile = path16.join(

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -780,7 +780,7 @@ export async function runQueries(
     // If this is a Code Quality analysis, correct the category to one
     // accepted by the Code Quality backend.
     let category = automationDetailsId;
-    if (dbAnalysisConfig.kind === analyses.AnalysisKind.CodeQuality) {
+    if (analysis.kind === analyses.AnalysisKind.CodeQuality) {
       category = fixCodeQualityCategory(logger, automationDetailsId);
     }
 


### PR DESCRIPTION
We accidentally kept `dbAnalysisConfig` here when refactoring this into its own function, instead of `analysis`. This meant that the check never succeeded, unless `code-quality` was the only active analysis.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
