### PR TITLE
Overlays: allow any build mode for Go

### DIFF
--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -87860,7 +87860,13 @@ async function getOverlayDatabaseMode(codeql, repository, features, languages, s
     return nonOverlayAnalysis;
   }
   if (buildMode !== "none" /* None */ && (await Promise.all(
-    languages.map(async (l) => await codeql.isTracedLanguage(l))
+    languages.map(
+      async (l) => l !== "go" /* go */ && // Workaround to allow overlay analysis for Go with any build
+      // mode, since it does not yet support BMN. The Go autobuilder and/or extractor will
+      // ensure that overlay-base databases are only created for supported Go build setups,
+      // and that we'll fall back to full databases in other cases.
+      await codeql.isTracedLanguage(l)
+    )
   )).some(Boolean)) {
     logger.warning(
       `Cannot build an ${overlayDatabaseMode} database because build-mode is set to "${buildMode}" instead of "none". Falling back to creating a normal full database instead.`

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -723,7 +723,14 @@ export async function getOverlayDatabaseMode(
     buildMode !== BuildMode.None &&
     (
       await Promise.all(
-        languages.map(async (l) => await codeql.isTracedLanguage(l)),
+        languages.map(
+          async (l) =>
+            l !== KnownLanguage.go && // Workaround to allow overlay analysis for Go with any build
+            // mode, since it does not yet support BMN. The Go autobuilder and/or extractor will
+            // ensure that overlay-base databases are only created for supported Go build setups,
+            // and that we'll fall back to full databases in other cases.
+            (await codeql.isTracedLanguage(l)),
+        ),
       )
     ).some(Boolean)
   ) {


### PR DESCRIPTION
We have a check that a traced language can only run overlay analysis with `build-mode: none`, but Go does not currently declare support for BMN, even though it has a similar autobuild mode that will work for overlay analysis.

This commit adds a hard-coded exception to that check, allowing any build mode for Go. This is intended as a short-term solution until Go declares BMN support.

For now, it should be safe to enable for all build modes:
- We can still control rollout, via the overlay feature flags, to repos we know will work correctly.
- It allows us to see what happens for manual builds.
- We should be able to ensure that the Go extractor/autobuilder fail for unsupported build configures in such a way that we fall back to full analysis.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

- **Advanced setup** - Impacts users who have custom workflows.
- **Default setup** - Impacts users who use default setup.
- **Code Scanning** - Impacts Code Scanning (i.e. `analysis-kinds: code-scanning`).
- **Code Quality** - Impacts Code Quality (i.e. `analysis-kinds: code-quality`).

#### How did/will you validate this change?

- **None** - I am not validating these changes specifically, but I have been testing overlay analysis for Go in general.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Feature flags** - All new or changed code paths can be fully disabled with corresponding feature flags.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
