### PR TITLE
Add PR check for CSRA artifact upload

### DIFF
--- a/.github/workflows/__risk-assessment-failure.yml
+++ b/.github/workflows/__risk-assessment-failure.yml
@@ -1,0 +1,94 @@
+# Warning: This file is generated automatically, and should not be modified.
+# Instead, please modify the template in the pr-checks directory and run:
+#     pr-checks/sync.sh
+# to regenerate this file.
+
+name: PR Check - Risk Assessment analysis failure uploads SARIF artifact
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: auto
+on:
+  push:
+    branches:
+      - main
+      - releases/v*
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs: {}
+  workflow_call:
+    inputs: {}
+defaults:
+  run:
+    shell: bash
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: risk-assessment-failure-${{github.ref}}
+jobs:
+  risk-assessment-failure:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            version: default
+    name: Risk Assessment analysis failure uploads SARIF artifact
+    if: github.triggering_actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      security-events: write
+    timeout-minutes: 45
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Prepare test
+        id: prepare-test
+        uses: ./.github/actions/prepare-test
+        with:
+          version: ${{ matrix.version }}
+          use-all-platform-bundle: 'false'
+          setup-kotlin: 'true'
+      - name: Initialise CodeQL
+        uses: ./../action/init
+        id: init
+        with:
+          tools: ${{ steps.prepare-test.outputs.tools-url }}
+          languages: javascript
+          analysis-kinds: risk-assessment
+
+      - name: Fail
+        run: exit 1
+    env:
+      CODEQL_ACTION_TEST_MODE: true
+  artifact-present:
+    name: Check artifact
+    if: github.triggering_actor != 'dependabot[bot]'
+    needs:
+      - risk-assessment-failure
+    permissions:
+      contents: read
+      security-events: read
+    timeout-minutes: 5
+    runs-on: ubuntu-slim
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          pattern: sarif-artifact-*
+          path: ${{ runner.temp }}/results
+          merge-multiple: true
+      - name: List contents
+        run: |
+          ls -lr
+    env:
+      CODEQL_ACTION_TEST_MODE: true

--- a/pr-checks/checks/risk-assessment-failure.yml
+++ b/pr-checks/checks/risk-assessment-failure.yml
@@ -1,0 +1,33 @@
+name: Risk Assessment analysis failure uploads SARIF artifact
+description: Check that a SARIF file is uploaded as artifact if Risk Assessment fails
+versions: ["default"]
+
+permissions:
+  contents: read
+  security-events: write # needed to upload the SARIF file
+
+steps:
+  - name: Initialise CodeQL
+    uses: ./../action/init
+    id: init
+    with:
+      tools: ${{ steps.prepare-test.outputs.tools-url }}
+      languages: javascript
+      analysis-kinds: risk-assessment
+
+  - name: Fail
+    run: exit 1
+
+validationJobs:
+  artifact-present:
+    name: Check artifact
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          pattern: sarif-artifact-*
+          path: ${{ runner.temp }}/results
+          merge-multiple: true
+      - name: List contents
+        run: |
+          ls -lr


### PR DESCRIPTION
Follow-up to https://github.com/github/codeql-action/pull/3519 which adds a PR check using the new functionality introduced by https://github.com/github/codeql-action/pull/3541.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Other** - Please provide details.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
