### PR TITLE
Fix `upload-sarif` not uploading non-`.sarif` files

### DIFF
--- a/.github/workflows/__upload-quality-sarif.yml
+++ b/.github/workflows/__upload-quality-sarif.yml
@@ -89,7 +89,7 @@ jobs:
           ref: refs/heads/main
           sha: 5e235361806c361d4d3f8859e3c897658025a9a2
       - name: Check output from `upload-sarif` step
-        if: fromJSON(steps.upload-sarif.outputs.sarif-ids)[0].analysis != 'code-quality'
+        if: !fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality
         run: exit 1
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -95568,18 +95568,10 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   walkSarifFiles(sarifPath);
   return sarifFiles;
 }
-function getSarifFilePaths(sarifPath, isSarif) {
-  if (!fs18.existsSync(sarifPath)) {
-    throw new ConfigurationError(`Path does not exist: ${sarifPath}`);
-  }
+function getSarifFilePaths(sarifPath, isSarif, pathStats) {
   let sarifFiles;
-  if (fs18.lstatSync(sarifPath).isDirectory()) {
+  if (pathStats.isDirectory()) {
     sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
-    if (sarifFiles.length === 0) {
-      throw new ConfigurationError(
-        `No SARIF files found to upload in "${sarifPath}".`
-      );
-    }
   } else {
     sarifFiles = [sarifPath];
   }
@@ -95681,10 +95673,20 @@ function buildPayload(commitOid, ref, analysisKey, analysisName, zippedSarif, wo
   return payloadObj;
 }
 async function uploadFiles(inputSarifPath, checkoutPath, category, features, logger, uploadTarget) {
+  const pathStats = fs18.lstatSync(inputSarifPath, { throwIfNoEntry: false });
+  if (pathStats === void 0) {
+    throw new ConfigurationError(`Path does not exist: ${inputSarifPath}`);
+  }
   const sarifPaths = getSarifFilePaths(
     inputSarifPath,
-    uploadTarget.sarifPredicate
+    uploadTarget.sarifPredicate,
+    pathStats
   );
+  if (sarifPaths.length === 0) {
+    throw new ConfigurationError(
+      `No SARIF files found to upload in "${inputSarifPath}".`
+    );
+  }
   return uploadSpecifiedFiles(
     sarifPaths,
     checkoutPath,

--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -90177,6 +90177,12 @@ var CodeQuality = {
   sarifPredicate: (name) => name.endsWith(CodeQuality.sarifExtension),
   sentinelPrefix: "CODEQL_UPLOAD_QUALITY_SARIF_"
 };
+var Analyses = [CodeScanning, CodeQuality];
+function isOtherAnalysisSarif(current, filepath) {
+  return Analyses.some(
+    (config) => config.kind !== current && config.sarifPredicate(filepath)
+  );
+}
 
 // src/analyze.ts
 var fs15 = __toESM(require("fs"));
@@ -95568,11 +95574,11 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   walkSarifFiles(sarifPath);
   return sarifFiles;
 }
-function getSarifFilePaths(sarifPath, isSarif, pathStats) {
-  let sarifFiles;
+function getSarifFilePaths(sarifPath, analysis, pathStats) {
+  let sarifFiles = [];
   if (pathStats.isDirectory()) {
-    sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
-  } else {
+    sarifFiles = findSarifFilesInDir(sarifPath, analysis.sarifPredicate);
+  } else if (!isOtherAnalysisSarif(analysis.kind, sarifPath)) {
     sarifFiles = [sarifPath];
   }
   return sarifFiles;
@@ -95677,11 +95683,7 @@ async function uploadFiles(inputSarifPath, checkoutPath, category, features, log
   if (pathStats === void 0) {
     throw new ConfigurationError(`Path does not exist: ${inputSarifPath}`);
   }
-  const sarifPaths = getSarifFilePaths(
-    inputSarifPath,
-    uploadTarget.sarifPredicate,
-    pathStats
-  );
+  const sarifPaths = getSarifFilePaths(inputSarifPath, uploadTarget, pathStats);
   if (sarifPaths.length === 0) {
     throw new ConfigurationError(
       `No SARIF files found to upload in "${inputSarifPath}".`

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -92374,18 +92374,10 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   walkSarifFiles(sarifPath);
   return sarifFiles;
 }
-function getSarifFilePaths(sarifPath, isSarif) {
-  if (!fs13.existsSync(sarifPath)) {
-    throw new ConfigurationError(`Path does not exist: ${sarifPath}`);
-  }
+function getSarifFilePaths(sarifPath, isSarif, pathStats) {
   let sarifFiles;
-  if (fs13.lstatSync(sarifPath).isDirectory()) {
+  if (pathStats.isDirectory()) {
     sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
-    if (sarifFiles.length === 0) {
-      throw new ConfigurationError(
-        `No SARIF files found to upload in "${sarifPath}".`
-      );
-    }
   } else {
     sarifFiles = [sarifPath];
   }
@@ -92487,10 +92479,20 @@ function buildPayload(commitOid, ref, analysisKey, analysisName, zippedSarif, wo
   return payloadObj;
 }
 async function uploadFiles(inputSarifPath, checkoutPath, category, features, logger, uploadTarget) {
+  const pathStats = fs13.lstatSync(inputSarifPath, { throwIfNoEntry: false });
+  if (pathStats === void 0) {
+    throw new ConfigurationError(`Path does not exist: ${inputSarifPath}`);
+  }
   const sarifPaths = getSarifFilePaths(
     inputSarifPath,
-    uploadTarget.sarifPredicate
+    uploadTarget.sarifPredicate,
+    pathStats
   );
+  if (sarifPaths.length === 0) {
+    throw new ConfigurationError(
+      `No SARIF files found to upload in "${inputSarifPath}".`
+    );
+  }
   return uploadSpecifiedFiles(
     sarifPaths,
     checkoutPath,

--- a/lib/upload-lib.js
+++ b/lib/upload-lib.js
@@ -88530,6 +88530,36 @@ async function runTool(cmd, args = [], opts = {}) {
   return stdout;
 }
 
+// src/analyses.ts
+var AnalysisKind = /* @__PURE__ */ ((AnalysisKind2) => {
+  AnalysisKind2["CodeScanning"] = "code-scanning";
+  AnalysisKind2["CodeQuality"] = "code-quality";
+  return AnalysisKind2;
+})(AnalysisKind || {});
+var supportedAnalysisKinds = new Set(Object.values(AnalysisKind));
+var CodeScanning = {
+  kind: "code-scanning" /* CodeScanning */,
+  name: "code scanning",
+  target: "PUT /repos/:owner/:repo/code-scanning/analysis" /* CODE_SCANNING */,
+  sarifExtension: ".sarif",
+  sarifPredicate: (name) => name.endsWith(CodeScanning.sarifExtension) && !CodeQuality.sarifPredicate(name),
+  sentinelPrefix: "CODEQL_UPLOAD_SARIF_"
+};
+var CodeQuality = {
+  kind: "code-quality" /* CodeQuality */,
+  name: "code quality",
+  target: "PUT /repos/:owner/:repo/code-quality/analysis" /* CODE_QUALITY */,
+  sarifExtension: ".quality.sarif",
+  sarifPredicate: (name) => name.endsWith(CodeQuality.sarifExtension),
+  sentinelPrefix: "CODEQL_UPLOAD_QUALITY_SARIF_"
+};
+var Analyses = [CodeScanning, CodeQuality];
+function isOtherAnalysisSarif(current, filepath) {
+  return Analyses.some(
+    (config) => config.kind !== current && config.sarifPredicate(filepath)
+  );
+}
+
 // src/api-client.ts
 var core5 = __toESM(require_core());
 var githubUtils = __toESM(require_utils4());
@@ -88920,14 +88950,6 @@ function wrapCliConfigurationError(cliError) {
 // src/config-utils.ts
 var fs7 = __toESM(require("fs"));
 var path9 = __toESM(require("path"));
-
-// src/analyses.ts
-var AnalysisKind = /* @__PURE__ */ ((AnalysisKind2) => {
-  AnalysisKind2["CodeScanning"] = "code-scanning";
-  AnalysisKind2["CodeQuality"] = "code-quality";
-  return AnalysisKind2;
-})(AnalysisKind || {});
-var supportedAnalysisKinds = new Set(Object.values(AnalysisKind));
 
 // src/caching-utils.ts
 var core6 = __toESM(require_core());
@@ -92374,11 +92396,11 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   walkSarifFiles(sarifPath);
   return sarifFiles;
 }
-function getSarifFilePaths(sarifPath, isSarif, pathStats) {
-  let sarifFiles;
+function getSarifFilePaths(sarifPath, analysis, pathStats) {
+  let sarifFiles = [];
   if (pathStats.isDirectory()) {
-    sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
-  } else {
+    sarifFiles = findSarifFilesInDir(sarifPath, analysis.sarifPredicate);
+  } else if (!isOtherAnalysisSarif(analysis.kind, sarifPath)) {
     sarifFiles = [sarifPath];
   }
   return sarifFiles;
@@ -92483,11 +92505,7 @@ async function uploadFiles(inputSarifPath, checkoutPath, category, features, log
   if (pathStats === void 0) {
     throw new ConfigurationError(`Path does not exist: ${inputSarifPath}`);
   }
-  const sarifPaths = getSarifFilePaths(
-    inputSarifPath,
-    uploadTarget.sarifPredicate,
-    pathStats
-  );
+  const sarifPaths = getSarifFilePaths(inputSarifPath, uploadTarget, pathStats);
   if (sarifPaths.length === 0) {
     throw new ConfigurationError(
       `No SARIF files found to upload in "${inputSarifPath}".`

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93523,6 +93523,9 @@ async function run() {
         id: qualityUploadResult.sarifID
       });
     }
+    if (sarifIds.length === 0) {
+      logger.warning(`No SARIF files were uploaded.`);
+    }
     core13.setOutput("sarif-ids", JSON.stringify(sarifIds));
     if (isInTestMode()) {
       core13.debug("In test mode. Waiting for processing is disabled.");

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93075,6 +93075,15 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   walkSarifFiles(sarifPath);
   return sarifFiles;
 }
+function getSarifFilePaths(sarifPath, isSarif, pathStats) {
+  let sarifFiles;
+  if (pathStats.isDirectory()) {
+    sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
+  } else {
+    sarifFiles = [sarifPath];
+  }
+  return sarifFiles;
+}
 function countResultsInSarif(sarif) {
   let numResults = 0;
   const parsedSarif = JSON.parse(sarif);
@@ -93418,17 +93427,11 @@ function filterAlertsByDiffRange(logger, sarif) {
 
 // src/upload-sarif.ts
 async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
-  let sarifFiles;
-  if (pathStats.isDirectory()) {
-    sarifFiles = findSarifFilesInDir(
-      sarifPath,
-      analysis.sarifPredicate
-    );
-  } else if (pathStats.isFile() && analysis.sarifPredicate(sarifPath)) {
-    sarifFiles = [sarifPath];
-  } else {
-    return void 0;
-  }
+  const sarifFiles = getSarifFilePaths(
+    sarifPath,
+    analysis.sarifPredicate,
+    pathStats
+  );
   if (sarifFiles.length !== 0) {
     return await uploadSpecifiedFiles(
       sarifFiles,

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -88781,6 +88781,12 @@ var CodeQuality = {
   sarifPredicate: (name) => name.endsWith(CodeQuality.sarifExtension),
   sentinelPrefix: "CODEQL_UPLOAD_QUALITY_SARIF_"
 };
+var Analyses = [CodeScanning, CodeQuality];
+function isOtherAnalysisSarif(current, filepath) {
+  return Analyses.some(
+    (config) => config.kind !== current && config.sarifPredicate(filepath)
+  );
+}
 
 // src/api-client.ts
 var core5 = __toESM(require_core());
@@ -93075,11 +93081,11 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   walkSarifFiles(sarifPath);
   return sarifFiles;
 }
-function getSarifFilePaths(sarifPath, isSarif, pathStats) {
-  let sarifFiles;
+function getSarifFilePaths(sarifPath, analysis, pathStats) {
+  let sarifFiles = [];
   if (pathStats.isDirectory()) {
-    sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
-  } else {
+    sarifFiles = findSarifFilesInDir(sarifPath, analysis.sarifPredicate);
+  } else if (!isOtherAnalysisSarif(analysis.kind, sarifPath)) {
     sarifFiles = [sarifPath];
   }
   return sarifFiles;
@@ -93430,7 +93436,7 @@ var core13 = __toESM(require_core());
 async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
   const sarifFiles = getSarifFilePaths(
     sarifPath,
-    analysis.sarifPredicate,
+    analysis,
     pathStats
   );
   if (sarifFiles.length !== 0) {

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -19713,7 +19713,7 @@ var require_core = __commonJS({
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
     exports2.getBooleanInput = getBooleanInput;
-    function setOutput2(name, value) {
+    function setOutput3(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
         return (0, file_command_1.issueFileCommand)("OUTPUT", (0, file_command_1.prepareKeyValueMessage)(name, value));
@@ -19721,7 +19721,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       process.stdout.write(os3.EOL);
       (0, command_1.issueCommand)("set-output", { name }, (0, utils_1.toCommandValue)(value));
     }
-    exports2.setOutput = setOutput2;
+    exports2.setOutput = setOutput3;
     function setCommandEcho(enabled) {
       (0, command_1.issue)("echo", enabled ? "on" : "off");
     }
@@ -33992,7 +33992,7 @@ var require_internal_glob_options_helper = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getOptions = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     function getOptions(copy) {
       const result = {
         followSymbolicLinks: true,
@@ -34002,15 +34002,15 @@ var require_internal_glob_options_helper = __commonJS({
       if (copy) {
         if (typeof copy.followSymbolicLinks === "boolean") {
           result.followSymbolicLinks = copy.followSymbolicLinks;
-          core14.debug(`followSymbolicLinks '${result.followSymbolicLinks}'`);
+          core15.debug(`followSymbolicLinks '${result.followSymbolicLinks}'`);
         }
         if (typeof copy.implicitDescendants === "boolean") {
           result.implicitDescendants = copy.implicitDescendants;
-          core14.debug(`implicitDescendants '${result.implicitDescendants}'`);
+          core15.debug(`implicitDescendants '${result.implicitDescendants}'`);
         }
         if (typeof copy.omitBrokenSymbolicLinks === "boolean") {
           result.omitBrokenSymbolicLinks = copy.omitBrokenSymbolicLinks;
-          core14.debug(`omitBrokenSymbolicLinks '${result.omitBrokenSymbolicLinks}'`);
+          core15.debug(`omitBrokenSymbolicLinks '${result.omitBrokenSymbolicLinks}'`);
         }
       }
       return result;
@@ -35464,7 +35464,7 @@ var require_internal_globber = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.DefaultGlobber = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var fs16 = __importStar4(require("fs"));
     var globOptionsHelper = __importStar4(require_internal_glob_options_helper());
     var path16 = __importStar4(require("path"));
@@ -35515,7 +35515,7 @@ var require_internal_globber = __commonJS({
           }
           const stack = [];
           for (const searchPath of patternHelper.getSearchPaths(patterns)) {
-            core14.debug(`Search path '${searchPath}'`);
+            core15.debug(`Search path '${searchPath}'`);
             try {
               yield __await4(fs16.promises.lstat(searchPath));
             } catch (err) {
@@ -35587,7 +35587,7 @@ var require_internal_globber = __commonJS({
             } catch (err) {
               if (err.code === "ENOENT") {
                 if (options.omitBrokenSymbolicLinks) {
-                  core14.debug(`Broken symlink '${item.path}'`);
+                  core15.debug(`Broken symlink '${item.path}'`);
                   return void 0;
                 }
                 throw new Error(`No information found for the path '${item.path}'. This may indicate a broken symbolic link.`);
@@ -35603,7 +35603,7 @@ var require_internal_globber = __commonJS({
               traversalChain.pop();
             }
             if (traversalChain.some((x) => x === realPath)) {
-              core14.debug(`Symlink cycle detected for path '${item.path}' and realpath '${realPath}'`);
+              core15.debug(`Symlink cycle detected for path '${item.path}' and realpath '${realPath}'`);
               return void 0;
             }
             traversalChain.push(realPath);
@@ -36927,7 +36927,7 @@ var require_cacheUtils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getRuntimeToken = exports2.getCacheVersion = exports2.assertDefined = exports2.getGnuTarPathOnWindows = exports2.getCacheFileName = exports2.getCompressionMethod = exports2.unlinkFile = exports2.resolvePaths = exports2.getArchiveFileSizeInBytes = exports2.createTempDirectory = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var exec2 = __importStar4(require_exec());
     var glob = __importStar4(require_glob());
     var io6 = __importStar4(require_io());
@@ -36980,7 +36980,7 @@ var require_cacheUtils = __commonJS({
             _e = false;
             const file = _c;
             const relativeFile = path16.relative(workspace, file).replace(new RegExp(`\\${path16.sep}`, "g"), "/");
-            core14.debug(`Matched: ${relativeFile}`);
+            core15.debug(`Matched: ${relativeFile}`);
             if (relativeFile === "") {
               paths.push(".");
             } else {
@@ -37010,7 +37010,7 @@ var require_cacheUtils = __commonJS({
       return __awaiter4(this, void 0, void 0, function* () {
         let versionOutput = "";
         additionalArgs.push("--version");
-        core14.debug(`Checking ${app} ${additionalArgs.join(" ")}`);
+        core15.debug(`Checking ${app} ${additionalArgs.join(" ")}`);
         try {
           yield exec2.exec(`${app}`, additionalArgs, {
             ignoreReturnCode: true,
@@ -37021,10 +37021,10 @@ var require_cacheUtils = __commonJS({
             }
           });
         } catch (err) {
-          core14.debug(err.message);
+          core15.debug(err.message);
         }
         versionOutput = versionOutput.trim();
-        core14.debug(versionOutput);
+        core15.debug(versionOutput);
         return versionOutput;
       });
     }
@@ -37032,7 +37032,7 @@ var require_cacheUtils = __commonJS({
       return __awaiter4(this, void 0, void 0, function* () {
         const versionOutput = yield getVersion("zstd", ["--quiet"]);
         const version = semver8.clean(versionOutput);
-        core14.debug(`zstd version: ${version}`);
+        core15.debug(`zstd version: ${version}`);
         if (versionOutput === "") {
           return constants_1.CompressionMethod.Gzip;
         } else {
@@ -72344,7 +72344,7 @@ var require_uploadUtils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.uploadCacheArchiveSDK = exports2.UploadProgress = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var storage_blob_1 = require_dist7();
     var errors_1 = require_errors2();
     var UploadProgress = class {
@@ -72386,7 +72386,7 @@ var require_uploadUtils = __commonJS({
         const percentage = (100 * (transferredBytes / this.contentLength)).toFixed(1);
         const elapsedTime = Date.now() - this.startTime;
         const uploadSpeed = (transferredBytes / (1024 * 1024) / (elapsedTime / 1e3)).toFixed(1);
-        core14.info(`Sent ${transferredBytes} of ${this.contentLength} (${percentage}%), ${uploadSpeed} MBs/sec`);
+        core15.info(`Sent ${transferredBytes} of ${this.contentLength} (${percentage}%), ${uploadSpeed} MBs/sec`);
         if (this.isDone()) {
           this.displayedComplete = true;
         }
@@ -72441,14 +72441,14 @@ var require_uploadUtils = __commonJS({
         };
         try {
           uploadProgress.startDisplayTimer();
-          core14.debug(`BlobClient: ${blobClient.name}:${blobClient.accountName}:${blobClient.containerName}`);
+          core15.debug(`BlobClient: ${blobClient.name}:${blobClient.accountName}:${blobClient.containerName}`);
           const response = yield blockBlobClient.uploadFile(archivePath, uploadOptions);
           if (response._response.status >= 400) {
             throw new errors_1.InvalidResponseError(`uploadCacheArchiveSDK: upload failed with status code ${response._response.status}`);
           }
           return response;
         } catch (error2) {
-          core14.warning(`uploadCacheArchiveSDK: internal error uploading cache archive: ${error2.message}`);
+          core15.warning(`uploadCacheArchiveSDK: internal error uploading cache archive: ${error2.message}`);
           throw error2;
         } finally {
           uploadProgress.stopDisplayTimer();
@@ -72519,7 +72519,7 @@ var require_requestUtils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.retryHttpClientResponse = exports2.retryTypedResponse = exports2.retry = exports2.isRetryableStatusCode = exports2.isServerErrorStatusCode = exports2.isSuccessStatusCode = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var http_client_1 = require_lib();
     var constants_1 = require_constants10();
     function isSuccessStatusCode(statusCode) {
@@ -72580,9 +72580,9 @@ var require_requestUtils = __commonJS({
             isRetryable = isRetryableStatusCode(statusCode);
             errorMessage = `Cache service responded with ${statusCode}`;
           }
-          core14.debug(`${name} - Attempt ${attempt} of ${maxAttempts} failed with error: ${errorMessage}`);
+          core15.debug(`${name} - Attempt ${attempt} of ${maxAttempts} failed with error: ${errorMessage}`);
           if (!isRetryable) {
-            core14.debug(`${name} - Error is not retryable`);
+            core15.debug(`${name} - Error is not retryable`);
             break;
           }
           yield sleep(delay2);
@@ -72687,7 +72687,7 @@ var require_downloadUtils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.downloadCacheStorageSDK = exports2.downloadCacheHttpClientConcurrent = exports2.downloadCacheHttpClient = exports2.DownloadProgress = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var http_client_1 = require_lib();
     var storage_blob_1 = require_dist7();
     var buffer = __importStar4(require("buffer"));
@@ -72725,7 +72725,7 @@ var require_downloadUtils = __commonJS({
         this.segmentIndex = this.segmentIndex + 1;
         this.segmentSize = segmentSize;
         this.receivedBytes = 0;
-        core14.debug(`Downloading segment at offset ${this.segmentOffset} with length ${this.segmentSize}...`);
+        core15.debug(`Downloading segment at offset ${this.segmentOffset} with length ${this.segmentSize}...`);
       }
       /**
        * Sets the number of bytes received for the current segment.
@@ -72759,7 +72759,7 @@ var require_downloadUtils = __commonJS({
         const percentage = (100 * (transferredBytes / this.contentLength)).toFixed(1);
         const elapsedTime = Date.now() - this.startTime;
         const downloadSpeed = (transferredBytes / (1024 * 1024) / (elapsedTime / 1e3)).toFixed(1);
-        core14.info(`Received ${transferredBytes} of ${this.contentLength} (${percentage}%), ${downloadSpeed} MBs/sec`);
+        core15.info(`Received ${transferredBytes} of ${this.contentLength} (${percentage}%), ${downloadSpeed} MBs/sec`);
         if (this.isDone()) {
           this.displayedComplete = true;
         }
@@ -72809,7 +72809,7 @@ var require_downloadUtils = __commonJS({
         }));
         downloadResponse.message.socket.setTimeout(constants_1.SocketTimeout, () => {
           downloadResponse.message.destroy();
-          core14.debug(`Aborting download, socket timed out after ${constants_1.SocketTimeout} ms`);
+          core15.debug(`Aborting download, socket timed out after ${constants_1.SocketTimeout} ms`);
         });
         yield pipeResponseToStream(downloadResponse, writeStream);
         const contentLengthHeader = downloadResponse.message.headers["content-length"];
@@ -72820,7 +72820,7 @@ var require_downloadUtils = __commonJS({
             throw new Error(`Incomplete download. Expected file size: ${expectedLength}, actual file size: ${actualLength}`);
           }
         } else {
-          core14.debug("Unable to validate download, no Content-Length header");
+          core15.debug("Unable to validate download, no Content-Length header");
         }
       });
     }
@@ -72940,7 +72940,7 @@ var require_downloadUtils = __commonJS({
         const properties = yield client.getProperties();
         const contentLength = (_a = properties.contentLength) !== null && _a !== void 0 ? _a : -1;
         if (contentLength < 0) {
-          core14.debug("Unable to determine content length, downloading file with http-client...");
+          core15.debug("Unable to determine content length, downloading file with http-client...");
           yield downloadCacheHttpClient(archiveLocation, archivePath);
         } else {
           const maxSegmentSize = Math.min(134217728, buffer.constants.MAX_LENGTH);
@@ -73020,7 +73020,7 @@ var require_options = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getDownloadOptions = exports2.getUploadOptions = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     function getUploadOptions(copy) {
       const result = {
         useAzureSdk: false,
@@ -73040,9 +73040,9 @@ var require_options = __commonJS({
       }
       result.uploadConcurrency = !isNaN(Number(process.env["CACHE_UPLOAD_CONCURRENCY"])) ? Math.min(32, Number(process.env["CACHE_UPLOAD_CONCURRENCY"])) : result.uploadConcurrency;
       result.uploadChunkSize = !isNaN(Number(process.env["CACHE_UPLOAD_CHUNK_SIZE"])) ? Math.min(128 * 1024 * 1024, Number(process.env["CACHE_UPLOAD_CHUNK_SIZE"]) * 1024 * 1024) : result.uploadChunkSize;
-      core14.debug(`Use Azure SDK: ${result.useAzureSdk}`);
-      core14.debug(`Upload concurrency: ${result.uploadConcurrency}`);
-      core14.debug(`Upload chunk size: ${result.uploadChunkSize}`);
+      core15.debug(`Use Azure SDK: ${result.useAzureSdk}`);
+      core15.debug(`Upload concurrency: ${result.uploadConcurrency}`);
+      core15.debug(`Upload chunk size: ${result.uploadChunkSize}`);
       return result;
     }
     exports2.getUploadOptions = getUploadOptions;
@@ -73079,12 +73079,12 @@ var require_options = __commonJS({
       if (segmentDownloadTimeoutMins && !isNaN(Number(segmentDownloadTimeoutMins)) && isFinite(Number(segmentDownloadTimeoutMins))) {
         result.segmentTimeoutInMs = Number(segmentDownloadTimeoutMins) * 60 * 1e3;
       }
-      core14.debug(`Use Azure SDK: ${result.useAzureSdk}`);
-      core14.debug(`Download concurrency: ${result.downloadConcurrency}`);
-      core14.debug(`Request timeout (ms): ${result.timeoutInMs}`);
-      core14.debug(`Cache segment download timeout mins env var: ${process.env["SEGMENT_DOWNLOAD_TIMEOUT_MINS"]}`);
-      core14.debug(`Segment download timeout (ms): ${result.segmentTimeoutInMs}`);
-      core14.debug(`Lookup only: ${result.lookupOnly}`);
+      core15.debug(`Use Azure SDK: ${result.useAzureSdk}`);
+      core15.debug(`Download concurrency: ${result.downloadConcurrency}`);
+      core15.debug(`Request timeout (ms): ${result.timeoutInMs}`);
+      core15.debug(`Cache segment download timeout mins env var: ${process.env["SEGMENT_DOWNLOAD_TIMEOUT_MINS"]}`);
+      core15.debug(`Segment download timeout (ms): ${result.segmentTimeoutInMs}`);
+      core15.debug(`Lookup only: ${result.lookupOnly}`);
       return result;
     }
     exports2.getDownloadOptions = getDownloadOptions;
@@ -73264,7 +73264,7 @@ var require_cacheHttpClient = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.saveCache = exports2.reserveCache = exports2.downloadCache = exports2.getCacheEntry = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var http_client_1 = require_lib();
     var auth_1 = require_auth();
     var fs16 = __importStar4(require("fs"));
@@ -73282,7 +73282,7 @@ var require_cacheHttpClient = __commonJS({
         throw new Error("Cache Service Url not found, unable to restore cache.");
       }
       const url2 = `${baseUrl}_apis/artifactcache/${resource}`;
-      core14.debug(`Resource Url: ${url2}`);
+      core15.debug(`Resource Url: ${url2}`);
       return url2;
     }
     function createAcceptHeader(type2, apiVersion) {
@@ -73310,7 +73310,7 @@ var require_cacheHttpClient = __commonJS({
           return httpClient.getJson(getCacheApiUrl(resource));
         }));
         if (response.statusCode === 204) {
-          if (core14.isDebug()) {
+          if (core15.isDebug()) {
             yield printCachesListForDiagnostics(keys[0], httpClient, version);
           }
           return null;
@@ -73323,9 +73323,9 @@ var require_cacheHttpClient = __commonJS({
         if (!cacheDownloadUrl) {
           throw new Error("Cache not found.");
         }
-        core14.setSecret(cacheDownloadUrl);
-        core14.debug(`Cache Result:`);
-        core14.debug(JSON.stringify(cacheResult));
+        core15.setSecret(cacheDownloadUrl);
+        core15.debug(`Cache Result:`);
+        core15.debug(JSON.stringify(cacheResult));
         return cacheResult;
       });
     }
@@ -73340,10 +73340,10 @@ var require_cacheHttpClient = __commonJS({
           const cacheListResult = response.result;
           const totalCount = cacheListResult === null || cacheListResult === void 0 ? void 0 : cacheListResult.totalCount;
           if (totalCount && totalCount > 0) {
-            core14.debug(`No matching cache found for cache key '${key}', version '${version} and scope ${process.env["GITHUB_REF"]}. There exist one or more cache(s) with similar key but they have different version or scope. See more info on cache matching here: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key 
+            core15.debug(`No matching cache found for cache key '${key}', version '${version} and scope ${process.env["GITHUB_REF"]}. There exist one or more cache(s) with similar key but they have different version or scope. See more info on cache matching here: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key 
 Other caches with similar key:`);
             for (const cacheEntry of (cacheListResult === null || cacheListResult === void 0 ? void 0 : cacheListResult.artifactCaches) || []) {
-              core14.debug(`Cache Key: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.cacheKey}, Cache Version: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.cacheVersion}, Cache Scope: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.scope}, Cache Created: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.creationTime}`);
+              core15.debug(`Cache Key: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.cacheKey}, Cache Version: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.cacheVersion}, Cache Scope: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.scope}, Cache Created: ${cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.creationTime}`);
             }
           }
         }
@@ -73388,7 +73388,7 @@ Other caches with similar key:`);
     }
     function uploadChunk(httpClient, resourceUrl, openStream, start, end) {
       return __awaiter4(this, void 0, void 0, function* () {
-        core14.debug(`Uploading chunk of size ${end - start + 1} bytes at offset ${start} with content range: ${getContentRange(start, end)}`);
+        core15.debug(`Uploading chunk of size ${end - start + 1} bytes at offset ${start} with content range: ${getContentRange(start, end)}`);
         const additionalHeaders = {
           "Content-Type": "application/octet-stream",
           "Content-Range": getContentRange(start, end)
@@ -73410,7 +73410,7 @@ Other caches with similar key:`);
         const concurrency = utils.assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
         const maxChunkSize = utils.assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
         const parallelUploads = [...new Array(concurrency).keys()];
-        core14.debug("Awaiting all uploads");
+        core15.debug("Awaiting all uploads");
         let offset = 0;
         try {
           yield Promise.all(parallelUploads.map(() => __awaiter4(this, void 0, void 0, function* () {
@@ -73453,16 +73453,16 @@ Other caches with similar key:`);
           yield (0, uploadUtils_1.uploadCacheArchiveSDK)(signedUploadURL, archivePath, options);
         } else {
           const httpClient = createHttpClient();
-          core14.debug("Upload cache");
+          core15.debug("Upload cache");
           yield uploadFile(httpClient, cacheId, archivePath, options);
-          core14.debug("Commiting cache");
+          core15.debug("Commiting cache");
           const cacheSize = utils.getArchiveFileSizeInBytes(archivePath);
-          core14.info(`Cache Size: ~${Math.round(cacheSize / (1024 * 1024))} MB (${cacheSize} B)`);
+          core15.info(`Cache Size: ~${Math.round(cacheSize / (1024 * 1024))} MB (${cacheSize} B)`);
           const commitCacheResponse = yield commitCache(httpClient, cacheId, cacheSize);
           if (!(0, requestUtils_1.isSuccessStatusCode)(commitCacheResponse.statusCode)) {
             throw new Error(`Cache service responded with ${commitCacheResponse.statusCode} during commit cache.`);
           }
-          core14.info("Cache saved successfully");
+          core15.info("Cache saved successfully");
         }
       });
     }
@@ -78914,7 +78914,7 @@ var require_cache3 = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.saveCache = exports2.restoreCache = exports2.isFeatureAvailable = exports2.FinalizeCacheError = exports2.ReserveCacheError = exports2.ValidationError = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var path16 = __importStar4(require("path"));
     var utils = __importStar4(require_cacheUtils());
     var cacheHttpClient = __importStar4(require_cacheHttpClient());
@@ -78974,7 +78974,7 @@ var require_cache3 = __commonJS({
     function restoreCache3(paths, primaryKey, restoreKeys, options, enableCrossOsArchive = false) {
       return __awaiter4(this, void 0, void 0, function* () {
         const cacheServiceVersion = (0, config_1.getCacheServiceVersion)();
-        core14.debug(`Cache service version: ${cacheServiceVersion}`);
+        core15.debug(`Cache service version: ${cacheServiceVersion}`);
         checkPaths(paths);
         switch (cacheServiceVersion) {
           case "v2":
@@ -78990,8 +78990,8 @@ var require_cache3 = __commonJS({
       return __awaiter4(this, void 0, void 0, function* () {
         restoreKeys = restoreKeys || [];
         const keys = [primaryKey, ...restoreKeys];
-        core14.debug("Resolved Keys:");
-        core14.debug(JSON.stringify(keys));
+        core15.debug("Resolved Keys:");
+        core15.debug(JSON.stringify(keys));
         if (keys.length > 10) {
           throw new ValidationError(`Key Validation Error: Keys are limited to a maximum of 10.`);
         }
@@ -79009,19 +79009,19 @@ var require_cache3 = __commonJS({
             return void 0;
           }
           if (options === null || options === void 0 ? void 0 : options.lookupOnly) {
-            core14.info("Lookup only - skipping download");
+            core15.info("Lookup only - skipping download");
             return cacheEntry.cacheKey;
           }
           archivePath = path16.join(yield utils.createTempDirectory(), utils.getCacheFileName(compressionMethod));
-          core14.debug(`Archive Path: ${archivePath}`);
+          core15.debug(`Archive Path: ${archivePath}`);
           yield cacheHttpClient.downloadCache(cacheEntry.archiveLocation, archivePath, options);
-          if (core14.isDebug()) {
+          if (core15.isDebug()) {
             yield (0, tar_1.listTar)(archivePath, compressionMethod);
           }
           const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
-          core14.info(`Cache Size: ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B)`);
+          core15.info(`Cache Size: ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B)`);
           yield (0, tar_1.extractTar)(archivePath, compressionMethod);
-          core14.info("Cache restored successfully");
+          core15.info("Cache restored successfully");
           return cacheEntry.cacheKey;
         } catch (error2) {
           const typedError = error2;
@@ -79029,16 +79029,16 @@ var require_cache3 = __commonJS({
             throw error2;
           } else {
             if (typedError instanceof http_client_1.HttpClientError && typeof typedError.statusCode === "number" && typedError.statusCode >= 500) {
-              core14.error(`Failed to restore: ${error2.message}`);
+              core15.error(`Failed to restore: ${error2.message}`);
             } else {
-              core14.warning(`Failed to restore: ${error2.message}`);
+              core15.warning(`Failed to restore: ${error2.message}`);
             }
           }
         } finally {
           try {
             yield utils.unlinkFile(archivePath);
           } catch (error2) {
-            core14.debug(`Failed to delete archive: ${error2}`);
+            core15.debug(`Failed to delete archive: ${error2}`);
           }
         }
         return void 0;
@@ -79049,8 +79049,8 @@ var require_cache3 = __commonJS({
         options = Object.assign(Object.assign({}, options), { useAzureSdk: true });
         restoreKeys = restoreKeys || [];
         const keys = [primaryKey, ...restoreKeys];
-        core14.debug("Resolved Keys:");
-        core14.debug(JSON.stringify(keys));
+        core15.debug("Resolved Keys:");
+        core15.debug(JSON.stringify(keys));
         if (keys.length > 10) {
           throw new ValidationError(`Key Validation Error: Keys are limited to a maximum of 10.`);
         }
@@ -79068,30 +79068,30 @@ var require_cache3 = __commonJS({
           };
           const response = yield twirpClient.GetCacheEntryDownloadURL(request);
           if (!response.ok) {
-            core14.debug(`Cache not found for version ${request.version} of keys: ${keys.join(", ")}`);
+            core15.debug(`Cache not found for version ${request.version} of keys: ${keys.join(", ")}`);
             return void 0;
           }
           const isRestoreKeyMatch = request.key !== response.matchedKey;
           if (isRestoreKeyMatch) {
-            core14.info(`Cache hit for restore-key: ${response.matchedKey}`);
+            core15.info(`Cache hit for restore-key: ${response.matchedKey}`);
           } else {
-            core14.info(`Cache hit for: ${response.matchedKey}`);
+            core15.info(`Cache hit for: ${response.matchedKey}`);
           }
           if (options === null || options === void 0 ? void 0 : options.lookupOnly) {
-            core14.info("Lookup only - skipping download");
+            core15.info("Lookup only - skipping download");
             return response.matchedKey;
           }
           archivePath = path16.join(yield utils.createTempDirectory(), utils.getCacheFileName(compressionMethod));
-          core14.debug(`Archive path: ${archivePath}`);
-          core14.debug(`Starting download of archive to: ${archivePath}`);
+          core15.debug(`Archive path: ${archivePath}`);
+          core15.debug(`Starting download of archive to: ${archivePath}`);
           yield cacheHttpClient.downloadCache(response.signedDownloadUrl, archivePath, options);
           const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
-          core14.info(`Cache Size: ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B)`);
-          if (core14.isDebug()) {
+          core15.info(`Cache Size: ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B)`);
+          if (core15.isDebug()) {
             yield (0, tar_1.listTar)(archivePath, compressionMethod);
           }
           yield (0, tar_1.extractTar)(archivePath, compressionMethod);
-          core14.info("Cache restored successfully");
+          core15.info("Cache restored successfully");
           return response.matchedKey;
         } catch (error2) {
           const typedError = error2;
@@ -79099,9 +79099,9 @@ var require_cache3 = __commonJS({
             throw error2;
           } else {
             if (typedError instanceof http_client_1.HttpClientError && typeof typedError.statusCode === "number" && typedError.statusCode >= 500) {
-              core14.error(`Failed to restore: ${error2.message}`);
+              core15.error(`Failed to restore: ${error2.message}`);
             } else {
-              core14.warning(`Failed to restore: ${error2.message}`);
+              core15.warning(`Failed to restore: ${error2.message}`);
             }
           }
         } finally {
@@ -79110,7 +79110,7 @@ var require_cache3 = __commonJS({
               yield utils.unlinkFile(archivePath);
             }
           } catch (error2) {
-            core14.debug(`Failed to delete archive: ${error2}`);
+            core15.debug(`Failed to delete archive: ${error2}`);
           }
         }
         return void 0;
@@ -79119,7 +79119,7 @@ var require_cache3 = __commonJS({
     function saveCache3(paths, key, options, enableCrossOsArchive = false) {
       return __awaiter4(this, void 0, void 0, function* () {
         const cacheServiceVersion = (0, config_1.getCacheServiceVersion)();
-        core14.debug(`Cache service version: ${cacheServiceVersion}`);
+        core15.debug(`Cache service version: ${cacheServiceVersion}`);
         checkPaths(paths);
         checkKey(key);
         switch (cacheServiceVersion) {
@@ -79138,26 +79138,26 @@ var require_cache3 = __commonJS({
         const compressionMethod = yield utils.getCompressionMethod();
         let cacheId = -1;
         const cachePaths = yield utils.resolvePaths(paths);
-        core14.debug("Cache Paths:");
-        core14.debug(`${JSON.stringify(cachePaths)}`);
+        core15.debug("Cache Paths:");
+        core15.debug(`${JSON.stringify(cachePaths)}`);
         if (cachePaths.length === 0) {
           throw new Error(`Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`);
         }
         const archiveFolder = yield utils.createTempDirectory();
         const archivePath = path16.join(archiveFolder, utils.getCacheFileName(compressionMethod));
-        core14.debug(`Archive Path: ${archivePath}`);
+        core15.debug(`Archive Path: ${archivePath}`);
         try {
           yield (0, tar_1.createTar)(archiveFolder, cachePaths, compressionMethod);
-          if (core14.isDebug()) {
+          if (core15.isDebug()) {
             yield (0, tar_1.listTar)(archivePath, compressionMethod);
           }
           const fileSizeLimit = 10 * 1024 * 1024 * 1024;
           const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
-          core14.debug(`File Size: ${archiveFileSize}`);
+          core15.debug(`File Size: ${archiveFileSize}`);
           if (archiveFileSize > fileSizeLimit && !(0, config_1.isGhes)()) {
             throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the 10GB limit, not saving cache.`);
           }
-          core14.debug("Reserving Cache");
+          core15.debug("Reserving Cache");
           const reserveCacheResponse = yield cacheHttpClient.reserveCache(key, paths, {
             compressionMethod,
             enableCrossOsArchive,
@@ -79170,26 +79170,26 @@ var require_cache3 = __commonJS({
           } else {
             throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache. More details: ${(_e = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _e === void 0 ? void 0 : _e.message}`);
           }
-          core14.debug(`Saving Cache (ID: ${cacheId})`);
+          core15.debug(`Saving Cache (ID: ${cacheId})`);
           yield cacheHttpClient.saveCache(cacheId, archivePath, "", options);
         } catch (error2) {
           const typedError = error2;
           if (typedError.name === ValidationError.name) {
             throw error2;
           } else if (typedError.name === ReserveCacheError.name) {
-            core14.info(`Failed to save: ${typedError.message}`);
+            core15.info(`Failed to save: ${typedError.message}`);
           } else {
             if (typedError instanceof http_client_1.HttpClientError && typeof typedError.statusCode === "number" && typedError.statusCode >= 500) {
-              core14.error(`Failed to save: ${typedError.message}`);
+              core15.error(`Failed to save: ${typedError.message}`);
             } else {
-              core14.warning(`Failed to save: ${typedError.message}`);
+              core15.warning(`Failed to save: ${typedError.message}`);
             }
           }
         } finally {
           try {
             yield utils.unlinkFile(archivePath);
           } catch (error2) {
-            core14.debug(`Failed to delete archive: ${error2}`);
+            core15.debug(`Failed to delete archive: ${error2}`);
           }
         }
         return cacheId;
@@ -79202,23 +79202,23 @@ var require_cache3 = __commonJS({
         const twirpClient = cacheTwirpClient.internalCacheTwirpClient();
         let cacheId = -1;
         const cachePaths = yield utils.resolvePaths(paths);
-        core14.debug("Cache Paths:");
-        core14.debug(`${JSON.stringify(cachePaths)}`);
+        core15.debug("Cache Paths:");
+        core15.debug(`${JSON.stringify(cachePaths)}`);
         if (cachePaths.length === 0) {
           throw new Error(`Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`);
         }
         const archiveFolder = yield utils.createTempDirectory();
         const archivePath = path16.join(archiveFolder, utils.getCacheFileName(compressionMethod));
-        core14.debug(`Archive Path: ${archivePath}`);
+        core15.debug(`Archive Path: ${archivePath}`);
         try {
           yield (0, tar_1.createTar)(archiveFolder, cachePaths, compressionMethod);
-          if (core14.isDebug()) {
+          if (core15.isDebug()) {
             yield (0, tar_1.listTar)(archivePath, compressionMethod);
           }
           const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
-          core14.debug(`File Size: ${archiveFileSize}`);
+          core15.debug(`File Size: ${archiveFileSize}`);
           options.archiveSizeBytes = archiveFileSize;
-          core14.debug("Reserving Cache");
+          core15.debug("Reserving Cache");
           const version = utils.getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
           const request = {
             key,
@@ -79229,16 +79229,16 @@ var require_cache3 = __commonJS({
             const response = yield twirpClient.CreateCacheEntry(request);
             if (!response.ok) {
               if (response.message) {
-                core14.warning(`Cache reservation failed: ${response.message}`);
+                core15.warning(`Cache reservation failed: ${response.message}`);
               }
               throw new Error(response.message || "Response was not ok");
             }
             signedUploadUrl = response.signedUploadUrl;
           } catch (error2) {
-            core14.debug(`Failed to reserve cache: ${error2}`);
+            core15.debug(`Failed to reserve cache: ${error2}`);
             throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache.`);
           }
-          core14.debug(`Attempting to upload cache located at: ${archivePath}`);
+          core15.debug(`Attempting to upload cache located at: ${archivePath}`);
           yield cacheHttpClient.saveCache(cacheId, archivePath, signedUploadUrl, options);
           const finalizeRequest = {
             key,
@@ -79246,7 +79246,7 @@ var require_cache3 = __commonJS({
             sizeBytes: `${archiveFileSize}`
           };
           const finalizeResponse = yield twirpClient.FinalizeCacheEntryUpload(finalizeRequest);
-          core14.debug(`FinalizeCacheEntryUploadResponse: ${finalizeResponse.ok}`);
+          core15.debug(`FinalizeCacheEntryUploadResponse: ${finalizeResponse.ok}`);
           if (!finalizeResponse.ok) {
             if (finalizeResponse.message) {
               throw new FinalizeCacheError(finalizeResponse.message);
@@ -79259,21 +79259,21 @@ var require_cache3 = __commonJS({
           if (typedError.name === ValidationError.name) {
             throw error2;
           } else if (typedError.name === ReserveCacheError.name) {
-            core14.info(`Failed to save: ${typedError.message}`);
+            core15.info(`Failed to save: ${typedError.message}`);
           } else if (typedError.name === FinalizeCacheError.name) {
-            core14.warning(typedError.message);
+            core15.warning(typedError.message);
           } else {
             if (typedError instanceof http_client_1.HttpClientError && typeof typedError.statusCode === "number" && typedError.statusCode >= 500) {
-              core14.error(`Failed to save: ${typedError.message}`);
+              core15.error(`Failed to save: ${typedError.message}`);
             } else {
-              core14.warning(`Failed to save: ${typedError.message}`);
+              core15.warning(`Failed to save: ${typedError.message}`);
             }
           }
         } finally {
           try {
             yield utils.unlinkFile(archivePath);
           } catch (error2) {
-            core14.debug(`Failed to delete archive: ${error2}`);
+            core15.debug(`Failed to delete archive: ${error2}`);
           }
         }
         return cacheId;
@@ -80778,7 +80778,7 @@ var require_retry_helper = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.RetryHelper = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var RetryHelper = class {
       constructor(maxAttempts, minSeconds, maxSeconds) {
         if (maxAttempts < 1) {
@@ -80801,10 +80801,10 @@ var require_retry_helper = __commonJS({
               if (isRetryable && !isRetryable(err)) {
                 throw err;
               }
-              core14.info(err.message);
+              core15.info(err.message);
             }
             const seconds = this.getSleepAmount();
-            core14.info(`Waiting ${seconds} seconds before trying again`);
+            core15.info(`Waiting ${seconds} seconds before trying again`);
             yield this.sleep(seconds);
             attempt++;
           }
@@ -80884,7 +80884,7 @@ var require_tool_cache = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.evaluateVersions = exports2.isExplicitVersion = exports2.findFromManifest = exports2.getManifestFromRepo = exports2.findAllVersions = exports2.find = exports2.cacheFile = exports2.cacheDir = exports2.extractZip = exports2.extractXar = exports2.extractTar = exports2.extract7z = exports2.downloadTool = exports2.HTTPError = void 0;
-    var core14 = __importStar4(require_core());
+    var core15 = __importStar4(require_core());
     var io6 = __importStar4(require_io());
     var crypto = __importStar4(require("crypto"));
     var fs16 = __importStar4(require("fs"));
@@ -80913,8 +80913,8 @@ var require_tool_cache = __commonJS({
       return __awaiter4(this, void 0, void 0, function* () {
         dest = dest || path16.join(_getTempDirectory(), crypto.randomUUID());
         yield io6.mkdirP(path16.dirname(dest));
-        core14.debug(`Downloading ${url2}`);
-        core14.debug(`Destination ${dest}`);
+        core15.debug(`Downloading ${url2}`);
+        core15.debug(`Destination ${dest}`);
         const maxAttempts = 3;
         const minSeconds = _getGlobal("TEST_DOWNLOAD_TOOL_RETRY_MIN_SECONDS", 10);
         const maxSeconds = _getGlobal("TEST_DOWNLOAD_TOOL_RETRY_MAX_SECONDS", 20);
@@ -80941,7 +80941,7 @@ var require_tool_cache = __commonJS({
           allowRetries: false
         });
         if (auth) {
-          core14.debug("set auth");
+          core15.debug("set auth");
           if (headers === void 0) {
             headers = {};
           }
@@ -80950,7 +80950,7 @@ var require_tool_cache = __commonJS({
         const response = yield http.get(url2, headers);
         if (response.message.statusCode !== 200) {
           const err = new HTTPError(response.message.statusCode);
-          core14.debug(`Failed to download from "${url2}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);
+          core15.debug(`Failed to download from "${url2}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);
           throw err;
         }
         const pipeline = util.promisify(stream2.pipeline);
@@ -80959,16 +80959,16 @@ var require_tool_cache = __commonJS({
         let succeeded = false;
         try {
           yield pipeline(readStream, fs16.createWriteStream(dest));
-          core14.debug("download complete");
+          core15.debug("download complete");
           succeeded = true;
           return dest;
         } finally {
           if (!succeeded) {
-            core14.debug("download failed");
+            core15.debug("download failed");
             try {
               yield io6.rmRF(dest);
             } catch (err) {
-              core14.debug(`Failed to delete '${dest}'. ${err.message}`);
+              core15.debug(`Failed to delete '${dest}'. ${err.message}`);
             }
           }
         }
@@ -80983,7 +80983,7 @@ var require_tool_cache = __commonJS({
         process.chdir(dest);
         if (_7zPath) {
           try {
-            const logLevel = core14.isDebug() ? "-bb1" : "-bb0";
+            const logLevel = core15.isDebug() ? "-bb1" : "-bb0";
             const args = [
               "x",
               logLevel,
@@ -81033,7 +81033,7 @@ var require_tool_cache = __commonJS({
           throw new Error("parameter 'file' is required");
         }
         dest = yield _createExtractFolder(dest);
-        core14.debug("Checking tar --version");
+        core15.debug("Checking tar --version");
         let versionOutput = "";
         yield (0, exec_1.exec)("tar --version", [], {
           ignoreReturnCode: true,
@@ -81043,7 +81043,7 @@ var require_tool_cache = __commonJS({
             stderr: (data) => versionOutput += data.toString()
           }
         });
-        core14.debug(versionOutput.trim());
+        core15.debug(versionOutput.trim());
         const isGnuTar = versionOutput.toUpperCase().includes("GNU TAR");
         let args;
         if (flags instanceof Array) {
@@ -81051,7 +81051,7 @@ var require_tool_cache = __commonJS({
         } else {
           args = [flags];
         }
-        if (core14.isDebug() && !flags.includes("v")) {
+        if (core15.isDebug() && !flags.includes("v")) {
           args.push("-v");
         }
         let destArg = dest;
@@ -81083,7 +81083,7 @@ var require_tool_cache = __commonJS({
           args = [flags];
         }
         args.push("-x", "-C", dest, "-f", file);
-        if (core14.isDebug()) {
+        if (core15.isDebug()) {
           args.push("-v");
         }
         const xarPath = yield io6.which("xar", true);
@@ -81128,7 +81128,7 @@ var require_tool_cache = __commonJS({
             "-Command",
             pwshCommand
           ];
-          core14.debug(`Using pwsh at path: ${pwshPath}`);
+          core15.debug(`Using pwsh at path: ${pwshPath}`);
           yield (0, exec_1.exec)(`"${pwshPath}"`, args);
         } else {
           const powershellCommand = [
@@ -81148,7 +81148,7 @@ var require_tool_cache = __commonJS({
             powershellCommand
           ];
           const powershellPath = yield io6.which("powershell", true);
-          core14.debug(`Using powershell at path: ${powershellPath}`);
+          core15.debug(`Using powershell at path: ${powershellPath}`);
           yield (0, exec_1.exec)(`"${powershellPath}"`, args);
         }
       });
@@ -81157,7 +81157,7 @@ var require_tool_cache = __commonJS({
       return __awaiter4(this, void 0, void 0, function* () {
         const unzipPath = yield io6.which("unzip", true);
         const args = [file];
-        if (!core14.isDebug()) {
+        if (!core15.isDebug()) {
           args.unshift("-q");
         }
         args.unshift("-o");
@@ -81168,8 +81168,8 @@ var require_tool_cache = __commonJS({
       return __awaiter4(this, void 0, void 0, function* () {
         version = semver8.clean(version) || version;
         arch2 = arch2 || os3.arch();
-        core14.debug(`Caching tool ${tool} ${version} ${arch2}`);
-        core14.debug(`source dir: ${sourceDir}`);
+        core15.debug(`Caching tool ${tool} ${version} ${arch2}`);
+        core15.debug(`source dir: ${sourceDir}`);
         if (!fs16.statSync(sourceDir).isDirectory()) {
           throw new Error("sourceDir is not a directory");
         }
@@ -81187,14 +81187,14 @@ var require_tool_cache = __commonJS({
       return __awaiter4(this, void 0, void 0, function* () {
         version = semver8.clean(version) || version;
         arch2 = arch2 || os3.arch();
-        core14.debug(`Caching tool ${tool} ${version} ${arch2}`);
-        core14.debug(`source file: ${sourceFile}`);
+        core15.debug(`Caching tool ${tool} ${version} ${arch2}`);
+        core15.debug(`source file: ${sourceFile}`);
         if (!fs16.statSync(sourceFile).isFile()) {
           throw new Error("sourceFile is not a file");
         }
         const destFolder = yield _createToolPath(tool, version, arch2);
         const destPath = path16.join(destFolder, targetFile);
-        core14.debug(`destination file ${destPath}`);
+        core15.debug(`destination file ${destPath}`);
         yield io6.cp(sourceFile, destPath);
         _completeToolPath(tool, version, arch2);
         return destFolder;
@@ -81218,12 +81218,12 @@ var require_tool_cache = __commonJS({
       if (versionSpec) {
         versionSpec = semver8.clean(versionSpec) || "";
         const cachePath = path16.join(_getCacheDirectory(), toolName, versionSpec, arch2);
-        core14.debug(`checking cache: ${cachePath}`);
+        core15.debug(`checking cache: ${cachePath}`);
         if (fs16.existsSync(cachePath) && fs16.existsSync(`${cachePath}.complete`)) {
-          core14.debug(`Found tool in cache ${toolName} ${versionSpec} ${arch2}`);
+          core15.debug(`Found tool in cache ${toolName} ${versionSpec} ${arch2}`);
           toolPath = cachePath;
         } else {
-          core14.debug("not found");
+          core15.debug("not found");
         }
       }
       return toolPath;
@@ -81254,7 +81254,7 @@ var require_tool_cache = __commonJS({
         const http = new httpm.HttpClient("tool-cache");
         const headers = {};
         if (auth) {
-          core14.debug("set auth");
+          core15.debug("set auth");
           headers.authorization = auth;
         }
         const response = yield http.getJson(treeUrl, headers);
@@ -81275,7 +81275,7 @@ var require_tool_cache = __commonJS({
           try {
             releases = JSON.parse(versionsRaw);
           } catch (_a) {
-            core14.debug("Invalid json");
+            core15.debug("Invalid json");
           }
         }
         return releases;
@@ -81301,7 +81301,7 @@ var require_tool_cache = __commonJS({
     function _createToolPath(tool, version, arch2) {
       return __awaiter4(this, void 0, void 0, function* () {
         const folderPath = path16.join(_getCacheDirectory(), tool, semver8.clean(version) || version, arch2 || "");
-        core14.debug(`destination ${folderPath}`);
+        core15.debug(`destination ${folderPath}`);
         const markerPath = `${folderPath}.complete`;
         yield io6.rmRF(folderPath);
         yield io6.rmRF(markerPath);
@@ -81313,19 +81313,19 @@ var require_tool_cache = __commonJS({
       const folderPath = path16.join(_getCacheDirectory(), tool, semver8.clean(version) || version, arch2 || "");
       const markerPath = `${folderPath}.complete`;
       fs16.writeFileSync(markerPath, "");
-      core14.debug("finished caching tool");
+      core15.debug("finished caching tool");
     }
     function isExplicitVersion(versionSpec) {
       const c = semver8.clean(versionSpec) || "";
-      core14.debug(`isExplicit: ${c}`);
+      core15.debug(`isExplicit: ${c}`);
       const valid3 = semver8.valid(c) != null;
-      core14.debug(`explicit? ${valid3}`);
+      core15.debug(`explicit? ${valid3}`);
       return valid3;
     }
     exports2.isExplicitVersion = isExplicitVersion;
     function evaluateVersions(versions, versionSpec) {
       let version = "";
-      core14.debug(`evaluating ${versions.length} versions`);
+      core15.debug(`evaluating ${versions.length} versions`);
       versions = versions.sort((a, b) => {
         if (semver8.gt(a, b)) {
           return 1;
@@ -81341,9 +81341,9 @@ var require_tool_cache = __commonJS({
         }
       }
       if (version) {
-        core14.debug(`matched: ${version}`);
+        core15.debug(`matched: ${version}`);
       } else {
-        core14.debug("match not found");
+        core15.debug("match not found");
       }
       return version;
     }
@@ -84817,7 +84817,7 @@ var require_sarif_schema_2_1_0 = __commonJS({
 
 // src/upload-sarif-action.ts
 var fs15 = __toESM(require("fs"));
-var core13 = __toESM(require_core());
+var core14 = __toESM(require_core());
 
 // src/actions-util.ts
 var fs4 = __toESM(require("fs"));
@@ -93426,6 +93426,7 @@ function filterAlertsByDiffRange(logger, sarif) {
 }
 
 // src/upload-sarif.ts
+var core13 = __toESM(require_core());
 async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
   const sarifFiles = getSarifFilePaths(
     sarifPath,
@@ -93443,6 +93444,41 @@ async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPat
     );
   }
   return void 0;
+}
+async function uploadSarif(logger, features, sarifPath, pathStats, checkoutPath, category) {
+  const uploadResults = {};
+  const uploadResult = await findAndUpload(
+    logger,
+    features,
+    sarifPath,
+    pathStats,
+    checkoutPath,
+    CodeScanning,
+    category
+  );
+  if (uploadResult !== void 0) {
+    core13.setOutput("sarif-id", uploadResult.sarifID);
+    uploadResults["code-scanning" /* CodeScanning */] = uploadResult;
+  }
+  const qualityUploadResult = await findAndUpload(
+    logger,
+    features,
+    sarifPath,
+    pathStats,
+    checkoutPath,
+    CodeQuality,
+    fixCodeQualityCategory(logger, category)
+  );
+  if (qualityUploadResult !== void 0) {
+    uploadResults["code-quality" /* CodeQuality */] = qualityUploadResult;
+  }
+  return uploadResults;
+}
+function uploadResultsToSarifIds(uploadResults) {
+  return Object.entries(uploadResults).map(([analysisKind, result]) => ({
+    analysis: analysisKind,
+    id: result.sarifID
+  }));
 }
 
 // src/upload-sarif-action.ts
@@ -93496,62 +93532,40 @@ async function run() {
     if (pathStats === void 0) {
       throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
     }
-    const sarifIds = [];
-    const uploadResult = await findAndUpload(
+    const uploadResults = await uploadSarif(
       logger,
       features,
       sarifPath,
       pathStats,
       checkoutPath,
-      CodeScanning,
       category
     );
-    if (uploadResult !== void 0) {
-      core13.setOutput("sarif-id", uploadResult.sarifID);
-      sarifIds.push({
-        analysis: "code-scanning" /* CodeScanning */,
-        id: uploadResult.sarifID
-      });
-    }
-    const qualityUploadResult = await findAndUpload(
-      logger,
-      features,
-      sarifPath,
-      pathStats,
-      checkoutPath,
-      CodeQuality,
-      fixCodeQualityCategory(logger, category)
-    );
-    if (qualityUploadResult !== void 0) {
-      sarifIds.push({
-        analysis: "code-quality" /* CodeQuality */,
-        id: qualityUploadResult.sarifID
-      });
-    }
-    if (sarifIds.length === 0) {
+    if (Object.keys(uploadResults).length === 0) {
       logger.warning(`No SARIF files were uploaded.`);
     }
-    core13.setOutput("sarif-ids", JSON.stringify(sarifIds));
+    const sarifIds = uploadResultsToSarifIds(uploadResults);
+    core14.setOutput("sarif-ids", JSON.stringify(sarifIds));
     if (isInTestMode()) {
-      core13.debug("In test mode. Waiting for processing is disabled.");
+      core14.debug("In test mode. Waiting for processing is disabled.");
     } else if (getRequiredInput("wait-for-processing") === "true") {
-      if (uploadResult !== void 0) {
+      const codeScanningUploadResult = uploadResults["code-scanning" /* CodeScanning */];
+      if (codeScanningUploadResult !== void 0) {
         await waitForProcessing(
           getRepositoryNwo(),
-          uploadResult.sarifID,
+          codeScanningUploadResult.sarifID,
           logger
         );
       }
     }
     await sendSuccessStatusReport(
       startedAt,
-      uploadResult?.statusReport || {},
+      uploadResults["code-scanning" /* CodeScanning */]?.statusReport || {},
       logger
     );
   } catch (unwrappedError) {
     const error2 = isThirdPartyAnalysis("upload-sarif" /* UploadSarif */) && unwrappedError instanceof InvalidSarifUploadError ? new ConfigurationError(unwrappedError.message) : wrapError(unwrappedError);
     const message = error2.message;
-    core13.setFailed(message);
+    core14.setFailed(message);
     const errorStatusReportBase = await createStatusReportBase(
       "upload-sarif" /* UploadSarif */,
       getActionsStatus(error2),
@@ -93572,7 +93586,7 @@ async function runWrapper() {
   try {
     await run();
   } catch (error2) {
-    core13.setFailed(
+    core14.setFailed(
       `codeql/upload-sarif action failed: ${getErrorMessage(error2)}`
     );
   }

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93466,17 +93466,19 @@ async function uploadSarif(logger, features, sarifPath, pathStats, checkoutPath,
     core13.setOutput("sarif-id", uploadResult.sarifID);
     uploadResults["code-scanning" /* CodeScanning */] = uploadResult;
   }
-  const qualityUploadResult = await findAndUpload(
-    logger,
-    features,
-    sarifPath,
-    pathStats,
-    checkoutPath,
-    CodeQuality,
-    fixCodeQualityCategory(logger, category)
-  );
-  if (qualityUploadResult !== void 0) {
-    uploadResults["code-quality" /* CodeQuality */] = qualityUploadResult;
+  if (pathStats.isDirectory() || pathStats.isFile() && CodeQuality.sarifPredicate(sarifPath)) {
+    const qualityUploadResult = await findAndUpload(
+      logger,
+      features,
+      sarifPath,
+      pathStats,
+      checkoutPath,
+      CodeQuality,
+      fixCodeQualityCategory(logger, category)
+    );
+    if (qualityUploadResult !== void 0) {
+      uploadResults["code-quality" /* CodeQuality */] = qualityUploadResult;
+    }
   }
   return uploadResults;
 }

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93416,7 +93416,7 @@ function filterAlertsByDiffRange(logger, sarif) {
   return sarif;
 }
 
-// src/upload-sarif-action.ts
+// src/upload-sarif.ts
 async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
   let sarifFiles;
   if (pathStats.isDirectory()) {
@@ -93441,6 +93441,8 @@ async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPat
   }
   return void 0;
 }
+
+// src/upload-sarif-action.ts
 async function sendSuccessStatusReport(startedAt, uploadStats, logger) {
   const statusReportBase = await createStatusReportBase(
     "upload-sarif" /* UploadSarif */,

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93475,10 +93475,11 @@ async function uploadSarif(logger, features, sarifPath, pathStats, checkoutPath,
   return uploadResults;
 }
 function uploadResultsToSarifIds(uploadResults) {
-  return Object.entries(uploadResults).map(([analysisKind, result]) => ({
-    analysis: analysisKind,
-    id: result.sarifID
-  }));
+  const result = {};
+  for (const uploadResult of Object.keys(uploadResults)) {
+    result[uploadResult] = uploadResults[uploadResult].id;
+  }
+  return result;
 }
 
 // src/upload-sarif-action.ts

--- a/pr-checks/checks/upload-quality-sarif.yml
+++ b/pr-checks/checks/upload-quality-sarif.yml
@@ -22,5 +22,5 @@ steps:
       ref: 'refs/heads/main'
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'
   - name: "Check output from `upload-sarif` step"
-    if: fromJSON(steps.upload-sarif.outputs.sarif-ids)[0].analysis != 'code-quality'
+    if: !fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality
     run: exit 1

--- a/src/analyses.test.ts
+++ b/src/analyses.test.ts
@@ -2,6 +2,7 @@ import test from "ava";
 
 import {
   AnalysisKind,
+  isOtherAnalysisSarif,
   parseAnalysisKinds,
   supportedAnalysisKinds,
 } from "./analyses";
@@ -33,4 +34,24 @@ test("Parsing analysis kinds requires at least one analysis kind", async (t) => 
   await t.throwsAsync(parseAnalysisKinds(","), {
     instanceOf: ConfigurationError,
   });
+});
+
+test("isOtherAnalysisSarif", async (t) => {
+  function expectTrue(analysisKind: AnalysisKind, filepath: string) {
+    t.assert(
+      isOtherAnalysisSarif(analysisKind, filepath),
+      `Expected ${filepath} to be for another analysis kind, but it matched ${analysisKind}.`,
+    );
+  }
+  function expectFalse(analysisKind: AnalysisKind, filepath: string) {
+    t.assert(
+      !isOtherAnalysisSarif(analysisKind, filepath),
+      `Expected ${filepath} to be for ${analysisKind}, but it matched some other analysis kind.`,
+    );
+  }
+  expectTrue(AnalysisKind.CodeQuality, "test.sarif");
+  expectFalse(AnalysisKind.CodeQuality, "test.quality.sarif");
+  expectTrue(AnalysisKind.CodeScanning, "test.quality.sarif");
+  expectFalse(AnalysisKind.CodeScanning, "test.sarif");
+  expectFalse(AnalysisKind.CodeScanning, "test.json");
 });

--- a/src/analyses.ts
+++ b/src/analyses.ts
@@ -86,3 +86,23 @@ export const CodeQuality: AnalysisConfig = {
   sarifPredicate: (name) => name.endsWith(CodeQuality.sarifExtension),
   sentinelPrefix: "CODEQL_UPLOAD_QUALITY_SARIF_",
 };
+
+// An array of all analysis configurations we know of.
+export const Analyses = [CodeScanning, CodeQuality];
+
+/**
+ * Determines based on the given `filepath`, whether the file is a SARIF file for
+ * an analysis other than the one given by `current`.
+ *
+ * @param current The current analysis kind.
+ * @param filepath The path of the file to check.
+ * @returns True if `filepath` is a SARIF file for an analysis other than `current`; False otherwise.
+ */
+export function isOtherAnalysisSarif(
+  current: AnalysisKind,
+  filepath: string,
+): boolean {
+  return Analyses.some(
+    (config) => config.kind !== current && config.sarifPredicate(filepath),
+  );
+}

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -437,13 +437,13 @@ export function findSarifFilesInDir(
 
 export function getSarifFilePaths(
   sarifPath: string,
-  isSarif: (name: string) => boolean,
+  analysis: analyses.AnalysisConfig,
   pathStats: fs.Stats,
 ) {
-  let sarifFiles: string[];
+  let sarifFiles: string[] = [];
   if (pathStats.isDirectory()) {
-    sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
-  } else {
+    sarifFiles = findSarifFilesInDir(sarifPath, analysis.sarifPredicate);
+  } else if (!analyses.isOtherAnalysisSarif(analysis.kind, sarifPath)) {
     sarifFiles = [sarifPath];
   }
   return sarifFiles;
@@ -620,11 +620,7 @@ export async function uploadFiles(
     throw new ConfigurationError(`Path does not exist: ${inputSarifPath}`);
   }
 
-  const sarifPaths = getSarifFilePaths(
-    inputSarifPath,
-    uploadTarget.sarifPredicate,
-    pathStats,
-  );
+  const sarifPaths = getSarifFilePaths(inputSarifPath, uploadTarget, pathStats);
 
   if (sarifPaths.length === 0) {
     // This is always a configuration error, even for first-party runs.

--- a/src/upload-sarif-action.ts
+++ b/src/upload-sarif-action.ts
@@ -179,6 +179,11 @@ async function run() {
         id: qualityUploadResult.sarifID,
       });
     }
+
+    if (sarifIds.length === 0) {
+      logger.warning(`No SARIF files were uploaded.`);
+    }
+
     core.setOutput("sarif-ids", JSON.stringify(sarifIds));
 
     // We don't upload results in test mode, so don't wait for processing

--- a/src/upload-sarif-action.ts
+++ b/src/upload-sarif-action.ts
@@ -18,6 +18,7 @@ import {
   isThirdPartyAnalysis,
 } from "./status-report";
 import * as upload_lib from "./upload-lib";
+import { findAndUpload } from "./upload-sarif";
 import {
   ConfigurationError,
   checkActionVersion,
@@ -31,55 +32,6 @@ import {
 interface UploadSarifStatusReport
   extends StatusReportBase,
     upload_lib.UploadStatusReport {}
-
-/**
- * Searches for SARIF files for the given `analysis` in the given `sarifPath`.
- * If any are found, then they are uploaded to the appropriate endpoint for the given `analysis`.
- *
- * @param logger The logger to use.
- * @param features Information about FFs.
- * @param sarifPath The path to a SARIF file or directory containing SARIF files.
- * @param pathStats Information about `sarifPath`.
- * @param checkoutPath The checkout path.
- * @param analysis The configuration of the analysis we should upload SARIF files for.
- * @param category The SARIF category to use for the upload.
- * @returns The result of uploading the SARIF file(s) or `undefined` if there are none.
- */
-async function findAndUpload(
-  logger: Logger,
-  features: Features,
-  sarifPath: string,
-  pathStats: fs.Stats,
-  checkoutPath: string,
-  analysis: analyses.AnalysisConfig,
-  category?: string,
-): Promise<upload_lib.UploadResult | undefined> {
-  let sarifFiles: string[] | undefined;
-
-  if (pathStats.isDirectory()) {
-    sarifFiles = upload_lib.findSarifFilesInDir(
-      sarifPath,
-      analysis.sarifPredicate,
-    );
-  } else if (pathStats.isFile() && analysis.sarifPredicate(sarifPath)) {
-    sarifFiles = [sarifPath];
-  } else {
-    return undefined;
-  }
-
-  if (sarifFiles.length !== 0) {
-    return await upload_lib.uploadSpecifiedFiles(
-      sarifFiles,
-      checkoutPath,
-      category,
-      features,
-      logger,
-      analysis,
-    );
-  }
-
-  return undefined;
-}
 
 async function sendSuccessStatusReport(
   startedAt: Date,

--- a/src/upload-sarif.test.ts
+++ b/src/upload-sarif.test.ts
@@ -1,0 +1,199 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import test, { ExecutionContext } from "ava";
+import * as sinon from "sinon";
+
+import {
+  AnalysisConfig,
+  AnalysisKind,
+  CodeQuality,
+  CodeScanning,
+} from "./analyses";
+import { getRunnerLogger } from "./logging";
+import { createFeatures, setupTests } from "./testing-utils";
+import { UploadResult } from "./upload-lib";
+import * as uploadLib from "./upload-lib";
+import { findAndUpload, uploadSarif, UploadSarifResults } from "./upload-sarif";
+import * as util from "./util";
+
+setupTests(test);
+
+const findAndUploadMacro = test.macro({
+  exec: async (
+    t: ExecutionContext<unknown>,
+    sarifFiles: string[],
+    analysis: AnalysisConfig,
+    sarifPath: (tempDir: string) => string = (tempDir) => tempDir,
+    expectedResult: UploadResult | undefined,
+  ) => {
+    await util.withTmpDir(async (tempDir) => {
+      sinon.stub(uploadLib, "uploadSpecifiedFiles").resolves(expectedResult);
+      const logger = getRunnerLogger(true);
+      const features = createFeatures([]);
+
+      for (const sarifFile of sarifFiles) {
+        fs.writeFileSync(path.join(tempDir, sarifFile), "");
+      }
+
+      const stats = fs.statSync(sarifPath(tempDir));
+      const actual = await findAndUpload(
+        logger,
+        features,
+        sarifPath(tempDir),
+        stats,
+        "",
+        analysis,
+      );
+
+      t.deepEqual(actual, expectedResult);
+    });
+  },
+  title: (providedTitle = "") => `findAndUpload - ${providedTitle}`,
+});
+
+test(
+  "no matching files",
+  findAndUploadMacro,
+  ["test.json"],
+  CodeScanning,
+  undefined,
+  undefined,
+);
+
+test(
+  "matching files for Code Scanning with directory path",
+  findAndUploadMacro,
+  ["test.sarif"],
+  CodeScanning,
+  undefined,
+  {
+    statusReport: {},
+    sarifID: "some-id",
+  },
+);
+
+test(
+  "matching files for Code Scanning with file path",
+  findAndUploadMacro,
+  ["test.sarif"],
+  CodeScanning,
+  (tempDir) => path.join(tempDir, "test.sarif"),
+  {
+    statusReport: {},
+    sarifID: "some-id",
+  },
+);
+
+const uploadSarifMacro = test.macro({
+  exec: async (
+    t: ExecutionContext<unknown>,
+    sarifFiles: string[],
+    sarifPath: (tempDir: string) => string = (tempDir) => tempDir,
+    expectedResult: UploadSarifResults,
+  ) => {
+    await util.withTmpDir(async (tempDir) => {
+      const logger = getRunnerLogger(true);
+      const testPath = sarifPath(tempDir);
+      const features = createFeatures([]);
+      const uploadSpecifiedFiles = sinon.stub(
+        uploadLib,
+        "uploadSpecifiedFiles",
+      );
+
+      for (const analysisKind of Object.keys(expectedResult)) {
+        uploadSpecifiedFiles
+          .withArgs(
+            sinon.match.any,
+            sinon.match.any,
+            sinon.match.any,
+            features,
+            logger,
+            analysisKind === AnalysisKind.CodeScanning
+              ? CodeScanning
+              : CodeQuality,
+          )
+          .resolves(expectedResult[analysisKind as AnalysisKind]);
+      }
+
+      for (const sarifFile of sarifFiles) {
+        fs.writeFileSync(path.join(tempDir, sarifFile), "");
+      }
+
+      const stats = fs.statSync(testPath);
+      const actual = await uploadSarif(logger, features, testPath, stats, "");
+
+      t.deepEqual(actual, expectedResult);
+    });
+  },
+  title: (providedTitle = "") => `uploadSarif - ${providedTitle}`,
+});
+
+test(
+  "SARIF file",
+  uploadSarifMacro,
+  ["test.sarif"],
+  (tempDir) => path.join(tempDir, "test.sarif"),
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+  },
+);
+
+test(
+  "JSON file",
+  uploadSarifMacro,
+  ["test.json"],
+  (tempDir) => path.join(tempDir, "test.json"),
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+  },
+);
+
+test(
+  "Code Scanning files",
+  uploadSarifMacro,
+  ["test.json", "test.sarif"],
+  undefined,
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+  },
+);
+
+test(
+  "Code Quality file",
+  uploadSarifMacro,
+  ["test.quality.sarif"],
+  (tempDir) => path.join(tempDir, "test.quality.sarif"),
+  {
+    "code-quality": {
+      statusReport: {},
+      sarifID: "code-quality-sarif",
+    },
+  },
+);
+
+test(
+  "Mixed files",
+  uploadSarifMacro,
+  ["test.sarif", "test.quality.sarif"],
+  undefined,
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+    "code-quality": {
+      statusReport: {},
+      sarifID: "code-quality-sarif",
+    },
+  },
+);

--- a/src/upload-sarif.test.ts
+++ b/src/upload-sarif.test.ts
@@ -14,7 +14,7 @@ import { getRunnerLogger } from "./logging";
 import { createFeatures, setupTests } from "./testing-utils";
 import { UploadResult } from "./upload-lib";
 import * as uploadLib from "./upload-lib";
-import { findAndUpload, uploadSarif, UploadSarifResults } from "./upload-sarif";
+import { findAndUpload, uploadSarif } from "./upload-sarif";
 import * as util from "./util";
 
 setupTests(test);
@@ -85,17 +85,25 @@ test(
   },
 );
 
+interface UploadSarifExpectedResult {
+  uploadResult?: UploadResult;
+  expectedFiles?: string[];
+}
+
 const uploadSarifMacro = test.macro({
   exec: async (
     t: ExecutionContext<unknown>,
     sarifFiles: string[],
     sarifPath: (tempDir: string) => string = (tempDir) => tempDir,
-    expectedResult: UploadSarifResults,
+    expectedResult: Partial<Record<AnalysisKind, UploadSarifExpectedResult>>,
   ) => {
     await util.withTmpDir(async (tempDir) => {
       const logger = getRunnerLogger(true);
       const testPath = sarifPath(tempDir);
       const features = createFeatures([]);
+
+      const toFullPath = (filename: string) => path.join(tempDir, filename);
+
       const uploadSpecifiedFiles = sinon.stub(
         uploadLib,
         "uploadSpecifiedFiles",
@@ -113,17 +121,39 @@ const uploadSarifMacro = test.macro({
               ? CodeScanning
               : CodeQuality,
           )
-          .resolves(expectedResult[analysisKind as AnalysisKind]);
+          .resolves(expectedResult[analysisKind as AnalysisKind]?.uploadResult);
       }
 
-      for (const sarifFile of sarifFiles) {
-        fs.writeFileSync(path.join(tempDir, sarifFile), "");
+      const fullSarifPaths = sarifFiles.map(toFullPath);
+      for (const sarifFile of fullSarifPaths) {
+        fs.writeFileSync(sarifFile, "");
       }
 
       const stats = fs.statSync(testPath);
       const actual = await uploadSarif(logger, features, testPath, stats, "");
 
-      t.deepEqual(actual, expectedResult);
+      for (const analysisKind of Object.values(AnalysisKind)) {
+        const analyisKindResult = expectedResult[analysisKind];
+        if (analyisKindResult) {
+          t.deepEqual(actual[analysisKind], analyisKindResult.uploadResult);
+
+          t.assert(
+            uploadSpecifiedFiles.calledWith(
+              analyisKindResult.expectedFiles?.map(toFullPath) ??
+                fullSarifPaths,
+              sinon.match.any,
+              sinon.match.any,
+              features,
+              logger,
+              analysisKind === AnalysisKind.CodeScanning
+                ? CodeScanning
+                : CodeQuality,
+            ),
+          );
+        } else {
+          t.is(actual[analysisKind], undefined);
+        }
+      }
     });
   },
   title: (providedTitle = "") => `uploadSarif - ${providedTitle}`,
@@ -136,8 +166,10 @@ test(
   (tempDir) => path.join(tempDir, "test.sarif"),
   {
     "code-scanning": {
-      statusReport: {},
-      sarifID: "code-scanning-sarif",
+      uploadResult: {
+        statusReport: {},
+        sarifID: "code-scanning-sarif",
+      },
     },
   },
 );
@@ -149,8 +181,10 @@ test(
   (tempDir) => path.join(tempDir, "test.json"),
   {
     "code-scanning": {
-      statusReport: {},
-      sarifID: "code-scanning-sarif",
+      uploadResult: {
+        statusReport: {},
+        sarifID: "code-scanning-sarif",
+      },
     },
   },
 );
@@ -162,8 +196,11 @@ test(
   undefined,
   {
     "code-scanning": {
-      statusReport: {},
-      sarifID: "code-scanning-sarif",
+      uploadResult: {
+        statusReport: {},
+        sarifID: "code-scanning-sarif",
+      },
+      expectedFiles: ["test.sarif"],
     },
   },
 );
@@ -175,8 +212,10 @@ test(
   (tempDir) => path.join(tempDir, "test.quality.sarif"),
   {
     "code-quality": {
-      statusReport: {},
-      sarifID: "code-quality-sarif",
+      uploadResult: {
+        statusReport: {},
+        sarifID: "code-quality-sarif",
+      },
     },
   },
 );
@@ -188,12 +227,18 @@ test(
   undefined,
   {
     "code-scanning": {
-      statusReport: {},
-      sarifID: "code-scanning-sarif",
+      uploadResult: {
+        statusReport: {},
+        sarifID: "code-scanning-sarif",
+      },
+      expectedFiles: ["test.sarif"],
     },
     "code-quality": {
-      statusReport: {},
-      sarifID: "code-quality-sarif",
+      uploadResult: {
+        statusReport: {},
+        sarifID: "code-quality-sarif",
+      },
+      expectedFiles: ["test.quality.sarif"],
     },
   },
 );

--- a/src/upload-sarif.test.ts
+++ b/src/upload-sarif.test.ts
@@ -109,7 +109,7 @@ const uploadSarifMacro = test.macro({
         "uploadSpecifiedFiles",
       );
 
-      for (const analysisKind of Object.keys(expectedResult)) {
+      for (const analysisKind of Object.values(AnalysisKind)) {
         uploadSpecifiedFiles
           .withArgs(
             sinon.match.any,
@@ -135,8 +135,10 @@ const uploadSarifMacro = test.macro({
       for (const analysisKind of Object.values(AnalysisKind)) {
         const analyisKindResult = expectedResult[analysisKind];
         if (analyisKindResult) {
+          // We are expecting a result for this analysis kind, check that we have it.
           t.deepEqual(actual[analysisKind], analyisKindResult.uploadResult);
-
+          // Additionally, check that the mocked `uploadSpecifiedFiles` was called with only the file paths
+          // that we expected it to be called with.
           t.assert(
             uploadSpecifiedFiles.calledWith(
               analyisKindResult.expectedFiles?.map(toFullPath) ??
@@ -151,7 +153,24 @@ const uploadSarifMacro = test.macro({
             ),
           );
         } else {
+          // Otherwise, we are not expecting a result for this analysis kind. However, note that `undefined`
+          // is also returned by our mocked `uploadSpecifiedFiles` when there is no expected result for this
+          // analysis kind.
           t.is(actual[analysisKind], undefined);
+          // Therefore, we also check that the mocked `uploadSpecifiedFiles` was not called for this analysis kind.
+          t.assert(
+            !uploadSpecifiedFiles.calledWith(
+              sinon.match.any,
+              sinon.match.any,
+              sinon.match.any,
+              features,
+              logger,
+              analysisKind === AnalysisKind.CodeScanning
+                ? CodeScanning
+                : CodeQuality,
+            ),
+            `uploadSpecifiedFiles was called for ${analysisKind}, but should not have been.`,
+          );
         }
       }
     });

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -1,0 +1,55 @@
+import * as fs from "fs";
+
+import * as analyses from "./analyses";
+import { Features } from "./feature-flags";
+import { Logger } from "./logging";
+import * as upload_lib from "./upload-lib";
+
+/**
+ * Searches for SARIF files for the given `analysis` in the given `sarifPath`.
+ * If any are found, then they are uploaded to the appropriate endpoint for the given `analysis`.
+ *
+ * @param logger The logger to use.
+ * @param features Information about FFs.
+ * @param sarifPath The path to a SARIF file or directory containing SARIF files.
+ * @param pathStats Information about `sarifPath`.
+ * @param checkoutPath The checkout path.
+ * @param analysis The configuration of the analysis we should upload SARIF files for.
+ * @param category The SARIF category to use for the upload.
+ * @returns The result of uploading the SARIF file(s) or `undefined` if there are none.
+ */
+export async function findAndUpload(
+  logger: Logger,
+  features: Features,
+  sarifPath: string,
+  pathStats: fs.Stats,
+  checkoutPath: string,
+  analysis: analyses.AnalysisConfig,
+  category?: string,
+): Promise<upload_lib.UploadResult | undefined> {
+  let sarifFiles: string[] | undefined;
+
+  if (pathStats.isDirectory()) {
+    sarifFiles = upload_lib.findSarifFilesInDir(
+      sarifPath,
+      analysis.sarifPredicate,
+    );
+  } else if (pathStats.isFile() && analysis.sarifPredicate(sarifPath)) {
+    sarifFiles = [sarifPath];
+  } else {
+    return undefined;
+  }
+
+  if (sarifFiles.length !== 0) {
+    return await upload_lib.uploadSpecifiedFiles(
+      sarifFiles,
+      checkoutPath,
+      category,
+      features,
+      logger,
+      analysis,
+    );
+  }
+
+  return undefined;
+}

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -83,17 +83,22 @@ export async function uploadSarif(
   }
 
   // If there are `.quality.sarif` files in `sarifPath`, then upload those to the code quality service.
-  const qualityUploadResult = await findAndUpload(
-    logger,
-    features,
-    sarifPath,
-    pathStats,
-    checkoutPath,
-    analyses.CodeQuality,
-    actionsUtil.fixCodeQualityCategory(logger, category),
-  );
-  if (qualityUploadResult !== undefined) {
-    uploadResults[analyses.AnalysisKind.CodeQuality] = qualityUploadResult;
+  if (
+    pathStats.isDirectory() ||
+    (pathStats.isFile() && analyses.CodeQuality.sarifPredicate(sarifPath))
+  ) {
+    const qualityUploadResult = await findAndUpload(
+      logger,
+      features,
+      sarifPath,
+      pathStats,
+      checkoutPath,
+      analyses.CodeQuality,
+      actionsUtil.fixCodeQualityCategory(logger, category),
+    );
+    if (qualityUploadResult !== undefined) {
+      uploadResults[analyses.AnalysisKind.CodeQuality] = qualityUploadResult;
+    }
   }
 
   return uploadResults;

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -4,7 +4,7 @@ import * as core from "@actions/core";
 
 import * as actionsUtil from "./actions-util";
 import * as analyses from "./analyses";
-import { Features } from "./feature-flags";
+import { FeatureEnablement } from "./feature-flags";
 import { Logger } from "./logging";
 import * as upload_lib from "./upload-lib";
 
@@ -23,7 +23,7 @@ import * as upload_lib from "./upload-lib";
  */
 export async function findAndUpload(
   logger: Logger,
-  features: Features,
+  features: FeatureEnablement,
   sarifPath: string,
   pathStats: fs.Stats,
   checkoutPath: string,
@@ -61,7 +61,7 @@ export type UploadSarifResults = Partial<
 
 export async function uploadSarif(
   logger: Logger,
-  features: Features,
+  features: FeatureEnablement,
   sarifPath: string,
   pathStats: fs.Stats,
   checkoutPath: string,

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -27,18 +27,11 @@ export async function findAndUpload(
   analysis: analyses.AnalysisConfig,
   category?: string,
 ): Promise<upload_lib.UploadResult | undefined> {
-  let sarifFiles: string[] | undefined;
-
-  if (pathStats.isDirectory()) {
-    sarifFiles = upload_lib.findSarifFilesInDir(
-      sarifPath,
-      analysis.sarifPredicate,
-    );
-  } else if (pathStats.isFile() && analysis.sarifPredicate(sarifPath)) {
-    sarifFiles = [sarifPath];
-  } else {
-    return undefined;
-  }
+  const sarifFiles: string[] | undefined = upload_lib.getSarifFilePaths(
+    sarifPath,
+    analysis.sarifPredicate,
+    pathStats,
+  );
 
   if (sarifFiles.length !== 0) {
     return await upload_lib.uploadSpecifiedFiles(

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -32,7 +32,7 @@ export async function findAndUpload(
 ): Promise<upload_lib.UploadResult | undefined> {
   const sarifFiles: string[] | undefined = upload_lib.getSarifFilePaths(
     sarifPath,
-    analysis.sarifPredicate,
+    analysis,
     pathStats,
   );
 

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -101,9 +101,10 @@ export async function uploadSarif(
 
 export function uploadResultsToSarifIds(
   uploadResults: UploadSarifResults,
-): UploadSarifResult[] {
-  return Object.entries(uploadResults).map(([analysisKind, result]) => ({
-    analysis: analysisKind as analyses.AnalysisKind,
-    id: result.sarifID,
-  }));
+): Partial<Record<analyses.AnalysisKind, string>> {
+  const result = {};
+  for (const uploadResult of Object.keys(uploadResults)) {
+    result[uploadResult] = uploadResults[uploadResult].id;
+  }
+  return result;
 }


### PR DESCRIPTION
Fixes #3156. 

In https://github.com/github/codeql-action/pull/3123, we inadvertently introduced a regression by using the same logic for uploading SARIF files as in the `analyze` Action: if a file ends in `.quality.sarif`, we upload it to Code Quality, and if it ends in `.sarif` (but not `.quality.sarif`), we upload it to Code Scanning.

However, that didn't account for the possibility that `sarif-path` is set to a file or directory containing files with other extensions (such as `.json`).

This PR restores this behaviour by using `!analyses.CodeQuality.sarifPredicate(name)` as the file predicate for Code Scanning in the `upload-sarif` Action.

I have also refactored `upload-sarif-action` slightly to move some parts to a new `upload-sarif` module that I have added some basic tests for.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
