### PR TITLE
Always skip database upload if `AnalysisKind.CodeScanning` is not enabled

### DIFF
--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -94082,6 +94082,12 @@ async function uploadDatabases(repositoryNwo, codeql, config, apiDetails, logger
     logger.debug("Database upload disabled in workflow. Skipping upload.");
     return;
   }
+  if (!config.analysisKinds.includes("code-scanning" /* CodeScanning */)) {
+    logger.debug(
+      `Not uploading database because 'analysis-kinds: ${"code-scanning" /* CodeScanning */}' is not enabled.`
+    );
+    return;
+  }
   if (isInTestMode()) {
     logger.debug("In test mode. Skipping database upload.");
     return;

--- a/src/database-upload.ts
+++ b/src/database-upload.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 
 import * as actionsUtil from "./actions-util";
+import { AnalysisKind } from "./analyses";
 import { getApiClient, GitHubApiDetails } from "./api-client";
 import { type CodeQL } from "./codeql";
 import { Config } from "./config-utils";
@@ -19,6 +20,13 @@ export async function uploadDatabases(
 ): Promise<void> {
   if (actionsUtil.getRequiredInput("upload-database") !== "true") {
     logger.debug("Database upload disabled in workflow. Skipping upload.");
+    return;
+  }
+
+  if (!config.analysisKinds.includes(AnalysisKind.CodeScanning)) {
+    logger.debug(
+      `Not uploading database because 'analysis-kinds: ${AnalysisKind.CodeScanning}' is not enabled.`,
+    );
     return;
   }
 


### PR DESCRIPTION
Databases that are produced if `analysis-kinds: code-quality` is the only enabled analysis kind are initialised for a different set of queries than those that are initialised if `analysis-kinds: code-scanning` is enabled. This shouldn't really be a problem in itself, but the API endpoint for database uploads also doesn't currently accept uploads if Code Scanning is not enabled. That results in a warning in the CodeQL Action, rather than an outright failure, but both of these points combined mean it probably makes sense for us to skip attempting a database upload.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. -->

- **Advanced setup** - Impacts users who have custom workflows.
- **Default setup** - Impacts users who use default setup.
- **Code Quality** - Impacts Code Quality (i.e. `analysis-kinds: code-quality`).

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
