### PR TITLE
init-action: save updated config

### DIFF
--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -87687,7 +87687,6 @@ async function initConfig(inputs) {
       exclude: { tags: "exclude-from-incremental" }
     });
   }
-  await saveConfig(config, logger);
   return config;
 }
 function parseRegistries(registriesInput) {

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -229,7 +229,7 @@ test("load code quality config", async (t) => {
   });
 });
 
-test("loading config saves config", async (t) => {
+test("loading a saved config produces the same config", async (t) => {
   return await withTmpDir(async (tempDir) => {
     const logger = getRunnerLogger(true);
 
@@ -259,6 +259,7 @@ test("loading config saves config", async (t) => {
         logger,
       }),
     );
+    await configUtils.saveConfig(config1, logger);
 
     // The saved config file should now exist
     t.true(fs.existsSync(configUtils.getPathToParsedConfigFile(tempDir)));
@@ -300,7 +301,7 @@ test("loading config with version mismatch throws", async (t) => {
       .stub(actionsUtil, "getActionVersion")
       .returns("does-not-exist");
 
-    await configUtils.initConfig(
+    const config = await configUtils.initConfig(
       createTestInitConfigInputs({
         languagesInput: "javascript,python",
         tempDir,
@@ -309,6 +310,8 @@ test("loading config with version mismatch throws", async (t) => {
         logger,
       }),
     );
+    // initConfig does not save the config, so we do it here.
+    await configUtils.saveConfig(config, logger);
 
     // Restore `getActionVersion`.
     getActionVersionStub.restore();

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -1189,9 +1189,6 @@ export async function initConfig(inputs: InitConfigInputs): Promise<Config> {
       exclude: { tags: "exclude-from-incremental" },
     });
   }
-
-  // Save the config so we can easily access it again in the future
-  await saveConfig(config, logger);
   return config;
 }
 

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -681,10 +681,10 @@ async function run() {
     logUnwrittenDiagnostics();
   }
 
-  // We may have updated the config returned from `initConfig`, e.g. to revert
-  // to `OverlayDatabaseMode.None` if we failed to download an overlay-base
-  // database. So we save the config again, to ensure that the `analyze` step
-  // reads the correct config.
+  // We save the config here instead of at the end of `initConfig` because we
+  // may have updated the config returned from `initConfig`, e.g. to revert to
+  // `OverlayDatabaseMode.None` if we failed to download an overlay-base
+  // database.
   await configUtils.saveConfig(config, logger);
   await sendCompletedStatusReport(
     startedAt,


### PR DESCRIPTION
This PR updates the init action to save the config again at the end of `run()`, so that config updates in `run()` are correctly propagated to the analyze action.

<!-- For GitHub staff: Remember that this is a public repository. -->

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
