### PR TITLE
Rename withTimeout() to waitForResultWithTimeLimit()

### DIFF
--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -89754,7 +89754,7 @@ async function tryGetFolderBytes(cacheDir, logger, quiet = false) {
   }
 }
 var hadTimeout = false;
-async function withTimeout(timeoutMs, promise, onTimeout) {
+async function waitForResultWithTimeLimit(timeoutMs, promise, onTimeout) {
   let finished2 = false;
   const mainTask = async () => {
     const result = await promise;
@@ -90940,7 +90940,7 @@ async function uploadOverlayBaseDatabaseToCache(codeql, config, logger) {
     `Uploading overlay-base database to Actions cache with key ${cacheSaveKey}`
   );
   try {
-    const cacheId = await withTimeout(
+    const cacheId = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.saveCache([dbLocation], cacheSaveKey),
       () => {
@@ -91498,7 +91498,7 @@ async function uploadTrapCaches(codeql, config, logger) {
       process.env.GITHUB_SHA || "unknown"
     );
     logger.info(`Uploading TRAP cache to Actions cache with key ${key}`);
-    await withTimeout(
+    await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS2,
       actionsCache2.saveCache([cacheDir], key),
       () => {

--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -85619,7 +85619,7 @@ async function tryGetFolderBytes(cacheDir, logger, quiet = false) {
   }
 }
 var hadTimeout = false;
-async function withTimeout(timeoutMs, promise, onTimeout) {
+async function waitForResultWithTimeLimit(timeoutMs, promise, onTimeout) {
   let finished2 = false;
   const mainTask = async () => {
     const result = await promise;
@@ -86521,7 +86521,7 @@ async function downloadOverlayBaseDatabaseFromCache(codeql, config, logger) {
   let databaseDownloadDurationMs = 0;
   try {
     const databaseDownloadStart = performance.now();
-    const foundKey = await withTimeout(
+    const foundKey = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.restoreCache([dbLocation], cacheRestoreKeyPrefix),
       () => {
@@ -87106,7 +87106,7 @@ async function downloadTrapCaches(codeql, languages, logger) {
     logger.info(
       `Looking in Actions cache for TRAP cache with key ${preferredKey}`
     );
-    const found = await withTimeout(
+    const found = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS2,
       actionsCache2.restoreCache([cacheDir], preferredKey, [
         // Fall back to any cache with the right key prefix

--- a/src/overlay-database-utils.ts
+++ b/src/overlay-database-utils.ts
@@ -10,7 +10,11 @@ import { type CodeQL } from "./codeql";
 import { type Config } from "./config-utils";
 import { getCommitOid, getFileOidsUnderPath } from "./git-utils";
 import { Logger, withGroupAsync } from "./logging";
-import { isInTestMode, tryGetFolderBytes, withTimeout } from "./util";
+import {
+  isInTestMode,
+  tryGetFolderBytes,
+  waitForResultWithTimeLimit,
+} from "./util";
 
 export enum OverlayDatabaseMode {
   Overlay = "overlay",
@@ -268,7 +272,7 @@ export async function uploadOverlayBaseDatabaseToCache(
   );
 
   try {
-    const cacheId = await withTimeout(
+    const cacheId = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.saveCache([dbLocation], cacheSaveKey),
       () => {},
@@ -346,7 +350,7 @@ export async function downloadOverlayBaseDatabaseFromCache(
   let databaseDownloadDurationMs = 0;
   try {
     const databaseDownloadStart = performance.now();
-    const foundKey = await withTimeout(
+    const foundKey = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.restoreCache([dbLocation], cacheRestoreKeyPrefix),
       () => {

--- a/src/trap-caching.ts
+++ b/src/trap-caching.ts
@@ -16,7 +16,7 @@ import {
   getErrorMessage,
   isHTTPError,
   tryGetFolderBytes,
-  withTimeout,
+  waitForResultWithTimeLimit,
 } from "./util";
 
 // This constant should be bumped if we make a breaking change
@@ -96,7 +96,7 @@ export async function downloadTrapCaches(
     logger.info(
       `Looking in Actions cache for TRAP cache with key ${preferredKey}`,
     );
-    const found = await withTimeout(
+    const found = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.restoreCache([cacheDir], preferredKey, [
         // Fall back to any cache with the right key prefix
@@ -156,7 +156,7 @@ export async function uploadTrapCaches(
       process.env.GITHUB_SHA || "unknown",
     );
     logger.info(`Uploading TRAP cache to Actions cache with key ${key}`);
-    await withTimeout(
+    await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.saveCache([cacheDir], key),
       () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -297,7 +297,7 @@ test("listFolder", async (t) => {
 const longTime = 999_999;
 const shortTime = 10;
 
-test("withTimeout on long task", async (t) => {
+test("waitForResultWithTimeLimit on long task", async (t) => {
   let longTaskTimedOut = false;
   const longTask = new Promise((resolve) => {
     const timer = setTimeout(() => {
@@ -305,35 +305,43 @@ test("withTimeout on long task", async (t) => {
     }, longTime);
     t.teardown(() => clearTimeout(timer));
   });
-  const result = await util.withTimeout(shortTime, longTask, () => {
-    longTaskTimedOut = true;
-  });
+  const result = await util.waitForResultWithTimeLimit(
+    shortTime,
+    longTask,
+    () => {
+      longTaskTimedOut = true;
+    },
+  );
   t.deepEqual(longTaskTimedOut, true);
   t.deepEqual(result, undefined);
 });
 
-test("withTimeout on short task", async (t) => {
+test("waitForResultWithTimeLimit on short task", async (t) => {
   let shortTaskTimedOut = false;
   const shortTask = new Promise((resolve) => {
     setTimeout(() => {
       resolve(99);
     }, shortTime);
   });
-  const result = await util.withTimeout(longTime, shortTask, () => {
-    shortTaskTimedOut = true;
-  });
+  const result = await util.waitForResultWithTimeLimit(
+    longTime,
+    shortTask,
+    () => {
+      shortTaskTimedOut = true;
+    },
+  );
   t.deepEqual(shortTaskTimedOut, false);
   t.deepEqual(result, 99);
 });
 
-test("withTimeout doesn't call callback if promise resolves", async (t) => {
+test("waitForResultWithTimeLimit doesn't call callback if promise resolves", async (t) => {
   let shortTaskTimedOut = false;
   const shortTask = new Promise((resolve) => {
     setTimeout(() => {
       resolve(99);
     }, shortTime);
   });
-  const result = await util.withTimeout(100, shortTask, () => {
+  const result = await util.waitForResultWithTimeLimit(100, shortTask, () => {
     shortTaskTimedOut = true;
   });
   await new Promise((r) => setTimeout(r, 200));

--- a/src/util.ts
+++ b/src/util.ts
@@ -864,7 +864,7 @@ let hadTimeout = false;
  * @param onTimeout A callback to call if the promise times out.
  * @returns The result of the promise, or undefined if the promise times out.
  */
-export async function withTimeout<T>(
+export async function waitForResultWithTimeLimit<T>(
   timeoutMs: number,
   promise: Promise<T>,
   onTimeout: () => void,
@@ -894,7 +894,7 @@ export async function withTimeout<T>(
  * Check if the global hadTimeout variable has been set, and if so then
  * exit the process to ensure any background tasks that are still running
  * are killed. This should be called at the end of execution if the
- * `withTimeout` function has been used.
+ * `waitForResultWithTimeLimit` function has been used.
  */
 export async function checkForTimeout() {
   if (hadTimeout === true) {


### PR DESCRIPTION
The name `withTimeout()` gives the impression that it would limit the execution of the promise to the given time bound. But that is not the case: it is only the _waiting_ that is limited, and the promise would keep running beyond the time bound.

This PR renames `withTimeout()` to `waitForResultWithTimeLimit()` so that developers are more likely to understand the actual behavior of this function.

<!-- For GitHub staff: Remember that this is a public repository. -->

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
