### PR TITLE
[Do not merge] Specify `Accept` header for `toolcache.downloadTool`

### DIFF
--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -49682,7 +49682,14 @@ async function getProxyBinaryPath(logger) {
   const proxyInfo = await getDownloadUrl(logger);
   let proxyBin = toolcache.find(proxyFileName, proxyInfo.version);
   if (!proxyBin) {
-    const temp = await toolcache.downloadTool(proxyInfo.url);
+    const temp = await toolcache.downloadTool(
+      proxyInfo.url,
+      void 0,
+      void 0,
+      {
+        accept: "application/octet-stream"
+      }
+    );
     const extracted = await toolcache.extractTar(temp);
     proxyBin = await toolcache.cacheDir(
       extracted,

--- a/src/start-proxy-action.ts
+++ b/src/start-proxy-action.ts
@@ -192,7 +192,14 @@ async function getProxyBinaryPath(logger: Logger): Promise<string> {
 
   let proxyBin = toolcache.find(proxyFileName, proxyInfo.version);
   if (!proxyBin) {
-    const temp = await toolcache.downloadTool(proxyInfo.url);
+    const temp = await toolcache.downloadTool(
+      proxyInfo.url,
+      undefined,
+      undefined,
+      {
+        accept: "application/octet-stream",
+      },
+    );
     const extracted = await toolcache.extractTar(temp);
     proxyBin = await toolcache.cacheDir(
       extracted,


### PR DESCRIPTION
For testing against `main` only.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.
- **High risk:** Changes are not fully under feature flags, have limited visibility and/or cannot be tested outside of production.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
