### PR TITLE
build: use --serial in 'just test_file'

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test: build
 
 # Run the tests for a single file
 test_file filename: build
-    npx ava --verbose {{filename}}
+    npx ava --serial --verbose {{filename}}
 
 [doc("Refresh the .js build artefacts in the lib directory")]
 [confirm]


### PR DESCRIPTION
Some tests require the `--serial` flag to pass.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
