### PR TITLE
Fix `upload-sarif` Action failing if there are no Code Scanning SARIF files

### DIFF
--- a/.github/workflows/__upload-quality-sarif.yml
+++ b/.github/workflows/__upload-quality-sarif.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}
-          languages: cpp,csharp,java,javascript,python
+          languages: csharp,java,javascript,python
           analysis-kinds: code-quality
       - name: Build code
         run: ./build.sh

--- a/.github/workflows/__upload-quality-sarif.yml
+++ b/.github/workflows/__upload-quality-sarif.yml
@@ -89,7 +89,7 @@ jobs:
           ref: refs/heads/main
           sha: 5e235361806c361d4d3f8859e3c897658025a9a2
       - name: Check output from `upload-sarif` step
-        if: fromJSON(steps.upload-sarif.sarif-ids)[0].analysis != 'code-quality'
+        if: fromJSON(steps.upload-sarif.outputs.sarif-ids)[0].analysis != 'code-quality'
         run: exit 1
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__upload-quality-sarif.yml
+++ b/.github/workflows/__upload-quality-sarif.yml
@@ -74,9 +74,7 @@ jobs:
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}
           languages: cpp,csharp,java,javascript,python
-          config-file: ${{ github.repository }}/tests/multi-language-repo/.github/codeql/custom-queries.yml@${{
-            github.sha }}
-          analysis-kinds: code-scanning,code-quality
+          analysis-kinds: code-quality
       - name: Build code
         run: ./build.sh
   # Generate some SARIF we can upload with the upload-sarif step
@@ -86,8 +84,12 @@ jobs:
           sha: 5e235361806c361d4d3f8859e3c897658025a9a2
           upload: never
       - uses: ./../action/upload-sarif
+        id: upload-sarif
         with:
           ref: refs/heads/main
           sha: 5e235361806c361d4d3f8859e3c897658025a9a2
