### PR TITLE
Don't dry-run `rollback-release` workflow on release branches

### DIFF
--- a/.github/workflows/rollback-release.yml
+++ b/.github/workflows/rollback-release.yml
@@ -10,6 +10,10 @@ on:
         required: true
   # Only for dry-runs of changes to the workflow.
   push:
+    # Don't run dry-run on release branches, to avoid an issue where the
+    # "new" tag determined by the "Prepare release" job already exists.
+    branches-ignore:
+      - releases/v*
     paths:
       - .github/workflows/rollback-release.yml
       - .github/actions/prepare-mergeback-branch/**


### PR DESCRIPTION
To avoid the issue observed in https://github.com/github/codeql-action/actions/runs/18004376110/job/51221112307#step:7:35

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
