### PR TITLE
Filter CCR jobs in `update-required-checks.sh`

### DIFF
--- a/.github/workflows/script/update-required-checks.sh
+++ b/.github/workflows/script/update-required-checks.sh
@@ -29,7 +29,7 @@ fi
 echo "Getting checks for $GITHUB_SHA"
 
 # Ignore any checks with "https://", CodeQL, LGTM, Update, and ESLint checks.
-CHECKS="$(gh api repos/github/codeql-action/commits/"${GITHUB_SHA}"/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs.[] | select(.conclusion != "skipped") | .name | select(contains("https://") or . == "CodeQL" or . == "Dependabot" or . == "check-expected-release-files" or contains("Update") or contains("ESLint") or contains("update") or contains("test-setup-python-scripts") | not)] | unique | sort')"
+CHECKS="$(gh api repos/github/codeql-action/commits/"${GITHUB_SHA}"/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs.[] | select(.conclusion != "skipped") | .name | select(contains("https://") or . == "CodeQL" or . == "Dependabot" or . == "check-expected-release-files" or contains("Update") or contains("ESLint") or contains("update") or contains("test-setup-python-scripts") or . == "Agent" or . == "Cleanup artifacts" or . == "Prepare" or . == "Upload results" | not)] | unique | sort')"
 
 echo "$CHECKS" | jq
 


### PR DESCRIPTION
I ran the script for https://github.com/github/codeql-action/pull/3274 and it added the CCR jobs. This PR modifies it to filter those out.

I ran the script with these changes and it seemed to work OK.

I am not particularly keen on the filtering based on names here and the long `jq` command. Maybe we could look at improving the script to make it a bit nicer.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

CI

#### How did/will you validate this change?

- **None** - I am not validating these changes.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

N/A

#### How will you know if something goes wrong after this change is released?

N/A

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
