### PR TITLE
Linting: Require unused function parameters to start with `_`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,6 +161,7 @@ export default [
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
+          "args": "all",
           "argsIgnorePattern": "^_",
         }
       ],


### PR DESCRIPTION
The default setting for this lint rule doesn't check function parameters, but in our codebase we are often cleaning up code paths for older versions of GHES, therefore it's desirable to check whether something is being passed that we could possibly avoid computing in the first place.