### PR TITLE
Remove `push` triggers from workflow collections

### DIFF
--- a/.github/workflows/__go.yml
+++ b/.github/workflows/__go.yml
@@ -8,9 +8,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GO111MODULE: auto
 on:
-  push:
-    paths:
-      - .github/workflows/__go.yml
   workflow_dispatch:
     inputs:
       go-version:

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -356,11 +356,6 @@ for collection_name in collections:
                 'GO111MODULE': 'auto'
             },
             'on': {
-                'push': {
-                    'paths': [
-                        f'.github/workflows/__{collection_name}.yml'
-                    ]
-                },
                 'workflow_dispatch': {
                     'inputs': combinedInputs
                 },


### PR DESCRIPTION
This occasionally caused weird results if the collection was triggered as well as some of the workflows in it, due to them ending up with the same concurrency group.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

N/A

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