+      - name: Check output from `upload-sarif` step
+        if: fromJSON(steps.upload-sarif.sarif-ids)[0].analysis != 'code-quality'
+        run: exit 1
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93401,6 +93401,7 @@ async function run() {
     if (pathStats === void 0) {
       throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
     }
+    const sarifIds = [];
     const uploadResult = await findAndUpload(
       logger,
       features,
@@ -93412,8 +93413,12 @@ async function run() {
     );
     if (uploadResult !== void 0) {
       core13.setOutput("sarif-id", uploadResult.sarifID);
+      sarifIds.push({
+        analysis: "code-scanning" /* CodeScanning */,
+        id: uploadResult.sarifID
+      });
     }
-    await findAndUpload(
+    const qualityUploadResult = await findAndUpload(
       logger,
       features,
       sarifPath,
@@ -93422,6 +93427,13 @@ async function run() {
       CodeQuality,
       fixCodeQualityCategory(logger, category)
     );
+    if (qualityUploadResult !== void 0) {
+      sarifIds.push({
+        analysis: "code-quality" /* CodeQuality */,
+        id: qualityUploadResult.sarifID
+      });
+    }
+    core13.setOutput("sarif-ids", JSON.stringify(sarifIds));
     if (isInTestMode()) {
       core13.debug("In test mode. Waiting for processing is disabled.");
     } else if (getRequiredInput("wait-for-processing") === "true") {

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -92985,23 +92985,6 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   walkSarifFiles(sarifPath);
   return sarifFiles;
 }
-function getSarifFilePaths(sarifPath, isSarif) {
-  if (!fs14.existsSync(sarifPath)) {
-    throw new ConfigurationError(`Path does not exist: ${sarifPath}`);
-  }
-  let sarifFiles;
-  if (fs14.lstatSync(sarifPath).isDirectory()) {
-    sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
-    if (sarifFiles.length === 0) {
-      throw new ConfigurationError(
-        `No SARIF files found to upload in "${sarifPath}".`
-      );
-    }
-  } else {
-    sarifFiles = [sarifPath];
-  }
-  return sarifFiles;
-}
 function countResultsInSarif(sarif) {
   let numResults = 0;
   const parsedSarif = JSON.parse(sarif);
@@ -93096,20 +93079,6 @@ function buildPayload(commitOid, ref, analysisKey, analysisName, zippedSarif, wo
     }
   }
   return payloadObj;
-}
-async function uploadFiles(inputSarifPath, checkoutPath, category, features, logger, uploadTarget) {
-  const sarifPaths = getSarifFilePaths(
-    inputSarifPath,
-    uploadTarget.sarifPredicate
-  );
-  return uploadSpecifiedFiles(
-    sarifPaths,
-    checkoutPath,
-    category,
-    features,
-    logger,
-    uploadTarget
-  );
 }
 async function uploadSpecifiedFiles(sarifPaths, checkoutPath, category, features, logger, uploadTarget) {
   logger.startGroup(`Uploading ${uploadTarget.name} results`);
@@ -93432,15 +93401,18 @@ async function run() {
     if (pathStats === void 0) {
       throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
     }
-    const uploadResult = await uploadFiles(
-      sarifPath,
-      checkoutPath,
-      category,
-      features,
+    const uploadResult = await findAndUpload(
       logger,
-      CodeScanning
+      features,
+      sarifPath,
+      pathStats,
+      checkoutPath,
+      CodeScanning,
+      category
     );
-    core13.setOutput("sarif-id", uploadResult.sarifID);
+    if (uploadResult !== void 0) {
+      core13.setOutput("sarif-id", uploadResult.sarifID);
+    }
     await findAndUpload(
       logger,
       features,
@@ -93453,13 +93425,19 @@ async function run() {
     if (isInTestMode()) {
       core13.debug("In test mode. Waiting for processing is disabled.");
     } else if (getRequiredInput("wait-for-processing") === "true") {
-      await waitForProcessing(
-        getRepositoryNwo(),
-        uploadResult.sarifID,
-        logger
-      );
+      if (uploadResult !== void 0) {
+        await waitForProcessing(
+          getRepositoryNwo(),
+          uploadResult.sarifID,
+          logger
+        );
+      }
     }
-    await sendSuccessStatusReport(startedAt, uploadResult.statusReport, logger);
+    await sendSuccessStatusReport(
+      startedAt,
+      uploadResult?.statusReport || {},
+      logger
+    );
   } catch (unwrappedError) {
     const error2 = isThirdPartyAnalysis("upload-sarif" /* UploadSarif */) && unwrappedError instanceof InvalidSarifUploadError ? new ConfigurationError(unwrappedError.message) : wrapError(unwrappedError);
     const message = error2.message;

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93358,20 +93358,22 @@ function filterAlertsByDiffRange(logger, sarif) {
 }
 
 // src/upload-sarif-action.ts
-async function findAndUpload(logger, features, sarifPath, checkoutPath, analysis, category) {
-  const sarifFiles = findSarifFilesInDir(
-    sarifPath,
-    analysis.sarifPredicate
-  );
-  if (sarifFiles.length !== 0) {
-    return await uploadSpecifiedFiles(
-      sarifFiles,
-      checkoutPath,
-      category,
-      features,
-      logger,
-      analysis
+async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
+  if (pathStats.isDirectory()) {
+    const sarifFiles = findSarifFilesInDir(
+      sarifPath,
+      analysis.sarifPredicate
     );
+    if (sarifFiles.length !== 0) {
+      return await uploadSpecifiedFiles(
+        sarifFiles,
+        checkoutPath,
+        category,
+        features,
+        logger,
+        analysis
+      );
+    }
   }
   return void 0;
 }
@@ -93434,16 +93436,15 @@ async function run() {
       CodeScanning
     );
     core13.setOutput("sarif-id", uploadResult.sarifID);
-    if (pathStats.isDirectory()) {
-      await findAndUpload(
-        logger,
-        features,
-        sarifPath,
-        checkoutPath,
-        CodeQuality,
-        fixCodeQualityCategory(logger, category)
-      );
-    }
+    await findAndUpload(
+      logger,
+      features,
+      sarifPath,
+      pathStats,
+      checkoutPath,
+      CodeQuality,
+      fixCodeQualityCategory(logger, category)
+    );
     if (isInTestMode()) {
       core13.debug("In test mode. Waiting for processing is disabled.");
     } else if (getRequiredInput("wait-for-processing") === "true") {

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93359,21 +93359,26 @@ function filterAlertsByDiffRange(logger, sarif) {
 
 // src/upload-sarif-action.ts
 async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
+  let sarifFiles;
   if (pathStats.isDirectory()) {
-    const sarifFiles = findSarifFilesInDir(
+    sarifFiles = findSarifFilesInDir(
       sarifPath,
       analysis.sarifPredicate
     );
-    if (sarifFiles.length !== 0) {
-      return await uploadSpecifiedFiles(
-        sarifFiles,
-        checkoutPath,
-        category,
-        features,
-        logger,
-        analysis
-      );
-    }
+  } else if (pathStats.isFile() && analysis.sarifPredicate(sarifPath)) {
+    sarifFiles = [sarifPath];
+  } else {
+    return void 0;
+  }
+  if (sarifFiles.length !== 0) {
+    return await uploadSpecifiedFiles(
+      sarifFiles,
+      checkoutPath,
+      category,
+      features,
+      logger,
+      analysis
+    );
   }
   return void 0;
 }

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93358,6 +93358,23 @@ function filterAlertsByDiffRange(logger, sarif) {
 }
 
 // src/upload-sarif-action.ts
+async function findAndUpload(logger, features, sarifPath, checkoutPath, analysis, category) {
+  const sarifFiles = findSarifFilesInDir(
+    sarifPath,
+    analysis.sarifPredicate
+  );
+  if (sarifFiles.length !== 0) {
+    return await uploadSpecifiedFiles(
+      sarifFiles,
+      checkoutPath,
+      category,
+      features,
+      logger,
+      analysis
+    );
+  }
+  return void 0;
+}
 async function sendSuccessStatusReport(startedAt, uploadStats, logger) {
   const statusReportBase = await createStatusReportBase(
     "upload-sarif" /* UploadSarif */,
@@ -93414,20 +93431,14 @@ async function run() {
     );
     core13.setOutput("sarif-id", uploadResult.sarifID);
     if (fs15.lstatSync(sarifPath).isDirectory()) {
-      const qualitySarifFiles = findSarifFilesInDir(
+      await findAndUpload(
+        logger,
+        features,
         sarifPath,
-        CodeQuality.sarifPredicate
+        checkoutPath,
+        CodeQuality,
+        fixCodeQualityCategory(logger, category)
       );
-      if (qualitySarifFiles.length !== 0) {
-        await uploadSpecifiedFiles(
-          qualitySarifFiles,
-          checkoutPath,
-          fixCodeQualityCategory(logger, category),
-          features,
-          logger,
-          CodeQuality
-        );
-      }
     }
     if (isInTestMode()) {
       core13.debug("In test mode. Waiting for processing is disabled.");

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93421,6 +93421,10 @@ async function run() {
     const sarifPath = getRequiredInput("sarif_file");
     const checkoutPath = getRequiredInput("checkout_path");
     const category = getOptionalInput("category");
+    const pathStats = fs15.lstatSync(sarifPath, { throwIfNoEntry: false });
+    if (pathStats === void 0) {
+      throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
+    }
     const uploadResult = await uploadFiles(
       sarifPath,
       checkoutPath,
@@ -93430,7 +93434,7 @@ async function run() {
       CodeScanning
     );
     core13.setOutput("sarif-id", uploadResult.sarifID);
-    if (fs15.lstatSync(sarifPath).isDirectory()) {
+    if (pathStats.isDirectory()) {
       await findAndUpload(
         logger,
         features,

--- a/pr-checks/checks/upload-quality-sarif.yml
+++ b/pr-checks/checks/upload-quality-sarif.yml
@@ -22,5 +22,5 @@ steps:
       ref: 'refs/heads/main'
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'
   - name: "Check output from `upload-sarif` step"
-    if: fromJSON(steps.upload-sarif.sarif-ids)[0].analysis != 'code-quality'
+    if: fromJSON(steps.upload-sarif.outputs.sarif-ids)[0].analysis != 'code-quality'
     run: exit 1

--- a/pr-checks/checks/upload-quality-sarif.yml
+++ b/pr-checks/checks/upload-quality-sarif.yml
@@ -7,8 +7,7 @@ steps:
     with:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
       languages: cpp,csharp,java,javascript,python
-      config-file: ${{ github.repository }}/tests/multi-language-repo/.github/codeql/custom-queries.yml@${{ github.sha }}
-      analysis-kinds: code-scanning,code-quality
+      analysis-kinds: code-quality
   - name: Build code
     run: ./build.sh
   # Generate some SARIF we can upload with the upload-sarif step
@@ -18,6 +17,10 @@ steps:
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'
       upload: never
   - uses: ./../action/upload-sarif
+    id: upload-sarif
     with:
       ref: 'refs/heads/main'
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'
+  - name: "Check output from `upload-sarif` step"
+    if: fromJSON(steps.upload-sarif.sarif-ids)[0].analysis != 'code-quality'
+    run: exit 1

--- a/pr-checks/checks/upload-quality-sarif.yml
+++ b/pr-checks/checks/upload-quality-sarif.yml
@@ -6,7 +6,7 @@ steps:
   - uses: ./../action/init
     with:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-      languages: cpp,csharp,java,javascript,python
+      languages: csharp,java,javascript,python
       analysis-kinds: code-quality
   - name: Build code
     run: ./build.sh

--- a/src/upload-sarif-action.ts
+++ b/src/upload-sarif-action.ts
@@ -164,8 +164,6 @@ async function run() {
     }
 
     // If there are `.quality.sarif` files in `sarifPath`, then upload those to the code quality service.
-    // Code quality can currently only be enabled on top of security, so we'd currently always expect to
-    // have a directory for the results here.
     const qualityUploadResult = await findAndUpload(
       logger,
       features,

--- a/src/upload-sarif-action.ts
+++ b/src/upload-sarif-action.ts
@@ -129,6 +129,11 @@ async function run() {
     const sarifPath = actionsUtil.getRequiredInput("sarif_file");
     const checkoutPath = actionsUtil.getRequiredInput("checkout_path");
     const category = actionsUtil.getOptionalInput("category");
+    const pathStats = fs.lstatSync(sarifPath, { throwIfNoEntry: false });
+
+    if (pathStats === undefined) {
+      throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
+    }
 
     const uploadResult = await upload_lib.uploadFiles(
       sarifPath,
@@ -143,7 +148,7 @@ async function run() {
     // If there are `.quality.sarif` files in `sarifPath`, then upload those to the code quality service.
     // Code quality can currently only be enabled on top of security, so we'd currently always expect to
     // have a directory for the results here.
-    if (fs.lstatSync(sarifPath).isDirectory()) {
+    if (pathStats.isDirectory()) {
       await findAndUpload(
         logger,
         features,

--- a/src/upload-sarif-action.ts
+++ b/src/upload-sarif-action.ts
@@ -145,6 +145,7 @@ async function run() {
       throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
     }
 
+    const sarifIds: Array<{ analysis: string; id: string }> = [];
     const uploadResult = await findAndUpload(
       logger,
       features,
@@ -156,12 +157,16 @@ async function run() {
     );
     if (uploadResult !== undefined) {
       core.setOutput("sarif-id", uploadResult.sarifID);
+      sarifIds.push({
+        analysis: analyses.AnalysisKind.CodeScanning,
+        id: uploadResult.sarifID,
+      });
     }
 
     // If there are `.quality.sarif` files in `sarifPath`, then upload those to the code quality service.
     // Code quality can currently only be enabled on top of security, so we'd currently always expect to
     // have a directory for the results here.
-    await findAndUpload(
+    const qualityUploadResult = await findAndUpload(
       logger,
       features,
       sarifPath,
@@ -170,6 +175,13 @@ async function run() {
       analyses.CodeQuality,
       actionsUtil.fixCodeQualityCategory(logger, category),
     );
+    if (qualityUploadResult !== undefined) {
+      sarifIds.push({
+        analysis: analyses.AnalysisKind.CodeQuality,
+        id: qualityUploadResult.sarifID,
+      });
+    }
+    core.setOutput("sarif-ids", JSON.stringify(sarifIds));
 
     // We don't upload results in test mode, so don't wait for processing
     if (isInTestMode()) {

--- a/upload-sarif/action.yml
+++ b/upload-sarif/action.yml
@@ -34,7 +34,12 @@ inputs:
     default: "true"
 outputs:
   sarif-id:
-    description: The ID of the uploaded SARIF file.
+    description: The ID of the uploaded Code Scanning SARIF file, if any.
+  sarif-ids:
+    description: |
+      A stringified JSON object containing the SARIF ID for each kind of analysis. For example:
+
+      { "code-scanning": "some-id", "code-quality": "some-other-id" }
 runs:
   using: node20
   main: '../lib/upload-sarif-action.js'


### PR DESCRIPTION
In https://github.com/github/codeql-action/pull/3064, we overlooked that `upload_lib.uploadFiles` is called in the `upload-sarif` Action, which will fail if it cannot find any SARIF files matching the predicate it is given.

For a Code Quality only analysis, there are no Code Scanning SARIF files and the call to `upload_lib.uploadFiles` therefore fails before the Code Quality SARIF file(s) can be uploaded.

This PR refactors the `upload-sarif` Action so that there's common code for Code Scanning and Code Quality to upload either one file or several matching files.

There are some optional, other changes in this PR as well, which I can remove if needed:

- ~The `UploadStatusReport` values for each SARIF upload are now combined for telemetry if both analysis kinds are enabled. Otherwise, we use the respective `UploadStatusReport`.~
- I have added a new `sarif-ids` output to the `upload-sarif` Action, which contains a stringified JSON object with details of the SARIF ids that we uploaded to different endpoints. Initially I went for just a comma-separated list of IDs, but I thought it would be useful to know which ID is for which service.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
