### PR TITLE
Release notes: Use author if they are GitHub staff

### DIFF
--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -173,11 +173,8 @@ def get_merger_of_pr(repo, pr):
 def get_pr_author_if_staff(pr):
   if pr.user is None:
     return None
-  try:
-    if getattr(pr.user, 'site_admin', False):
-      return pr.user.login
-  except Exception:
-    pass
+  if getattr(pr.user, 'site_admin', False):
+    return pr.user.login
   return None
 
 def get_current_version():


### PR DESCRIPTION
Modifies `update-release-branch.py` to use the PR author if they are GitHub staff, or the merger as before otherwise.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **None** - I am not validating these changes.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

Release process will fail.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
