### PR TITLE
Pin `@actions/tool-cache@3` in workflows to avoid failures with `github-script`

### DIFF
--- a/.github/workflows/__bundle-from-toolcache.yml
+++ b/.github/workflows/__bundle-from-toolcache.yml
@@ -56,7 +56,7 @@ jobs:
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
       - name: Install @actions/tool-cache
-        run: npm install @actions/tool-cache
+        run: npm install @actions/tool-cache@3
       - name: Check toolcache contains CodeQL
         continue-on-error: true
         uses: actions/github-script@v8

--- a/.github/workflows/__bundle-toolcache.yml
+++ b/.github/workflows/__bundle-toolcache.yml
@@ -68,7 +68,7 @@ jobs:
             const codeqlPath = path.join(process.env['RUNNER_TOOL_CACHE'], 'CodeQL');
             fs.rmdirSync(codeqlPath, { recursive: true });
       - name: Install @actions/tool-cache
-        run: npm install @actions/tool-cache
+        run: npm install @actions/tool-cache@3
       - name: Check toolcache does not contain CodeQL
         uses: actions/github-script@v8
         with:

--- a/pr-checks/checks/bundle-from-toolcache.yml
+++ b/pr-checks/checks/bundle-from-toolcache.yml
@@ -4,7 +4,7 @@ versions:
   - toolcache
 steps:
   - name: Install @actions/tool-cache
-    run: npm install @actions/tool-cache
+    run: npm install @actions/tool-cache@3
   - name: Check toolcache contains CodeQL
     continue-on-error: true
     uses: actions/github-script@v8

--- a/pr-checks/checks/bundle-toolcache.yml
+++ b/pr-checks/checks/bundle-toolcache.yml
@@ -16,7 +16,7 @@ steps:
         const codeqlPath = path.join(process.env['RUNNER_TOOL_CACHE'], 'CodeQL');
         fs.rmdirSync(codeqlPath, { recursive: true });
   - name: Install @actions/tool-cache
-    run: npm install @actions/tool-cache
+    run: npm install @actions/tool-cache@3
   - name: Check toolcache does not contain CodeQL
     uses: actions/github-script@v8
     with:


### PR DESCRIPTION
It seems that `v4` of `@actions/tool-cache` now uses ESM modules ([similarly to `v9` of `@actions/github`](https://github.com/github/codeql-action/pull/3441)) which leads to [failures like this](https://github.com/github/codeql-action/actions/runs/21578492497/job/62170818481#step:7:43) in some of our CI checks, where we install `@actions/tool-cache` for use with `github-script`, but don't pin a particular version.

This PR pins `v3` in those workflows to unblock these workflows.

Alternatively, we could switch to using `import` in the scripts, which [is supported by `github-script`](https://github.com/actions/github-script?tab=readme-ov-file#use-esm-import).

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

CI failures.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
