### PR TITLE
Disable TypeScript `noUnusedLocals` and `noUnusedParameters` options, already covered by eslint

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,8 @@
     "alwaysStrict": true,                     /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true,                   /* Report errors on unused locals. */
-    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noUnusedLocals": false,                   /* Report errors on unused locals. */
+    "noUnusedParameters": false,               /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
 


### PR DESCRIPTION
Probably a controversial change, but:

- We already use `eslint`, which has the same rules configured.
- `eslint` allows the equivalent errors to be suppressed with comments. TypeScript allows unused parameter errors to be suppressed with a leading `_` in the name, but there is no way to suppress unused locals.
- While working on changes, it is annoying to get errors for this when testing partially complete code. Meanwhile `eslint` can be run on demand when it makes sense.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **None** - I am not validating these changes.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

N/A

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
