### PR TITLE
Add tests for getCredentials with multiple goproxy_servers and maven_…

### DIFF
--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -275,8 +275,16 @@ test("getCredentials returns all goproxy_servers for a language when specified",
 
 test("getCredentials returns all maven_repositories for a language when specified", async (t) => {
   const multipleMavenRepositories = [
-    { type: "maven_repository", host: "maven1.pkg.github.com", token: "token1" },
-    { type: "maven_repository", host: "maven2.pkg.github.com", token: "token2" },
+    {
+      type: "maven_repository",
+      host: "maven1.pkg.github.com",
+      token: "token1",
+    },
+    {
+      type: "maven_repository",
+      host: "maven2.pkg.github.com",
+      token: "token2",
+    },
     { type: "git_source", host: "github.com/github", token: "mno" },
   ];
 
@@ -288,7 +296,9 @@ test("getCredentials returns all maven_repositories for a language when specifie
   );
   t.is(credentials.length, 2);
 
-  const mavenRepositories = credentials.filter((c) => c.type === "maven_repository");
+  const mavenRepositories = credentials.filter(
+    (c) => c.type === "maven_repository",
+  );
   t.assert(mavenRepositories.some((c) => c.host === "maven1.pkg.github.com"));
   t.assert(mavenRepositories.some((c) => c.host === "maven2.pkg.github.com"));
 });

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -252,6 +252,47 @@ test("getCredentials returns all for a language when specified", async (t) => {
   t.assert(credentialsTypes.includes("git_source"));
 });
 
+test("getCredentials returns all goproxy_servers for a language when specified", async (t) => {
+  const multipleGoproxyServers = [
+    { type: "goproxy_server", host: "goproxy1.example.com", token: "token1" },
+    { type: "goproxy_server", host: "goproxy2.example.com", token: "token2" },
+    { type: "git_source", host: "github.com/github", token: "mno" },
+  ];
+
+  const credentials = startProxyExports.getCredentials(
+    getRunnerLogger(true),
+    undefined,
+    toEncodedJSON(multipleGoproxyServers),
+    KnownLanguage.go,
+  );
+  t.is(credentials.length, 3);
+
+  const goproxyServers = credentials.filter((c) => c.type === "goproxy_server");
+  t.is(goproxyServers.length, 2);
+  t.assert(goproxyServers.some((c) => c.host === "goproxy1.example.com"));
+  t.assert(goproxyServers.some((c) => c.host === "goproxy2.example.com"));
+});
+
+test("getCredentials returns all maven_repositories for a language when specified", async (t) => {
+  const multipleMavenRepositories = [
+    { type: "maven_repository", host: "maven1.pkg.github.com", token: "token1" },
+    { type: "maven_repository", host: "maven2.pkg.github.com", token: "token2" },
+    { type: "git_source", host: "github.com/github", token: "mno" },
+  ];
+
+  const credentials = startProxyExports.getCredentials(
+    getRunnerLogger(true),
+    undefined,
+    toEncodedJSON(multipleMavenRepositories),
+    KnownLanguage.java,
+  );
+  t.is(credentials.length, 2);
+
+  const mavenRepositories = credentials.filter((c) => c.type === "maven_repository");
+  t.assert(mavenRepositories.some((c) => c.host === "maven1.pkg.github.com"));
+  t.assert(mavenRepositories.some((c) => c.host === "maven2.pkg.github.com"));
+});
+
 test("getCredentials returns all credentials when no language specified", async (t) => {
   const credentialsInput = toEncodedJSON(mixedCredentials);
 

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -252,7 +252,7 @@ test("getCredentials returns all for a language when specified", async (t) => {
   t.assert(credentialsTypes.includes("git_source"));
 });
 
-test("getCredentials returns all goproxy_servers for a language when specified", async (t) => {
+test("getCredentials returns all goproxy_servers for Go when specified", async (t) => {
   const multipleGoproxyServers = [
     { type: "goproxy_server", host: "goproxy1.example.com", token: "token1" },
     { type: "goproxy_server", host: "goproxy2.example.com", token: "token2" },

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -273,7 +273,7 @@ test("getCredentials returns all goproxy_servers for Go when specified", async (
   t.assert(goproxyServers.some((c) => c.host === "goproxy2.example.com"));
 });
 
-test("getCredentials returns all maven_repositories for a language when specified", async (t) => {
+test("getCredentials returns all maven_repositories for Java when specified", async (t) => {
   const multipleMavenRepositories = [
     {
       type: "maven_repository",


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

This PR adds two new tests to the `start-proxy` action, to assert that registry configurations with more than one registry of the same kind (two `goproxy_server` and two `maven_repository` in this case) are parsed and reported appropriately. While one additional test would be sufficient to test this multi-registry use-case, I thought two tests across two languages offered a bit more safety.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Other** - I expect a PR check to fail if these tests are implemented incorrectly.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
