### PR TITLE
Provide `Authorization` header when downloading `update-job-proxy`

### DIFF
--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -90198,6 +90198,14 @@ function getApiDetails() {
 function getApiClient() {
   return createApiClientWithDetails(getApiDetails());
 }
+function getAuthorizationHeaderFor(logger, apiDetails, url2, purpose = "CodeQL tools") {
+  if (url2.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && url2.startsWith(`${apiDetails.apiURL}/`)) {
+    logger.debug(`Providing an authorization token to download ${purpose}.`);
+    return `token ${apiDetails.auth}`;
+  }
+  logger.debug(`Downloading ${purpose} without an authorization token.`);
+  return void 0;
+}
 var cachedGitHubVersion = void 0;
 async function getGitHubVersionFromApi(apiClient, apiDetails) {
   if (parseGitHubUrl(apiDetails.url) === GITHUB_DOTCOM_URL) {
@@ -92391,11 +92399,12 @@ var downloadCodeQL = async function(codeqlURL, compressionMethod, maybeBundleVer
   let authorization = void 0;
   if (searchParams.has("token")) {
     logger.debug("CodeQL tools URL contains an authorization token.");
-  } else if (codeqlURL.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && codeqlURL.startsWith(`${apiDetails.apiURL}/`)) {
-    logger.debug("Providing an authorization token to download CodeQL tools.");
-    authorization = `token ${apiDetails.auth}`;
   } else {
-    logger.debug("Downloading CodeQL tools without an authorization token.");
+    authorization = getAuthorizationHeaderFor(
+      logger,
+      apiDetails,
+      codeqlURL
+    );
   }
   const toolcacheInfo = getToolcacheDestinationInfo(
     maybeBundleVersion,

--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -86053,6 +86053,14 @@ function getApiClient() {
 function getApiClientWithExternalAuth(apiDetails) {
   return createApiClientWithDetails(apiDetails, { allowExternal: true });
 }
+function getAuthorizationHeaderFor(logger, apiDetails, url, purpose = "CodeQL tools") {
+  if (url.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && url.startsWith(`${apiDetails.apiURL}/`)) {
+    logger.debug(`Providing an authorization token to download ${purpose}.`);
+    return `token ${apiDetails.auth}`;
+  }
+  logger.debug(`Downloading ${purpose} without an authorization token.`);
+  return void 0;
+}
 var cachedGitHubVersion = void 0;
 async function getGitHubVersionFromApi(apiClient, apiDetails) {
   if (parseGitHubUrl(apiDetails.url) === GITHUB_DOTCOM_URL) {
@@ -89163,11 +89171,12 @@ var downloadCodeQL = async function(codeqlURL, compressionMethod, maybeBundleVer
   let authorization = void 0;
   if (searchParams.has("token")) {
     logger.debug("CodeQL tools URL contains an authorization token.");
-  } else if (codeqlURL.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && codeqlURL.startsWith(`${apiDetails.apiURL}/`)) {
-    logger.debug("Providing an authorization token to download CodeQL tools.");
-    authorization = `token ${apiDetails.auth}`;
   } else {
-    logger.debug("Downloading CodeQL tools without an authorization token.");
+    authorization = getAuthorizationHeaderFor(
+      logger,
+      apiDetails,
+      codeqlURL
+    );
   }
   const toolcacheInfo = getToolcacheDestinationInfo(
     maybeBundleVersion,

--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -49356,17 +49356,8 @@ var persistInputs = function() {
   core4.saveState(persistedInputsKey, JSON.stringify(inputEnvironmentVariables));
 };
 
-// src/logging.ts
-var core5 = __toESM(require_core());
-function getActionsLogger() {
-  return core5;
-}
-
-// src/start-proxy.ts
-var core7 = __toESM(require_core());
-
 // src/api-client.ts
-var core6 = __toESM(require_core());
+var core5 = __toESM(require_core());
 var githubUtils = __toESM(require_utils4());
 var retry = __toESM(require_dist_node15());
 var import_console_log_level = __toESM(require_console_log_level());
@@ -49391,6 +49382,23 @@ function getApiDetails() {
 function getApiClient() {
   return createApiClientWithDetails(getApiDetails());
 }
+function getAuthorizationHeaderFor(logger, apiDetails, url, purpose = "CodeQL tools") {
+  if (url.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && url.startsWith(`${apiDetails.apiURL}/`)) {
+    logger.debug(`Providing an authorization token to download ${purpose}.`);
+    return `token ${apiDetails.auth}`;
+  }
+  logger.debug(`Downloading ${purpose} without an authorization token.`);
+  return void 0;
+}
+
+// src/logging.ts
+var core6 = __toESM(require_core());
+function getActionsLogger() {
+  return core6;
+}
+
+// src/start-proxy.ts
+var core7 = __toESM(require_core());
 
 // src/defaults.json
 var bundleVersion = "codeql-bundle-v2.23.1";
@@ -49682,10 +49690,17 @@ async function getProxyBinaryPath(logger) {
   const proxyInfo = await getDownloadUrl(logger);
   let proxyBin = toolcache.find(proxyFileName, proxyInfo.version);
   if (!proxyBin) {
+    const apiDetails = getApiDetails();
+    const authorization = getAuthorizationHeaderFor(
+      logger,
+      apiDetails,
+      proxyInfo.url,
+      "`update-job-proxy`"
+    );
     const temp = await toolcache.downloadTool(
       proxyInfo.url,
       void 0,
-      void 0,
+      authorization,
       {
         accept: "application/octet-stream"
       }

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -88544,6 +88544,14 @@ function getApiDetails() {
 function getApiClient() {
   return createApiClientWithDetails(getApiDetails());
 }
+function getAuthorizationHeaderFor(logger, apiDetails, url2, purpose = "CodeQL tools") {
+  if (url2.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && url2.startsWith(`${apiDetails.apiURL}/`)) {
+    logger.debug(`Providing an authorization token to download ${purpose}.`);
+    return `token ${apiDetails.auth}`;
+  }
+  logger.debug(`Downloading ${purpose} without an authorization token.`);
+  return void 0;
+}
 var cachedGitHubVersion = void 0;
 async function getGitHubVersionFromApi(apiClient, apiDetails) {
   if (parseGitHubUrl(apiDetails.url) === GITHUB_DOTCOM_URL) {
@@ -90162,11 +90170,12 @@ var downloadCodeQL = async function(codeqlURL, compressionMethod, maybeBundleVer
   let authorization = void 0;
   if (searchParams.has("token")) {
     logger.debug("CodeQL tools URL contains an authorization token.");
-  } else if (codeqlURL.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && codeqlURL.startsWith(`${apiDetails.apiURL}/`)) {
-    logger.debug("Providing an authorization token to download CodeQL tools.");
-    authorization = `token ${apiDetails.auth}`;
   } else {
-    logger.debug("Downloading CodeQL tools without an authorization token.");
+    authorization = getAuthorizationHeaderFor(
+      logger,
+      apiDetails,
+      codeqlURL
+    );
   }
   const toolcacheInfo = getToolcacheDestinationInfo(
     maybeBundleVersion,

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -88796,6 +88796,14 @@ function getApiDetails() {
 function getApiClient() {
   return createApiClientWithDetails(getApiDetails());
 }
+function getAuthorizationHeaderFor(logger, apiDetails, url2, purpose = "CodeQL tools") {
+  if (url2.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && url2.startsWith(`${apiDetails.apiURL}/`)) {
+    logger.debug(`Providing an authorization token to download ${purpose}.`);
+    return `token ${apiDetails.auth}`;
+  }
+  logger.debug(`Downloading ${purpose} without an authorization token.`);
+  return void 0;
+}
 var cachedGitHubVersion = void 0;
 async function getGitHubVersionFromApi(apiClient, apiDetails) {
   if (parseGitHubUrl(apiDetails.url) === GITHUB_DOTCOM_URL) {
@@ -90863,11 +90871,12 @@ var downloadCodeQL = async function(codeqlURL, compressionMethod, maybeBundleVer
   let authorization = void 0;
   if (searchParams.has("token")) {
     logger.debug("CodeQL tools URL contains an authorization token.");
-  } else if (codeqlURL.startsWith(`${apiDetails.url}/`) || apiDetails.apiURL && codeqlURL.startsWith(`${apiDetails.apiURL}/`)) {
-    logger.debug("Providing an authorization token to download CodeQL tools.");
-    authorization = `token ${apiDetails.auth}`;
   } else {
-    logger.debug("Downloading CodeQL tools without an authorization token.");
+    authorization = getAuthorizationHeaderFor(
+      logger,
+      apiDetails,
+      codeqlURL
+    );
   }
   const toolcacheInfo = getToolcacheDestinationInfo(
     maybeBundleVersion,

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -4,6 +4,7 @@ import * as retry from "@octokit/plugin-retry";
 import consoleLogLevel from "console-log-level";
 
 import { getActionVersion, getRequiredInput } from "./actions-util";
+import { Logger } from "./logging";
 import { getRepositoryNwo, RepositoryNwo } from "./repository";
 import {
   ConfigurationError,
@@ -54,7 +55,7 @@ function createApiClientWithDetails(
   );
 }
 
-export function getApiDetails() {
+export function getApiDetails(): GitHubApiDetails {
   return {
     auth: getRequiredInput("token"),
     url: getRequiredEnvParam("GITHUB_SERVER_URL"),
@@ -70,6 +71,34 @@ export function getApiClientWithExternalAuth(
   apiDetails: GitHubApiCombinedDetails,
 ) {
   return createApiClientWithDetails(apiDetails, { allowExternal: true });
+}
+
+/**
+ * Gets a value for the `Authorization` header to download `url` or `undefined` if the
+ * `Authorization` header should not be set for `url`.
+ *
+ * @param logger The logger to use for debugging messages.
+ * @param apiDetails Details of the GitHub API we are using.
+ * @param url The URL for which we want to add an `Authorization` header.
+ * @param purpose A description of what we want to download, for debug messages.
+ * @returns The value for the `Authorization` header or `undefined` if it shouldn't be populated.
+ */
+export function getAuthorizationHeaderFor(
+  logger: Logger,
+  apiDetails: GitHubApiDetails,
+  url: string,
+  purpose: string = "CodeQL tools",
+): string | undefined {
+  if (
+    url.startsWith(`${apiDetails.url}/`) ||
+    (apiDetails.apiURL && url.startsWith(`${apiDetails.apiURL}/`))
+  ) {
+    logger.debug(`Providing an authorization token to download ${purpose}.`);
+    return `token ${apiDetails.auth}`;
+  }
+
+  logger.debug(`Downloading ${purpose} without an authorization token.`);
+  return undefined;
 }
 
 let cachedGitHubVersion: GitHubVersion | undefined = undefined;

--- a/src/setup-codeql.ts
+++ b/src/setup-codeql.ts
@@ -574,14 +574,12 @@ export const downloadCodeQL = async function (
   let authorization: string | undefined = undefined;
   if (searchParams.has("token")) {
     logger.debug("CodeQL tools URL contains an authorization token.");
-  } else if (
-    codeqlURL.startsWith(`${apiDetails.url}/`) ||
-    (apiDetails.apiURL && codeqlURL.startsWith(`${apiDetails.apiURL}/`))
-  ) {
-    logger.debug("Providing an authorization token to download CodeQL tools.");
-    authorization = `token ${apiDetails.auth}`;
   } else {
-    logger.debug("Downloading CodeQL tools without an authorization token.");
+    authorization = api.getAuthorizationHeaderFor(
+      logger,
+      apiDetails,
+      codeqlURL,
+    );
   }
 
   const toolcacheInfo = getToolcacheDestinationInfo(

--- a/src/start-proxy-action.ts
+++ b/src/start-proxy-action.ts
@@ -6,6 +6,7 @@ import * as toolcache from "@actions/tool-cache";
 import { pki } from "node-forge";
 
 import * as actionsUtil from "./actions-util";
+import { getApiDetails, getAuthorizationHeaderFor } from "./api-client";
 import { getActionsLogger, Logger } from "./logging";
 import {
   Credential,
@@ -192,10 +193,20 @@ async function getProxyBinaryPath(logger: Logger): Promise<string> {
 
   let proxyBin = toolcache.find(proxyFileName, proxyInfo.version);
   if (!proxyBin) {
+    // We only want to provide an authorization header if we are downloading
+    // from the same GitHub instance the Action is running on.
+    // This avoids leaking Enterprise tokens to dotcom.
+    const apiDetails = getApiDetails();
+    const authorization = getAuthorizationHeaderFor(
+      logger,
+      apiDetails,
+      proxyInfo.url,
+      "`update-job-proxy`",
+    );
     const temp = await toolcache.downloadTool(
       proxyInfo.url,
       undefined,
-      undefined,
+      authorization,
       {
         accept: "application/octet-stream",
       },


### PR DESCRIPTION
This changes the `start-proxy` action to provide an `Authorization` header for the `toolcache.downloadTool` call under the same circumstances where we provide one for the `toolcache.downloadTool` call when downloading the CLI bundle.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
