### PR TITLE
Add tests for `upload-sarif`

### DIFF
--- a/.github/workflows/__upload-quality-sarif.yml
+++ b/.github/workflows/__upload-quality-sarif.yml
@@ -89,7 +89,7 @@ jobs:
           ref: refs/heads/main
           sha: 5e235361806c361d4d3f8859e3c897658025a9a2
       - name: Check output from `upload-sarif` step
-        if: !(fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality)
+        if: '!(fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality)'
         run: exit 1
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__upload-quality-sarif.yml
+++ b/.github/workflows/__upload-quality-sarif.yml
@@ -89,7 +89,7 @@ jobs:
           ref: refs/heads/main
           sha: 5e235361806c361d4d3f8859e3c897658025a9a2
       - name: Check output from `upload-sarif` step
-        if: fromJSON(steps.upload-sarif.outputs.sarif-ids)[0].analysis != 'code-quality'
+        if: !(fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality)
         run: exit 1
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93416,7 +93416,7 @@ function filterAlertsByDiffRange(logger, sarif) {
   return sarif;
 }
 
-// src/upload-sarif-action.ts
+// src/upload-sarif.ts
 async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
   let sarifFiles;
   if (pathStats.isDirectory()) {
@@ -93441,6 +93441,8 @@ async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPat
   }
   return void 0;
 }
