### PR TITLE
Don't run `npm install` when in an Actions workflow

### DIFF
--- a/scripts/check-node-modules.sh
+++ b/scripts/check-node-modules.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
+
 set -e
+
+# Check if running in GitHub Actions
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+  exit 0
+fi
 
 # Check if npm install is likely needed before proceeding
 if [ ! -d node_modules ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then

--- a/scripts/check-node-modules.sh
+++ b/scripts/check-node-modules.sh
@@ -4,10 +4,14 @@ set -e
 
 # Check if running in GitHub Actions
 if [ "$GITHUB_ACTIONS" = "true" ]; then
+  echo "Running in a GitHub Actions workflow; not running 'npm install'"
   exit 0
 fi
 
 # Check if npm install is likely needed before proceeding
 if [ ! -d node_modules ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then
+  echo "Running 'npm install' because 'node_modules/.package-lock.json' appears to be outdated..."
   npm install
+else
+  echo "Skipping 'npm install' because 'node_modules/.package-lock.json' appears to be up-to-date."
 fi


### PR DESCRIPTION
Follow-up to #3154 to skip running `npm install` when running in a GitHub Actions workflow.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
