### PR TITLE
Ensure uniqueness of overlay-base database cache keys

### DIFF
--- a/lib/analyze-action.js
+++ b/lib/analyze-action.js
@@ -91049,7 +91049,8 @@ async function uploadOverlayBaseDatabaseToCache(codeql, config, logger) {
   const cacheSaveKey = await getCacheSaveKey(
     config,
     codeQlVersion,
-    checkoutPath
+    checkoutPath,
+    logger
   );
   logger.info(
     `Uploading overlay-base database to Actions cache with key ${cacheSaveKey}`
@@ -91074,9 +91075,17 @@ async function uploadOverlayBaseDatabaseToCache(codeql, config, logger) {
   logger.info(`Successfully uploaded overlay-base database from ${dbLocation}`);
   return true;
 }
-async function getCacheSaveKey(config, codeQlVersion, checkoutPath) {
-  const runId = getWorkflowRunID();
-  const attemptId = getWorkflowRunAttempt();
+async function getCacheSaveKey(config, codeQlVersion, checkoutPath, logger) {
+  let runId = 1;
+  let attemptId = 1;
+  try {
+    runId = getWorkflowRunID();
+    attemptId = getWorkflowRunAttempt();
+  } catch (e) {
+    logger.warning(
+      `Failed to get workflow run ID or attempt ID. Reason: ${getErrorMessage(e)}`
+    );
+  }
   const sha = await getCommitOid(checkoutPath);
   const restoreKeyPrefix = await getCacheRestoreKeyPrefix(
     config,

--- a/src/overlay-database-utils.test.ts
+++ b/src/overlay-database-utils.test.ts
@@ -265,6 +265,7 @@ test(
 );
 
 test("overlay-base database cache keys remain stable", async (t) => {
+  const logger = getRunnerLogger(true);
   const config = createTestConfig({ languages: ["python", "javascript"] });
   const codeQlVersion = "2.23.0";
   const commitOid = "abc123def456";
@@ -274,7 +275,12 @@ test("overlay-base database cache keys remain stable", async (t) => {
   sinon.stub(actionsUtil, "getWorkflowRunID").returns(12345);
   sinon.stub(actionsUtil, "getWorkflowRunAttempt").returns(1);
 
-  const saveKey = await getCacheSaveKey(config, codeQlVersion, "checkout-path");
+  const saveKey = await getCacheSaveKey(
+    config,
+    codeQlVersion,
+    "checkout-path",
+    logger,
+  );
   const expectedSaveKey =
     "codeql-overlay-base-database-1-c5666c509a2d9895-javascript_python-2.23.0-abc123def456-12345-1";
   t.is(


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

This PR adds a workflow run id and workflow attempt id to the overlay base database cache key postfix to ensure uniqueness of the cache keys. The cache key prefix used for restoring overlay-base databases remains unchanged. 

The motivation for the change is that currently if a successful overlay analysis run on the default branch is retried or a repo contains a scheduled CodeQL workflow on the default branch that runs twice without any changes on the default branch in between, then uploading of the overlay-base database will fail due to a cache key collision. 

The first commit which adds a unit test for overlay-base cache keys was cherry-picked from https://github.com/github/codeql-action/pull/3158.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

This individual change is not under feature flag, but it only affects overlay analysis, which is under feature flag and can be disabled in case of unexpected negative impact.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. -->

- **Advanced setup** - Impacts users who have custom workflows.
- **Default setup** - Impacts users who use default setup.
- **Code Scanning** - Impacts Code Scanning (i.e. `analysis-kinds: code-scanning`).

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Test repository** - This change will be tested on a test repository before merging.
- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Feature flags** - All new or changed code paths can be fully disabled with corresponding feature flags.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
