### PR TITLE
CI: Update CodeQL Action test to use `setup-codeql`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,8 @@ jobs:
 
     permissions:
       contents: read
+      # We currently need `security-events: read` to access feature flags.
+      security-events: read
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/debug-artifacts-failure-safe.yml
+++ b/.github/workflows/debug-artifacts-failure-safe.yml
@@ -41,6 +41,8 @@ jobs:
       CODEQL_ACTION_TEST_MODE: true
     permissions:
       contents: read
+      # We currently need `security-events: read` to access feature flags.
+      security-events: read
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/debug-artifacts-safe.yml
+++ b/.github/workflows/debug-artifacts-safe.yml
@@ -40,6 +40,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      # We currently need `security-events: read` to access feature flags.
+      security-events: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/python312-windows.yml
+++ b/.github/workflows/python312-windows.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      # We currently need `security-events: read` to access feature flags.
+      security-events: read
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
This saves a bit of unnecessary work creating databases that we don't need.