### PR TITLE
Fix conditions in code scanning config checks for merge queue

### DIFF
--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -80,7 +80,7 @@ jobs:
     # On PRs, overlay analysis may change the config that is passed to the CLI.
     # Therefore, we have two variants of the following test, one for PRs and one for other events.
     - name: Empty file (non-PR)
-      if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+      if: github.event_name != 'pull_request'
       uses: ./../action/.github/actions/check-codescanning-config
       with:
         expected-config-file-contents: "{}"
@@ -88,7 +88,7 @@ jobs:
         tools: ${{ steps.prepare-test.outputs.tools-url }}
 
     - name: Empty file (PR)
-      if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+      if: github.event_name == 'pull_request'
       uses: ./../action/.github/actions/check-codescanning-config
       with:
         expected-config-file-contents: |


### PR DESCRIPTION
DIff-informed analysis isn't enabled in the merge queue.