### PR TITLE
Allow `Partial<Config>` for `createStatusReportBase`

### DIFF
--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -94111,7 +94111,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       action_ref: actionRef,
       action_started_at: actionStartedAt.toISOString(),
       action_version: getActionVersion(),
-      analysis_kinds: config?.analysisKinds.join(","),
+      analysis_kinds: config?.analysisKinds?.join(","),
       analysis_key,
       build_mode: config?.buildMode,
       commit_oid: commitOid,
@@ -94134,7 +94134,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       logger.warning(`Could not determine the workflow event name: ${e}.`);
     }
     if (config) {
-      statusReport.languages = config.languages.join(",");
+      statusReport.languages = config.languages?.join(",");
     }
     if (diskInfo) {
       statusReport.runner_available_disk_space_bytes = diskInfo.numAvailableBytes;

--- a/lib/autobuild-action.js
+++ b/lib/autobuild-action.js
@@ -79812,7 +79812,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       action_ref: actionRef,
       action_started_at: actionStartedAt.toISOString(),
       action_version: getActionVersion(),
-      analysis_kinds: config?.analysisKinds.join(","),
+      analysis_kinds: config?.analysisKinds?.join(","),
       analysis_key,
       build_mode: config?.buildMode,
       commit_oid: commitOid,
@@ -79835,7 +79835,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       logger.warning(`Could not determine the workflow event name: ${e}.`);
     }
     if (config) {
-      statusReport.languages = config.languages.join(",");
+      statusReport.languages = config.languages?.join(",");
     }
     if (diskInfo) {
       statusReport.runner_available_disk_space_bytes = diskInfo.numAvailableBytes;

--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -90265,7 +90265,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       action_ref: actionRef,
       action_started_at: actionStartedAt.toISOString(),
       action_version: getActionVersion(),
-      analysis_kinds: config?.analysisKinds.join(","),
+      analysis_kinds: config?.analysisKinds?.join(","),
       analysis_key,
       build_mode: config?.buildMode,
       commit_oid: commitOid,
@@ -90288,7 +90288,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       logger.warning(`Could not determine the workflow event name: ${e}.`);
     }
     if (config) {
-      statusReport.languages = config.languages.join(",");
+      statusReport.languages = config.languages?.join(",");
     }
     if (diskInfo) {
       statusReport.runner_available_disk_space_bytes = diskInfo.numAvailableBytes;

--- a/lib/resolve-environment-action.js
+++ b/lib/resolve-environment-action.js
@@ -79439,7 +79439,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       action_ref: actionRef,
       action_started_at: actionStartedAt.toISOString(),
       action_version: getActionVersion(),
-      analysis_kinds: config?.analysisKinds.join(","),
+      analysis_kinds: config?.analysisKinds?.join(","),
       analysis_key,
       build_mode: config?.buildMode,
       commit_oid: commitOid,
@@ -79462,7 +79462,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       logger.warning(`Could not determine the workflow event name: ${e}.`);
     }
     if (config) {
-      statusReport.languages = config.languages.join(",");
+      statusReport.languages = config.languages?.join(",");
     }
     if (diskInfo) {
       statusReport.runner_available_disk_space_bytes = diskInfo.numAvailableBytes;

--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -95589,7 +95589,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       action_ref: actionRef,
       action_started_at: actionStartedAt.toISOString(),
       action_version: getActionVersion(),
-      analysis_kinds: config?.analysisKinds.join(","),
+      analysis_kinds: config?.analysisKinds?.join(","),
       analysis_key,
       build_mode: config?.buildMode,
       commit_oid: commitOid,
@@ -95612,7 +95612,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       logger.warning(`Could not determine the workflow event name: ${e}.`);
     }
     if (config) {
-      statusReport.languages = config.languages.join(",");
+      statusReport.languages = config.languages?.join(",");
     }
     if (diskInfo) {
       statusReport.runner_available_disk_space_bytes = diskInfo.numAvailableBytes;

--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -95087,8 +95087,7 @@ var LANGUAGE_TO_REGISTRY_TYPE = {
   rust: ["cargo_registry"],
   go: ["goproxy_server", "git_source"]
 };
-function getCredentials(logger, registrySecrets, registriesCredentials, languageString) {
-  const language = languageString ? parseLanguage(languageString) : void 0;
+function getCredentials(logger, registrySecrets, registriesCredentials, language) {
   const registryTypeForLanguage = language ? LANGUAGE_TO_REGISTRY_TYPE[language] : void 0;
   let credentialsStr;
   if (registriesCredentials !== void 0) {
@@ -95780,11 +95779,13 @@ async function runWrapper() {
     const tempDir = getTemporaryDirectory();
     const proxyLogFilePath = path.resolve(tempDir, "proxy.log");
     core11.saveState("proxy-log-file", proxyLogFilePath);
+    const languageInput = getOptionalInput("language");
+    const language = languageInput ? parseLanguage(languageInput) : void 0;
     const credentials = getCredentials(
       logger,
       getOptionalInput("registry_secrets"),
       getOptionalInput("registries_credentials"),
-      getOptionalInput("language")
+      language
     );
     if (credentials.length === 0) {
       logger.info("No credentials found, skipping proxy setup.");

--- a/lib/start-proxy-action.js
+++ b/lib/start-proxy-action.js
@@ -95754,12 +95754,12 @@ function generateCertificateAuthority() {
   const key = import_node_forge.pki.privateKeyToPem(keys.privateKey);
   return { cert: pem, key };
 }
-async function sendSuccessStatusReport(startedAt, registry_types, logger) {
+async function sendSuccessStatusReport(startedAt, config, registry_types, logger) {
   const statusReportBase = await createStatusReportBase(
     "start-proxy" /* StartProxy */,
     "success",
     startedAt,
-    void 0,
+    config,
     await checkDiskUsage(logger),
     logger
   );
@@ -95804,6 +95804,9 @@ async function runWrapper() {
     await startProxy(proxyBin, proxyConfig, proxyLogFilePath, logger);
     await sendSuccessStatusReport(
       startedAt,
+      {
+        languages: language ? [language] : []
+      },
       proxyConfig.all_credentials.map((c) => c.type),
       logger
     );

--- a/lib/upload-sarif-action.js
+++ b/lib/upload-sarif-action.js
@@ -89856,7 +89856,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       action_ref: actionRef,
       action_started_at: actionStartedAt.toISOString(),
       action_version: getActionVersion(),
-      analysis_kinds: config?.analysisKinds.join(","),
+      analysis_kinds: config?.analysisKinds?.join(","),
       analysis_key,
       build_mode: config?.buildMode,
       commit_oid: commitOid,
@@ -89879,7 +89879,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       logger.warning(`Could not determine the workflow event name: ${e}.`);
     }
     if (config) {
-      statusReport.languages = config.languages.join(",");
+      statusReport.languages = config.languages?.join(",");
     }
     if (diskInfo) {
       statusReport.runner_available_disk_space_bytes = diskInfo.numAvailableBytes;

--- a/src/start-proxy-action.ts
+++ b/src/start-proxy-action.ts
@@ -12,6 +12,7 @@ import {
   Credential,
   getCredentials,
   getDownloadUrl,
+  parseLanguage,
   UPDATEJOB_PROXY,
 } from "./start-proxy";
 import {
@@ -133,11 +134,13 @@ async function runWrapper() {
     core.saveState("proxy-log-file", proxyLogFilePath);
 
     // Get the configuration options
+    const languageInput = actionsUtil.getOptionalInput("language");
+    const language = languageInput ? parseLanguage(languageInput) : undefined;
     const credentials = getCredentials(
       logger,
       actionsUtil.getOptionalInput("registry_secrets"),
       actionsUtil.getOptionalInput("registries_credentials"),
-      actionsUtil.getOptionalInput("language"),
+      language,
     );
 
     if (credentials.length === 0) {

--- a/src/start-proxy-action.ts
+++ b/src/start-proxy-action.ts
@@ -7,6 +7,7 @@ import { pki } from "node-forge";
 
 import * as actionsUtil from "./actions-util";
 import { getApiDetails, getAuthorizationHeaderFor } from "./api-client";
+import { Config } from "./config-utils";
 import { getActionsLogger, Logger } from "./logging";
 import {
   Credential,
@@ -99,6 +100,7 @@ interface StartProxyStatus extends StatusReportBase {
 
 async function sendSuccessStatusReport(
   startedAt: Date,
+  config: Partial<Config>,
   registry_types: string[],
   logger: Logger,
 ) {
@@ -106,7 +108,7 @@ async function sendSuccessStatusReport(
     ActionName.StartProxy,
     "success",
     startedAt,
-    undefined,
+    config,
     await util.checkDiskUsage(logger),
     logger,
   );
@@ -168,6 +170,9 @@ async function runWrapper() {
     // Report success if we have reached this point.
     await sendSuccessStatusReport(
       startedAt,
+      {
+        languages: language ? [language] : [],
+      },
       proxyConfig.all_credentials.map((c) => c.type),
       logger,
     );

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -109,7 +109,7 @@ test("getCredentials filters by language when specified", async (t) => {
     getRunnerLogger(true),
     undefined,
     toEncodedJSON(mixedCredentials),
-    "java",
+    KnownLanguage.java,
   );
   t.is(credentials.length, 1);
   t.is(credentials[0].type, "maven_repository");
@@ -120,7 +120,7 @@ test("getCredentials returns all for a language when specified", async (t) => {
     getRunnerLogger(true),
     undefined,
     toEncodedJSON(mixedCredentials),
-    "go",
+    KnownLanguage.go,
   );
   t.is(credentials.length, 2);
 

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -79,9 +79,8 @@ export function getCredentials(
   logger: Logger,
   registrySecrets: string | undefined,
   registriesCredentials: string | undefined,
-  languageString: string | undefined,
+  language: KnownLanguage | undefined,
 ): Credential[] {
-  const language = languageString ? parseLanguage(languageString) : undefined;
   const registryTypeForLanguage = language
     ? LANGUAGE_TO_REGISTRY_TYPE[language]
     : undefined;

--- a/src/status-report.test.ts
+++ b/src/status-report.test.ts
@@ -92,6 +92,49 @@ test("createStatusReportBase", async (t) => {
   });
 });
 
+test("createStatusReportBase - empty configuration", async (t) => {
+  await withTmpDir(async (tmpDir: string) => {
+    setupEnvironmentAndStub(tmpDir);
+
+    const statusReport = await createStatusReportBase(
+      ActionName.StartProxy,
+      "success",
+      new Date("May 19, 2023 05:19:00"),
+      {},
+      { numAvailableBytes: 100, numTotalBytes: 500 },
+      getRunnerLogger(false),
+    );
+
+    if (t.truthy(statusReport)) {
+      t.is(statusReport.action_name, ActionName.StartProxy);
+      t.is(statusReport.status, "success");
+    }
+  });
+});
+
+test("createStatusReportBase - partial configuration", async (t) => {
+  await withTmpDir(async (tmpDir: string) => {
+    setupEnvironmentAndStub(tmpDir);
+
+    const statusReport = await createStatusReportBase(
+      ActionName.StartProxy,
+      "success",
+      new Date("May 19, 2023 05:19:00"),
+      {
+        languages: ["go"],
+      },
+      { numAvailableBytes: 100, numTotalBytes: 500 },
+      getRunnerLogger(false),
+    );
+
+    if (t.truthy(statusReport)) {
+      t.is(statusReport.action_name, ActionName.StartProxy);
+      t.is(statusReport.status, "success");
+      t.is(statusReport.languages, "go");
+    }
+  });
+});
+
 test("createStatusReportBase_firstParty", async (t) => {
   await withTmpDir(async (tmpDir: string) => {
     setupEnvironmentAndStub(tmpDir);

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -260,7 +260,7 @@ export async function createStatusReportBase(
   actionName: ActionName,
   status: ActionStatus,
   actionStartedAt: Date,
-  config: Config | undefined,
+  config: Partial<Config> | undefined,
   diskInfo: DiskUsage | undefined,
   logger: Logger,
   cause?: string,
@@ -299,7 +299,7 @@ export async function createStatusReportBase(
       action_ref: actionRef,
       action_started_at: actionStartedAt.toISOString(),
       action_version: getActionVersion(),
-      analysis_kinds: config?.analysisKinds.join(","),
+      analysis_kinds: config?.analysisKinds?.join(","),
       analysis_key,
       build_mode: config?.buildMode,
       commit_oid: commitOid,
@@ -324,7 +324,7 @@ export async function createStatusReportBase(
     }
 
     if (config) {
-      statusReport.languages = config.languages.join(",");
+      statusReport.languages = config.languages?.join(",");
     }
 
     if (diskInfo) {


### PR DESCRIPTION
This PR changes the type of `createStatusReportBase` to allow `Partial<Config> | undefined` rather than `Config | undefined`. The unit tests for `createStatusReportBase` are updated accordingly. I then made use of this to populate the `languages` field in the `start-proxy` telemetry.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

- **Default setup** - Impacts users who use default setup.
- **Code Scanning** - Impacts Code Scanning (i.e. `analysis-kinds: code-scanning`).
- **Code Quality** - Impacts Code Quality (i.e. `analysis-kinds: code-quality`).
- **GHES** - Impacts GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
