### PR TITLE
Use `browser_download_url` instead of `url`

### DIFF
--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -49528,10 +49528,10 @@ async function getDownloadUrl(logger) {
     for (const asset of cliRelease.data.assets) {
       if (asset.name === proxyPackage) {
         logger.info(
-          `Found '${proxyPackage}' in release '${bundleVersion}' at '${asset.url}'`
+          `Found '${proxyPackage}' in release '${bundleVersion}' at '${asset.browser_download_url}'`
         );
         return {
-          url: asset.url,
+          url: asset.browser_download_url,
           // The `update-job-proxy` doesn't have a version as such. Since we now bundle it
           // with CodeQL CLI bundle releases, we use the corresponding CLI version to
           // differentiate between (potentially) different versions of `update-job-proxy`.

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -255,8 +255,11 @@ test("getDownloadUrl returns fallback when there's no matching release asset", a
 
 test("getDownloadUrl returns matching release asset", async (t) => {
   const assets = [
-    { name: "foo", url: "other-url" },
-    { name: startProxyExports.getProxyPackage(), url: "url-we-want" },
+    { name: "foo", browser_download_url: "other-url" },
+    {
+      name: startProxyExports.getProxyPackage(),
+      browser_download_url: "url-we-want",
+    },
   ];
   mockGetReleaseByTag(assets);
 

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -231,10 +231,10 @@ export async function getDownloadUrl(
     for (const asset of cliRelease.data.assets) {
       if (asset.name === proxyPackage) {
         logger.info(
-          `Found '${proxyPackage}' in release '${defaults.bundleVersion}' at '${asset.url}'`,
+          `Found '${proxyPackage}' in release '${defaults.bundleVersion}' at '${asset.browser_download_url}'`,
         );
         return {
-          url: asset.url,
+          url: asset.browser_download_url,
           // The `update-job-proxy` doesn't have a version as such. Since we now bundle it
           // with CodeQL CLI bundle releases, we use the corresponding CLI version to
           // differentiate between (potentially) different versions of `update-job-proxy`.


### PR DESCRIPTION
Fixes a bug with https://github.com/github/codeql-action/pull/3110, where we used `url` instead of `browser_download_url`.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
