### PR TITLE
Create immutable action version on tag push

### DIFF
--- a/.github/workflows/publish-immutable-action.yml
+++ b/.github/workflows/publish-immutable-action.yml
@@ -1,8 +1,10 @@
 name: 'Publish Immutable Action Version'
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      # Match version tags, but not the major version tags.
+      - 'v[0-9]+.**'
 
 defaults:
   run:
@@ -17,23 +19,9 @@ jobs:
       packages: write
 
     steps:
-      - name: Check release name
-        id: check
-        env:
-          RELEASE_NAME: ${{ github.event.release.name }}
-        run: |
-          echo "Release name: ${{ github.event.release.name }}"
-          if [[ $RELEASE_NAME == v* ]]; then
-            echo "This is a CodeQL Action release. Create an Immutable Action"
-            echo "is-action-release=true" >> $GITHUB_OUTPUT
-          else
-            echo "This is a CodeQL Bundle release. Do not create an Immutable Action"
-            echo "is-action-release=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Checking out
-        if: steps.check.outputs.is-action-release == 'true'
+      - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Publish
-        if: steps.check.outputs.is-action-release == 'true'
+
+      - name: Publish immutable release
         id: publish
         uses: actions/publish-immutable-action@v0.0.4


### PR DESCRIPTION
This PR changes the workflow that creates the immutable releases to trigger on tags getting pushed (only specific CodeQL Action version tags, not major version tags or CLI bundle tags), rather than releases being published. 

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

Release CI.

#### How did/will you validate this change?

- **None** - I am not validating these changes.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

If this results in a problem during the next release, we could manually run the workflow later for the relevant tag.

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

We will see during the next release.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
