### PR TITLE
Run lightweight workflows on `ubuntu-slim`

### DIFF
--- a/.github/workflows/check-expected-release-files.yml
+++ b/.github/workflows/check-expected-release-files.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   check-expected-release-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       contents: read

--- a/.github/workflows/label-pr-size.yml
+++ b/.github/workflows/label-pr-size.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   sizeup:
     name: Label PR with size
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Run sizeup

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -24,7 +24,7 @@ defaults:
 
 jobs:
   merge-back:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: Automation
     if: github.repository == 'github/codeql-action'
     env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   prepare:
     name: "Prepare release"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'github/codeql-action'
 
     permissions:

--- a/.github/workflows/publish-immutable-action.yml
+++ b/.github/workflows/publish-immutable-action.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/update-bundle.yml
+++ b/.github/workflows/update-bundle.yml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   update-bundle:
     if: github.event.release.prerelease && startsWith(github.event.release.tag_name, 'codeql-bundle-')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write # needed to push commits
       pull-requests: write # needed to create pull requests

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -26,7 +26,7 @@ jobs:
 
   update:
     timeout-minutes: 45
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.event_name == 'workflow_dispatch'
     needs: [prepare]
     env:
@@ -77,7 +77,7 @@ jobs:
 
   backport:
     timeout-minutes: 45
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: Automation
     needs: [prepare]
     if: ${{ (github.event_name == 'push') && needs.prepare.outputs.backport_target_branches != '[]' }}

--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -9,7 +9,7 @@ jobs:
   update-supported-enterprise-server-versions:
     name: Update Supported Enterprise Server Versions
     timeout-minutes: 45
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'github/codeql-action'
     permissions:
       contents: write # needed to push commits


### PR DESCRIPTION
Save resources by using `ubuntu-slim` for lightweight workflows.  This runner size has 1 vCPU and 5 GB RAM.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. -->

Dev/test only

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