+
+// src/upload-sarif-action.ts
 async function sendSuccessStatusReport(startedAt, uploadStats, logger) {
   const statusReportBase = await createStatusReportBase(
     "upload-sarif" /* UploadSarif */,

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -93528,6 +93528,11 @@ async function run() {
       sarifPath,
       category
     );
+    if (Object.keys(uploadResults).length === 0) {
+      throw new ConfigurationError(
+        `No SARIF files found to upload in "${sarifPath}".`
+      );
+    }
     const codeScanningResult = uploadResults["code-scanning" /* CodeScanning */];
     if (codeScanningResult !== void 0) {
       core13.setOutput("sarif-id", codeScanningResult.sarifID);

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -84816,7 +84816,6 @@ var require_sarif_schema_2_1_0 = __commonJS({
 });
 
 // src/upload-sarif-action.ts
-var fs15 = __toESM(require("fs"));
 var core13 = __toESM(require_core());
 
 // src/actions-util.ts
@@ -93417,6 +93416,7 @@ function filterAlertsByDiffRange(logger, sarif) {
 }
 
 // src/upload-sarif.ts
+var fs15 = __toESM(require("fs"));
 async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPath, analysis, category) {
   let sarifFiles;
   if (pathStats.isDirectory()) {
@@ -93440,6 +93440,38 @@ async function findAndUpload(logger, features, sarifPath, pathStats, checkoutPat
     );
   }
   return void 0;
+}
+async function uploadSarif(logger, features, checkoutPath, sarifPath, category) {
+  const pathStats = fs15.lstatSync(sarifPath, { throwIfNoEntry: false });
+  if (pathStats === void 0) {
+    throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
+  }
+  const uploadResults = {};
+  const uploadResult = await findAndUpload(
+    logger,
+    features,
+    sarifPath,
+    pathStats,
+    checkoutPath,
+    CodeScanning,
+    category
+  );
+  if (uploadResult !== void 0) {
+    uploadResults["code-scanning" /* CodeScanning */] = uploadResult;
+  }
+  const qualityUploadResult = await findAndUpload(
+    logger,
+    features,
+    sarifPath,
+    pathStats,
+    checkoutPath,
+    CodeQuality,
+    fixCodeQualityCategory(logger, category)
+  );
+  if (qualityUploadResult !== void 0) {
+    uploadResults["code-quality" /* CodeQuality */] = qualityUploadResult;
+  }
+  return uploadResults;
 }
 
 // src/upload-sarif-action.ts
@@ -93489,57 +93521,32 @@ async function run() {
     const sarifPath = getRequiredInput("sarif_file");
     const checkoutPath = getRequiredInput("checkout_path");
     const category = getOptionalInput("category");
-    const pathStats = fs15.lstatSync(sarifPath, { throwIfNoEntry: false });
-    if (pathStats === void 0) {
-      throw new ConfigurationError(`Path does not exist: ${sarifPath}.`);
-    }
-    const sarifIds = [];
-    const uploadResult = await findAndUpload(
+    const uploadResults = await uploadSarif(
       logger,
       features,
-      sarifPath,
-      pathStats,
       checkoutPath,
-      CodeScanning,
+      sarifPath,
       category
     );
-    if (uploadResult !== void 0) {
-      core13.setOutput("sarif-id", uploadResult.sarifID);
-      sarifIds.push({
-        analysis: "code-scanning" /* CodeScanning */,
-        id: uploadResult.sarifID
-      });
+    const codeScanningResult = uploadResults["code-scanning" /* CodeScanning */];
+    if (codeScanningResult !== void 0) {
+      core13.setOutput("sarif-id", codeScanningResult.sarifID);
     }
-    const qualityUploadResult = await findAndUpload(
-      logger,
-      features,
-      sarifPath,
-      pathStats,
-      checkoutPath,
-      CodeQuality,
-      fixCodeQualityCategory(logger, category)
-    );
-    if (qualityUploadResult !== void 0) {
-      sarifIds.push({
-        analysis: "code-quality" /* CodeQuality */,
-        id: qualityUploadResult.sarifID
-      });
-    }
-    core13.setOutput("sarif-ids", JSON.stringify(sarifIds));
+    core13.setOutput("sarif-ids", JSON.stringify(uploadResults));
     if (isInTestMode()) {
       core13.debug("In test mode. Waiting for processing is disabled.");
     } else if (getRequiredInput("wait-for-processing") === "true") {
-      if (uploadResult !== void 0) {
+      if (codeScanningResult !== void 0) {
         await waitForProcessing(
           getRepositoryNwo(),
-          uploadResult.sarifID,
+          codeScanningResult.sarifID,
           logger
         );
       }
     }
     await sendSuccessStatusReport(
       startedAt,
-      uploadResult?.statusReport || {},
+      codeScanningResult?.statusReport || {},
       logger
     );
   } catch (unwrappedError) {

--- a/pr-checks/checks/upload-quality-sarif.yml
+++ b/pr-checks/checks/upload-quality-sarif.yml
@@ -22,5 +22,5 @@ steps:
       ref: 'refs/heads/main'
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'
   - name: "Check output from `upload-sarif` step"
-    if: !(fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality)
+    if: '!(fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality)'
     run: exit 1

--- a/pr-checks/checks/upload-quality-sarif.yml
+++ b/pr-checks/checks/upload-quality-sarif.yml
@@ -22,5 +22,5 @@ steps:
       ref: 'refs/heads/main'
       sha: '5e235361806c361d4d3f8859e3c897658025a9a2'
   - name: "Check output from `upload-sarif` step"
-    if: fromJSON(steps.upload-sarif.outputs.sarif-ids)[0].analysis != 'code-quality'
+    if: !(fromJSON(steps.upload-sarif.outputs.sarif-ids).code-quality)
     run: exit 1

--- a/src/upload-sarif-action.ts
+++ b/src/upload-sarif-action.ts
@@ -97,6 +97,14 @@ async function run() {
       sarifPath,
       category,
     );
+
+    // Fail if we didn't upload anything.
+    if (Object.keys(uploadResults).length === 0) {
+      throw new ConfigurationError(
+        `No SARIF files found to upload in "${sarifPath}".`,
+      );
+    }
+
     const codeScanningResult =
       uploadResults[analyses.AnalysisKind.CodeScanning];
     if (codeScanningResult !== undefined) {

--- a/src/upload-sarif-action.ts
+++ b/src/upload-sarif-action.ts
@@ -18,6 +18,7 @@ import {
   isThirdPartyAnalysis,
 } from "./status-report";
 import * as upload_lib from "./upload-lib";
+import { findAndUpload } from "./upload-sarif";
 import {
   ConfigurationError,
   checkActionVersion,
@@ -31,60 +32,6 @@ import {
 interface UploadSarifStatusReport
   extends StatusReportBase,
     upload_lib.UploadStatusReport {}
-
-/**
- * Searches for SARIF files for the given `analysis` in the given `sarifPath`.
- * If any are found, then they are uploaded to the appropriate endpoint for the given `analysis`.
- *
- * @param logger The logger to use.
- * @param features Information about FFs.
- * @param sarifPath The path to a SARIF file or directory containing SARIF files.
- * @param pathStats Information about `sarifPath`.
- * @param checkoutPath The checkout path.
- * @param analysis The configuration of the analysis we should upload SARIF files for.
- * @param category The SARIF category to use for the upload.
- * @returns The result of uploading the SARIF file(s) or `undefined` if there are none.
- */
-async function findAndUpload(
-  logger: Logger,
-  features: Features,
-  sarifPath: string,
-  pathStats: fs.Stats,
-  checkoutPath: string,
-  analysis: analyses.AnalysisConfig,
-  category?: string,
-): Promise<upload_lib.UploadResult | undefined> {
-  let sarifFiles: string[] | undefined;
-
-  if (pathStats.isDirectory()) {
-    sarifFiles = upload_lib.findSarifFilesInDir(
-      sarifPath,
-      analysis.sarifPredicate,
-    );
-  } else if (
-    pathStats.isFile() &&
-    (analysis.sarifPredicate(sarifPath) ||
-      (analysis.kind === analyses.AnalysisKind.CodeScanning &&
-        !analyses.CodeQuality.sarifPredicate(sarifPath)))
-  ) {
-    sarifFiles = [sarifPath];
-  } else {
-    return undefined;
-  }
-
-  if (sarifFiles.length !== 0) {
-    return await upload_lib.uploadSpecifiedFiles(
-      sarifFiles,
-      checkoutPath,
-      category,
-      features,
-      logger,
-      analysis,
-    );
-  }
-
-  return undefined;
-}
 
 async function sendSuccessStatusReport(
   startedAt: Date,

--- a/src/upload-sarif.test.ts
+++ b/src/upload-sarif.test.ts
@@ -132,15 +132,15 @@ const uploadSarifMacro = test.macro({
       const actual = await uploadSarif(logger, features, "", testPath);
 
       for (const analysisKind of Object.values(AnalysisKind)) {
-        const analyisKindResult = expectedResult[analysisKind];
-        if (analyisKindResult) {
+        const analysisKindResult = expectedResult[analysisKind];
+        if (analysisKindResult) {
           // We are expecting a result for this analysis kind, check that we have it.
-          t.deepEqual(actual[analysisKind], analyisKindResult.uploadResult);
+          t.deepEqual(actual[analysisKind], analysisKindResult.uploadResult);
           // Additionally, check that the mocked `uploadSpecifiedFiles` was called with only the file paths
           // that we expected it to be called with.
           t.assert(
             uploadSpecifiedFiles.calledWith(
-              analyisKindResult.expectedFiles?.map(toFullPath) ??
+              analysisKindResult.expectedFiles?.map(toFullPath) ??
                 fullSarifPaths,
               sinon.match.any,
               sinon.match.any,

--- a/src/upload-sarif.test.ts
+++ b/src/upload-sarif.test.ts
@@ -1,0 +1,198 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import test, { ExecutionContext } from "ava";
+import * as sinon from "sinon";
+
+import {
+  AnalysisConfig,
+  AnalysisKind,
+  CodeQuality,
+  CodeScanning,
+} from "./analyses";
+import { getRunnerLogger } from "./logging";
+import { createFeatures, setupTests } from "./testing-utils";
+import { UploadResult } from "./upload-lib";
+import * as uploadLib from "./upload-lib";
+import { findAndUpload, uploadSarif, UploadSarifResults } from "./upload-sarif";
+import * as util from "./util";
+
+setupTests(test);
+
+const findAndUploadMacro = test.macro({
+  exec: async (
+    t: ExecutionContext<unknown>,
+    sarifFiles: string[],
+    analysis: AnalysisConfig,
+    sarifPath: (tempDir: string) => string = (tempDir) => tempDir,
+    expectedResult: UploadResult | undefined,
+  ) => {
+    await util.withTmpDir(async (tempDir) => {
+      sinon.stub(uploadLib, "uploadSpecifiedFiles").resolves(expectedResult);
+      const logger = getRunnerLogger(true);
+      const features = createFeatures([]);
+
+      for (const sarifFile of sarifFiles) {
+        fs.writeFileSync(path.join(tempDir, sarifFile), "");
+      }
+
+      const stats = fs.statSync(sarifPath(tempDir));
+      const actual = await findAndUpload(
+        logger,
+        features,
+        sarifPath(tempDir),
+        stats,
+        "",
+        analysis,
+      );
+
+      t.deepEqual(actual, expectedResult);
+    });
+  },
+  title: (providedTitle = "") => `findAndUpload - ${providedTitle}`,
+});
+
+test(
+  "no matching files",
+  findAndUploadMacro,
+  ["test.json"],
+  CodeScanning,
+  undefined,
+  undefined,
+);
+
+test(
+  "matching files for Code Scanning with directory path",
+  findAndUploadMacro,
+  ["test.sarif"],
+  CodeScanning,
+  undefined,
+  {
+    statusReport: {},
+    sarifID: "some-id",
+  },
+);
+
+test(
+  "matching files for Code Scanning with file path",
+  findAndUploadMacro,
+  ["test.sarif"],
+  CodeScanning,
+  (tempDir) => path.join(tempDir, "test.sarif"),
+  {
+    statusReport: {},
+    sarifID: "some-id",
+  },
+);
+
+const uploadSarifMacro = test.macro({
+  exec: async (
+    t: ExecutionContext<unknown>,
+    sarifFiles: string[],
+    sarifPath: (tempDir: string) => string = (tempDir) => tempDir,
+    expectedResult: UploadSarifResults,
+  ) => {
+    await util.withTmpDir(async (tempDir) => {
+      const logger = getRunnerLogger(true);
+      const testPath = sarifPath(tempDir);
+      const features = createFeatures([]);
+      const uploadSpecifiedFiles = sinon.stub(
+        uploadLib,
+        "uploadSpecifiedFiles",
+      );
+
+      for (const analysisKind of Object.keys(expectedResult)) {
+        uploadSpecifiedFiles
+          .withArgs(
+            sinon.match.any,
+            sinon.match.any,
+            sinon.match.any,
+            features,
+            logger,
+            analysisKind === AnalysisKind.CodeScanning
+              ? CodeScanning
+              : CodeQuality,
+          )
+          .resolves(expectedResult[analysisKind as AnalysisKind]);
+      }
+
+      for (const sarifFile of sarifFiles) {
+        fs.writeFileSync(path.join(tempDir, sarifFile), "");
+      }
+
+      const actual = await uploadSarif(logger, features, "", testPath);
+
+      t.deepEqual(actual, expectedResult);
+    });
+  },
+  title: (providedTitle = "") => `uploadSarif - ${providedTitle}`,
+});
+
+test(
+  "SARIF file",
+  uploadSarifMacro,
+  ["test.sarif"],
+  (tempDir) => path.join(tempDir, "test.sarif"),
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+  },
+);
+
+test(
+  "JSON file",
+  uploadSarifMacro,
+  ["test.json"],
+  (tempDir) => path.join(tempDir, "test.json"),
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+  },
+);
+
+test(
+  "Code Scanning files",
+  uploadSarifMacro,
+  ["test.json", "test.sarif"],
+  undefined,
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+  },
+);
+
+test(
+  "Code Quality file",
+  uploadSarifMacro,
+  ["test.quality.sarif"],
+  (tempDir) => path.join(tempDir, "test.quality.sarif"),
+  {
+    "code-quality": {
+      statusReport: {},
+      sarifID: "code-quality-sarif",
+    },
+  },
+);
+
+test(
+  "Mixed files",
+  uploadSarifMacro,
+  ["test.sarif", "test.quality.sarif"],
+  undefined,
+  {
+    "code-scanning": {
+      statusReport: {},
+      sarifID: "code-scanning-sarif",
+    },
+    "code-quality": {
+      statusReport: {},
+      sarifID: "code-quality-sarif",
+    },
+  },
+);

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+
+import * as analyses from "./analyses";
+import { Features } from "./feature-flags";
+import { Logger } from "./logging";
+import * as upload_lib from "./upload-lib";
+
+/**
+ * Searches for SARIF files for the given `analysis` in the given `sarifPath`.
+ * If any are found, then they are uploaded to the appropriate endpoint for the given `analysis`.
+ *
+ * @param logger The logger to use.
+ * @param features Information about FFs.
+ * @param sarifPath The path to a SARIF file or directory containing SARIF files.
+ * @param pathStats Information about `sarifPath`.
+ * @param checkoutPath The checkout path.
+ * @param analysis The configuration of the analysis we should upload SARIF files for.
+ * @param category The SARIF category to use for the upload.
+ * @returns The result of uploading the SARIF file(s) or `undefined` if there are none.
+ */
+export async function findAndUpload(
+  logger: Logger,
+  features: Features,
+  sarifPath: string,
+  pathStats: fs.Stats,
+  checkoutPath: string,
+  analysis: analyses.AnalysisConfig,
+  category?: string,
+): Promise<upload_lib.UploadResult | undefined> {
+  let sarifFiles: string[] | undefined;
+
+  if (pathStats.isDirectory()) {
+    sarifFiles = upload_lib.findSarifFilesInDir(
+      sarifPath,
+      analysis.sarifPredicate,
+    );
+  } else if (
+    pathStats.isFile() &&
+    (analysis.sarifPredicate(sarifPath) ||
+      (analysis.kind === analyses.AnalysisKind.CodeScanning &&
+        !analyses.CodeQuality.sarifPredicate(sarifPath)))
+  ) {
+    sarifFiles = [sarifPath];
+  } else {
+    return undefined;
+  }
+
+  if (sarifFiles.length !== 0) {
+    return await upload_lib.uploadSpecifiedFiles(
+      sarifFiles,
+      checkoutPath,
+      category,
+      features,
+      logger,
+      analysis,
+    );
+  }
+
+  return undefined;
+}

--- a/src/upload-sarif.ts
+++ b/src/upload-sarif.ts
@@ -62,7 +62,7 @@ export async function findAndUpload(
 }
 
 // Maps analysis kinds to SARIF IDs.
-type UploadSarifResults = Partial<
+export type UploadSarifResults = Partial<
   Record<analyses.AnalysisKind, upload_lib.UploadResult>
 >;
 


### PR DESCRIPTION
This PR takes parts of #3157:

- Moves logic from `upload-sarif-action.ts` to `upload-sarif.ts`
- Adds unit test coverage for the functions in `upload-sarif.ts`
- Fixes `sarif-ids` output format to match documentation
- Throws a `ConfigurationError` if no SARIF files were uploaded, matching the behaviour of `upload-sarif` prior to https://github.com/github/codeql-action/pull/3123

This doesn't make any further changes to the actual upload logic beyond the hotfix we added in #3160. I am planning a follow-up PR to improve on that after having come up with an idea for a good approach over the weekend, but want to the tests, `sarif-ids` fix, and error for the case where no files were uploaded merged first.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
