### PR TITLE
Allow `query-filters` for `code-quality`

### DIFF
--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -86985,7 +86985,7 @@ function userConfigFromActionPath(tempDir) {
   return path7.resolve(tempDir, "user-config-from-action.yml");
 }
 function hasQueryCustomisation(userConfig) {
-  return isDefined(userConfig["disable-default-queries"]) || isDefined(userConfig.queries) || isDefined(userConfig["query-filters"]);
+  return isDefined(userConfig["disable-default-queries"]) || isDefined(userConfig.queries);
 }
 async function initConfig(features, inputs) {
   const { logger, tempDir } = inputs;
@@ -87024,7 +87024,6 @@ async function initConfig(features, inputs) {
     const queries = codeQualityQueries.map((v) => ({ uses: v }));
     config.computedConfig["disable-default-queries"] = true;
     config.computedConfig.queries = queries;
-    config.computedConfig["query-filters"] = [];
   }
   const { overlayDatabaseMode, useOverlayDatabaseCaching } = await getOverlayDatabaseMode(
     inputs.codeql,

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -210,7 +210,6 @@ test("load code quality config", async (t) => {
       computedConfig: {
         "disable-default-queries": true,
         queries: [{ uses: "code-quality" }],
-        "query-filters": [],
       },
       tempDir,
       codeQLCmd: codeql.getPath(),
@@ -256,7 +255,6 @@ test("initActionState doesn't throw if there are queries configured in the repos
     const computedConfig: configUtils.UserConfig = {
       "disable-default-queries": true,
       queries: [{ uses: "code-quality" }],
-      "query-filters": [],
     };
 
     const expectedConfig = createTestConfig({

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -776,8 +776,7 @@ function userConfigFromActionPath(tempDir: string): string {
 function hasQueryCustomisation(userConfig: UserConfig): boolean {
   return (
     isDefined(userConfig["disable-default-queries"]) ||
-    isDefined(userConfig.queries) ||
-    isDefined(userConfig["query-filters"])
+    isDefined(userConfig.queries)
   );
 }
 
@@ -839,7 +838,6 @@ export async function initConfig(
     // Set the query customisation options for Code Quality only analysis.
     config.computedConfig["disable-default-queries"] = true;
     config.computedConfig.queries = queries;
-    config.computedConfig["query-filters"] = [];
   }
 
   // The choice of overlay database mode depends on the selection of languages


### PR DESCRIPTION
This PR changes the configuration checks we perform when `code-quality` is the only enabled analysis kind to allow `query-filters`.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. -->

- **Advanced setup** - Impacts users who have custom workflows.
- **Default setup** - Impacts users who use default setup.
- **Code Quality** - Impacts Code Quality (i.e. `analysis-kinds: code-quality`).
- **GHES** - Impacts GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
