### PR TITLE
Remove `gh` setup from global proxy test

### DIFF
--- a/.github/workflows/__global-proxy.yml
+++ b/.github/workflows/__global-proxy.yml
@@ -48,18 +48,6 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     steps:
-  # These steps are required to initialise the `gh` cli in a container that doesn't
-  # come pre-installed with it. The reason for that is that this is later
-  # needed by the `prepare-test` workflow to find the latest release of CodeQL.
-      - name: Set up GitHub CLI
-        run: |
-          apt update
-          apt install -y curl libreadline8 gnupg2 software-properties-common zstd
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          apt-key add /usr/share/keyrings/githubcli-archive-keyring.gpg
-          apt-add-repository https://cli.github.com/packages
-          apt install -y gh
-        env: {}
       - name: Check out repository
         uses: actions/checkout@v6
       - name: Prepare test

--- a/pr-checks/checks/global-proxy.yml
+++ b/pr-checks/checks/global-proxy.yml
@@ -3,19 +3,6 @@ description: "Tests using a proxy specified by the https_proxy environment varia
 versions: ["linked", "nightly-latest"]
 container:
   image: ubuntu:22.04
-container-init-steps:
-  # These steps are required to initialise the `gh` cli in a container that doesn't
-  # come pre-installed with it. The reason for that is that this is later
-  # needed by the `prepare-test` workflow to find the latest release of CodeQL. 
-  name: Set up GitHub CLI
-  run: |
-    apt update
-    apt install -y curl libreadline8 gnupg2 software-properties-common zstd
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-    apt-key add /usr/share/keyrings/githubcli-archive-keyring.gpg
-    apt-add-repository https://cli.github.com/packages
-    apt install -y gh
-  env: {}
 services:
   squid-proxy:
     image: ubuntu/squid:latest


### PR DESCRIPTION
This is no longer needed by `prepare-test`.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

N/A

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
