### PR TITLE
Add `concurrency` settings to PR checks

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   all-platform-bundle:
     strategy:

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   analyze-ref-input:
     strategy:

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   autobuild-action:
     strategy:

--- a/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
+++ b/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   autobuild-direct-tracing-with-working-dir:
     strategy:

--- a/.github/workflows/__autobuild-direct-tracing.yml
+++ b/.github/workflows/__autobuild-direct-tracing.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   autobuild-direct-tracing:
     strategy:

--- a/.github/workflows/__build-mode-autobuild.yml
+++ b/.github/workflows/__build-mode-autobuild.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   build-mode-autobuild:
     strategy:

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   build-mode-manual:
     strategy:

--- a/.github/workflows/__build-mode-none.yml
+++ b/.github/workflows/__build-mode-none.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   build-mode-none:
     strategy:

--- a/.github/workflows/__build-mode-rollback.yml
+++ b/.github/workflows/__build-mode-rollback.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   build-mode-rollback:
     strategy:

--- a/.github/workflows/__bundle-toolcache.yml
+++ b/.github/workflows/__bundle-toolcache.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bundle-toolcache:
     strategy:

--- a/.github/workflows/__bundle-zstd.yml
+++ b/.github/workflows/__bundle-zstd.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   bundle-zstd:
     strategy:

--- a/.github/workflows/__cleanup-db-cluster-dir.yml
+++ b/.github/workflows/__cleanup-db-cluster-dir.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   cleanup-db-cluster-dir:
     strategy:

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   config-export:
     strategy:

--- a/.github/workflows/__config-input.yml
+++ b/.github/workflows/__config-input.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   config-input:
     strategy:

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   cpp-deptrace-disabled:
     strategy:

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   cpp-deptrace-enabled-on-macos:
     strategy:

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   cpp-deptrace-enabled:
     strategy:

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   diagnostics-export:
     strategy:

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   export-file-baseline-information:
     strategy:

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   extractor-ram-threads:
     strategy:

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   go-custom-queries:
     strategy:

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   go-indirect-tracing-workaround-diagnostic:
     strategy:

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   go-indirect-tracing-workaround-no-file-program:
     strategy:

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   go-indirect-tracing-workaround:
     strategy:

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   go-tracing-autobuilder:
     strategy:

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   go-tracing-custom-build-steps:
     strategy:

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   go-tracing-legacy-workflow:
     strategy:

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   init-with-registries:
     strategy:

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   javascript-source-root:
     strategy:

--- a/.github/workflows/__job-run-uuid-sarif.yml
+++ b/.github/workflows/__job-run-uuid-sarif.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   job-run-uuid-sarif:
     strategy:

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   language-aliases:
     strategy:

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   multi-language-autodetect:
     strategy:

--- a/.github/workflows/__overlay-init-fallback.yml
+++ b/.github/workflows/__overlay-init-fallback.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   overlay-init-fallback:
     strategy:

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   packaging-codescanning-config-inputs-js:
     strategy:

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   packaging-config-inputs-js:
     strategy:

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   packaging-config-js:
     strategy:

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   packaging-inputs-js:
     strategy:

--- a/.github/workflows/__quality-queries.yml
+++ b/.github/workflows/__quality-queries.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   quality-queries:
     strategy:

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   remote-config:
     strategy:

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   resolve-environment-action:
     strategy:

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   rubocop-multi-language:
     strategy:

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   ruby:
     strategy:

--- a/.github/workflows/__rust.yml
+++ b/.github/workflows/__rust.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   rust:
     strategy:

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   split-workflow:
     strategy:

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   start-proxy:
     strategy:

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   submit-sarif-failure:
     strategy:

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   swift-autobuild:
     strategy:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   swift-custom-build:
     strategy:

--- a/.github/workflows/__test-autobuild-working-dir.yml
+++ b/.github/workflows/__test-autobuild-working-dir.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   test-autobuild-working-dir:
     strategy:

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   test-local-codeql:
     strategy:

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -27,6 +27,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   test-proxy:
     strategy:

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   unset-environment:
     strategy:

--- a/.github/workflows/__upload-quality-sarif.yml
+++ b/.github/workflows/__upload-quality-sarif.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   upload-quality-sarif:
     strategy:

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   upload-ref-sha-input:
     strategy:

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -37,6 +37,9 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   with-checkout-path:
     strategy:

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -269,6 +269,17 @@ for file in sorted((this_dir / 'checks').glob('*.yml')):
                     'shell': 'bash',
                 },
             },
+            'concurrency': {
+                # Cancel in-progress workflows in the same 'group' for pull_request events,
+                # but other event types. This should have the effect that workflows on PRs
+                # get cancelled if there is a newer workflow in the same concurrency group.
+                # For other events, the new workflows should wait until earlier ones have finished.
+                # This should help reduce the number of concurrent workflows on the repo, and
+                # consequently the number of concurrent API requests.
+                'cancel-in-progress': "${{ github.event_name == 'pull_request' }}",
+                # The group is determined by the workflow name + the ref
+                'group': "${{ github.workflow }}-${{ github.ref }}"
+            },
             'jobs': {
                 checkName: checkJob
             }

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -271,7 +271,7 @@ for file in sorted((this_dir / 'checks').glob('*.yml')):
             },
             'concurrency': {
                 # Cancel in-progress workflows in the same 'group' for pull_request events,
-                # but other event types. This should have the effect that workflows on PRs
+                # but not other event types. This should have the effect that workflows on PRs
                 # get cancelled if there is a newer workflow in the same concurrency group.
                 # For other events, the new workflows should wait until earlier ones have finished.
                 # This should help reduce the number of concurrent workflows on the repo, and


### PR DESCRIPTION
This PR updates `sync.py` to add `concurrency` settings to all PR checks so that:

- There is one concurrency group per workflow per `ref`.
- For `pull_request` events, in-progress workflows in the same concurrency group are cancelled if a new workflow is starting.
- For other events, new workflows will wait until previous ones in the same concurrency group have finished.

This should reduce the number of concurrent workflows that we have running for the repo.
### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
