### PR TITLE
Don't run `label-pr-size` once a PR has been merged

### DIFF
--- a/.github/workflows/label-pr-size.yml
+++ b/.github/workflows/label-pr-size.yml
@@ -17,6 +17,7 @@ jobs:
   sizeup:
     name: Label PR with size
     runs-on: ubuntu-slim
+    if: github.event.pull_request.merged != true
 
     steps:
       - name: Run sizeup


### PR DESCRIPTION
Since branches are auto-deleted, the workflow fails if it runs after a PR is merged. There are probably other solutions for this to filter the events more than the added check here, but I have no particular preference.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

The workflow will run.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

N/A

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
