### PR TITLE
Install Python 3.13 to fix failing PR checks with older CLI versions

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -70,6 +80,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__local-bundle.yml
+++ b/.github/workflows/__local-bundle.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -70,6 +80,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - name: Fetch latest CodeQL bundle
         run: |
           wget https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.zst

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -104,6 +114,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - name: Use Xcode 16
         if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
         run: sudo xcode-select -s "/Applications/Xcode_16.app"

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -81,6 +91,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - uses: ./../action/init
         with:
           config-file: .github/codeql/codeql-config-packaging3.yml

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -72,6 +82,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -72,6 +82,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - uses: ./../action/init
         id: init
         with:

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -70,6 +80,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__upload-sarif.yml
+++ b/.github/workflows/__upload-sarif.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -77,6 +87,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - uses: ./../action/init
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -27,6 +27,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
   workflow_call:
     inputs:
       go-version:
@@ -34,6 +39,11 @@ on:
         description: The version of Go to install
         required: false
         default: '>=1.21.0'
+      python-version:
+        type: string
+        description: The version of Python to install
+        required: false
+        default: '3.13'
 defaults:
   run:
     shell: bash
@@ -70,6 +80,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
+      - name: Install Python
+        if: matrix.version != 'nightly-latest'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version || '3.13' }}
       - name: Delete original checkout
         run: |
           # delete the original checkout so we don't accidentally use it.

--- a/pr-checks/checks/analyze-ref-input.yml
+++ b/pr-checks/checks/analyze-ref-input.yml
@@ -2,6 +2,7 @@ name: "Analyze: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
 versions: ["default"]
 installGo: true
+installPython: true
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/local-bundle.yml
+++ b/pr-checks/checks/local-bundle.yml
@@ -2,6 +2,7 @@ name: "Local CodeQL bundle"
 description: "Tests using a CodeQL bundle from a local file rather than a URL"
 versions: ["linked"]
 installGo: true
+installPython: true
 steps:
   - name: Fetch latest CodeQL bundle
     run: |

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -4,6 +4,7 @@ operatingSystems: ["macos", "ubuntu"]
 env:
   CODEQL_ACTION_RESOLVE_SUPPORTED_LANGUAGES_USING_CLI: true
 installGo: true
+installPython: true
 steps:
   - name: Use Xcode 16
     if: runner.os == 'macOS' && matrix.version != 'nightly-latest'

--- a/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
+++ b/pr-checks/checks/packaging-codescanning-config-inputs-js.yml
@@ -3,6 +3,7 @@ description: "Checks that specifying packages using a combination of a config fi
 versions: ["linked", "default", "nightly-latest"] # This feature is not compatible with old CLIs
 installGo: true
 installNode: true
+installPython: true
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/remote-config.yml
+++ b/pr-checks/checks/remote-config.yml
@@ -6,6 +6,7 @@ versions:
   - linked
   - nightly-latest
 installGo: true
+installPython: true
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/unset-environment.yml
+++ b/pr-checks/checks/unset-environment.yml
@@ -6,6 +6,7 @@ versions:
   - linked
   - nightly-latest
 installGo: true
+installPython: true
 steps:
   - uses: ./../action/init
     id: init

--- a/pr-checks/checks/upload-ref-sha-input.yml
+++ b/pr-checks/checks/upload-ref-sha-input.yml
@@ -2,6 +2,7 @@ name: "Upload-sarif: 'ref' and 'sha' from inputs"
 description: "Checks that specifying 'ref' and 'sha' as inputs works"
 versions: ["default"]
 installGo: true
+installPython: true
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/upload-sarif.yml
+++ b/pr-checks/checks/upload-sarif.yml
@@ -3,6 +3,7 @@ description: "Checks that uploading SARIFs to the code quality endpoint works"
 versions: ["default"]
 analysisKinds: ["code-scanning", "code-quality", "code-scanning,code-quality"]
 installGo: true
+installPython: true
 steps:
   - uses: ./../action/init
     with:

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -2,6 +2,7 @@ name: "Use a custom `checkout_path`"
 description: "Checks that a custom `checkout_path` will find the proper commit_oid"
 versions: ["linked"]
 installGo: true
+installPython: true
 steps:
   # This ensures we don't accidentally use the original checkout for any part of the test.
   - name: Delete original checkout

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -184,6 +184,26 @@ for file in sorted((this_dir / 'checks').glob('*.yml')):
             }
         })
 
+    installPython = is_truthy(checkSpecification.get('installPython', ''))
+
+    if installPython:
+        basePythonVersionExpr = '3.13'
+        workflowInputs['python-version'] = {
+            'type': 'string',
+            'description': 'The version of Python to install',
+            'required': False,
+            'default': basePythonVersionExpr,
+        }
+
+        steps.append({
+            'name': 'Install Python',
+            'if': 'matrix.version != \'nightly-latest\'',
+            'uses': 'actions/setup-python@v6',
+            'with': {
+                'python-version': '${{ inputs.python-version || \'' + basePythonVersionExpr + '\' }}'
+            }
+        })
+
     # If container initialisation steps are present in the check specification,
     # make sure to execute them first.
     if 'container' in checkSpecification and 'container-init-steps' in checkSpecification:


### PR DESCRIPTION
Some of our PR checks are currently failing [due to an incompatibility between older CLI versions and Python 3.14](https://github.com/github/codeql/issues/20628). The problem is fixed in `nightly-latest`, but older CLI releases need Python 3.13 or below.

This PR updates `sync.py` to support an `installPython` option in workflow templates. I have set this option to `true` for all PR checks that run a Python analysis.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

CI only.

#### How did/will you validate this change?

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

CI only.

#### How will you know if something goes wrong after this change is released?

CI will continue to fail.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
