### PR TITLE
Overlay: Fall back to full analysis if memory flag is low

### DIFF
--- a/lib/init-action.js
+++ b/lib/init-action.js
@@ -86920,7 +86920,7 @@ async function isOverlayAnalysisFeatureEnabled(features, codeql, languages, code
   }
   return true;
 }
-async function getOverlayDatabaseMode(codeql, features, languages, sourceRoot, buildMode, codeScanningConfig, logger) {
+async function getOverlayDatabaseMode(codeql, features, languages, sourceRoot, buildMode, ramInput, codeScanningConfig, logger) {
   let overlayDatabaseMode = "none" /* None */;
   let useOverlayDatabaseCaching = false;
   const modeEnv = process.env.CODEQL_OVERLAY_DATABASE_MODE;
@@ -86936,6 +86936,7 @@ async function getOverlayDatabaseMode(codeql, features, languages, sourceRoot, b
     codeScanningConfig
   )) {
     const diskUsage = await checkDiskUsage(logger);
+    const memoryFlagValue = getMemoryFlagValue(ramInput, logger);
     if (diskUsage === void 0 || diskUsage.numAvailableBytes < OVERLAY_MINIMUM_AVAILABLE_DISK_SPACE_BYTES) {
       const diskSpaceMb = diskUsage === void 0 ? 0 : Math.round(diskUsage.numAvailableBytes / 1e6);
       overlayDatabaseMode = "none" /* None */;
@@ -86943,20 +86944,24 @@ async function getOverlayDatabaseMode(codeql, features, languages, sourceRoot, b
       logger.info(
         `Setting overlay database mode to ${overlayDatabaseMode} due to insufficient disk space (${diskSpaceMb} MB).`
       );
-    } else {
-      if (isAnalyzingPullRequest()) {
-        overlayDatabaseMode = "overlay" /* Overlay */;
-        useOverlayDatabaseCaching = true;
-        logger.info(
-          `Setting overlay database mode to ${overlayDatabaseMode} with caching because we are analyzing a pull request.`
-        );
-      } else if (await isAnalyzingDefaultBranch()) {
-        overlayDatabaseMode = "overlay-base" /* OverlayBase */;
-        useOverlayDatabaseCaching = true;
-        logger.info(
-          `Setting overlay database mode to ${overlayDatabaseMode} with caching because we are analyzing the default branch.`
-        );
-      }
+    } else if (memoryFlagValue < 5 * 1024) {
+      overlayDatabaseMode = "none" /* None */;
+      useOverlayDatabaseCaching = false;
+      logger.info(
+        `Setting overlay database mode to ${overlayDatabaseMode} due to insufficient memory for CodeQL analysis (${memoryFlagValue} MB).`
+      );
+    } else if (isAnalyzingPullRequest()) {
+      overlayDatabaseMode = "overlay" /* Overlay */;
+      useOverlayDatabaseCaching = true;
+      logger.info(
+        `Setting overlay database mode to ${overlayDatabaseMode} with caching because we are analyzing a pull request.`
+      );
+    } else if (await isAnalyzingDefaultBranch()) {
+      overlayDatabaseMode = "overlay-base" /* OverlayBase */;
+      useOverlayDatabaseCaching = true;
+      logger.info(
+        `Setting overlay database mode to ${overlayDatabaseMode} with caching because we are analyzing the default branch.`
+      );
     }
   }
   const nonOverlayAnalysis = {
@@ -87051,6 +87056,7 @@ async function initConfig(features, inputs) {
     config.languages,
     inputs.sourceRoot,
     config.buildMode,
+    inputs.ramInput,
     config.computedConfig,
     logger
   );
@@ -89998,6 +90004,7 @@ async function run() {
       queriesInput: getOptionalInput("queries"),
       packsInput: getOptionalInput("packs"),
       buildModeInput: getOptionalInput("build-mode"),
+      ramInput: getOptionalInput("ram"),
       configFile,
       dbLocation: getOptionalInput("db-location"),
       configInput: getOptionalInput("config"),

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -44,6 +44,7 @@ import {
   cloneObject,
   isDefined,
   checkDiskUsage,
+  getMemoryFlagValue,
 } from "./util";
 
 export * from "./config/db-config";
@@ -393,6 +394,7 @@ export interface InitConfigInputs {
   dbLocation: string | undefined;
   configInput: string | undefined;
   buildModeInput: string | undefined;
+  ramInput: string | undefined;
   trapCachingEnabled: boolean;
   dependencyCachingEnabled: string | undefined;
   debugMode: boolean;
@@ -661,6 +663,7 @@ export async function getOverlayDatabaseMode(
   languages: Language[],
   sourceRoot: string,
   buildMode: BuildMode | undefined,
+  ramInput: string | undefined,
   codeScanningConfig: UserConfig,
   logger: Logger,
 ): Promise<{
@@ -692,6 +695,7 @@ export async function getOverlayDatabaseMode(
     )
   ) {
     const diskUsage = await checkDiskUsage(logger);
+    const memoryFlagValue = getMemoryFlagValue(ramInput, logger);
     if (
       diskUsage === undefined ||
       diskUsage.numAvailableBytes < OVERLAY_MINIMUM_AVAILABLE_DISK_SPACE_BYTES
@@ -705,6 +709,13 @@ export async function getOverlayDatabaseMode(
       logger.info(
         `Setting overlay database mode to ${overlayDatabaseMode} ` +
           `due to insufficient disk space (${diskSpaceMb} MB).`,
+      );
+    } else if (memoryFlagValue < 5 * 1024) {
+      overlayDatabaseMode = OverlayDatabaseMode.None;
+      useOverlayDatabaseCaching = false;
+      logger.info(
+        `Setting overlay database mode to ${overlayDatabaseMode} ` +
+          `due to insufficient memory for CodeQL analysis (${memoryFlagValue} MB).`,
       );
     } else if (isAnalyzingPullRequest()) {
       overlayDatabaseMode = OverlayDatabaseMode.Overlay;
@@ -873,6 +884,7 @@ export async function initConfig(
       config.languages,
       inputs.sourceRoot,
       config.buildMode,
+      inputs.ramInput,
       config.computedConfig,
       logger,
     );

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -324,6 +324,7 @@ async function run() {
       queriesInput: getOptionalInput("queries"),
       packsInput: getOptionalInput("packs"),
       buildModeInput: getOptionalInput("build-mode"),
+      ramInput: getOptionalInput("ram"),
       configFile,
       dbLocation: getOptionalInput("db-location"),
       configInput: getOptionalInput("config"),


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

This PR modifies the `init` action to perform full analysis instead of overlay analysis if CodeQL will have less than 5GB of memory available for analysis. All non-slim GitHub hosted runners for public and private repos have +7GB of memory and the action will assign more than 5GB of memory to CodeQL on all such runners unless a lower memory limit has been manually specified. The limit is primarily intended to target self-hosted runners with little memory available for CodeQL as we have seen out-of-memory errors on self-hosted runners where CodeQL has only been given 3GB of memory for analysis. 

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, CCR, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com`.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Test repository** - This change will be tested on a test repository before merging.
- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Feature flags** - All new or changed code paths can be fully disabled with corresponding feature flags.
- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.
- **Special considerations** - This change should only be merged once certain preconditions are met. Please provide details of those or link to this PR from an internal issue.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
