### PR TITLE
Store language aliases from linked CLI

### DIFF
--- a/.github/workflows/update-bundle.yml
+++ b/.github/workflows/update-bundle.yml
@@ -57,6 +57,20 @@ jobs:
       - name: Update bundle
         uses: ./.github/actions/update-bundle
 
+      - name: Set up CodeQL CLI from new bundle
+        id: setup-codeql
+        uses: ./setup-codeql
+        with:
+          tools: https://github.com/github/codeql-action/releases/download/${{ github.event.release.tag_name }}/codeql-bundle-linux64.tar.gz
+
+      - name: Update language aliases
+        env:
+          CODEQL_PATH: ${{ steps.setup-codeql.outputs.codeql-path }}
+        run: |
+          "$CODEQL_PATH" resolve languages --format=betterjson --extractor-include-aliases \
+            | jq -S '.aliases // {}' \
+            > src/known-language-aliases.json
+
       - name: Bump Action minor version if new CodeQL minor version series
         id: bump-action-version
         run: |

--- a/src/known-language-aliases.json
+++ b/src/known-language-aliases.json
@@ -1,0 +1,11 @@
+{
+  "c": "cpp",
+  "c-c++": "cpp",
+  "c-cpp": "cpp",
+  "c#": "csharp",
+  "c++": "cpp",
+  "java-kotlin": "java",
+  "javascript-typescript": "javascript",
+  "kotlin": "java",
+  "typescript": "javascript"
+}

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -18,6 +18,7 @@ import {
   FeatureEnablement,
 } from "./feature-flags";
 import * as json from "./json";
+import * as knownLanguageAliases from "./known-language-aliases.json";
 import { KnownLanguage } from "./languages";
 import { Logger } from "./logging";
 import {
@@ -188,43 +189,30 @@ export const UPDATEJOB_PROXY_VERSION = "v2.0.20250624110901";
 const UPDATEJOB_PROXY_URL_PREFIX =
   "https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.22.0/";
 
-/*
- * Language aliases supported by the start-proxy Action.
- *
- * In general, the CodeQL CLI is the source of truth for language aliases, and to
- * allow us to more easily support new languages, we want to avoid hardcoding these
- * aliases in the Action itself.  However this is difficult to do in the start-proxy
- * Action since this Action does not use CodeQL, so we're accepting some hardcoding
- * for this Action.
- */
-const LANGUAGE_ALIASES: { [lang: string]: KnownLanguage } = {
-  c: KnownLanguage.cpp,
-  "c++": KnownLanguage.cpp,
-  "c#": KnownLanguage.csharp,
-  kotlin: KnownLanguage.java,
-  typescript: KnownLanguage.javascript,
-  "javascript-typescript": KnownLanguage.javascript,
-  "java-kotlin": KnownLanguage.java,
-};
-
 /**
  * Parse the start-proxy language input into its canonical CodeQL language name.
  *
- * Exported for testing. Do not use this outside of the start-proxy Action
- * to avoid complicating the process of adding new CodeQL languages.
+ * This uses the language aliases shipped with the Action and will not be able to resolve aliases
+ * added by versions of the CodeQL CLI newer than the one mentioned in `defaults.json`. However,
+ * this is sufficient for the start-proxy Action since we are already specifying proxy
+ * configurations on a per-language basis.
  */
 export function parseLanguage(language: string): KnownLanguage | undefined {
   // Normalize to lower case
   language = language.trim().toLowerCase();
 
   // See if it's an exact match
-  if (language in KnownLanguage) {
+  if (Object.hasOwn(KnownLanguage, language)) {
     return language as KnownLanguage;
   }
 
   // Check language aliases
-  if (language in LANGUAGE_ALIASES) {
-    return LANGUAGE_ALIASES[language];
+  if (Object.hasOwn(knownLanguageAliases, language)) {
+    language =
+      knownLanguageAliases[language as keyof typeof knownLanguageAliases];
+    if (Object.hasOwn(KnownLanguage, language)) {
+      return language as KnownLanguage;
+    }
   }
 
   return undefined;


### PR DESCRIPTION
Add a checked-in snapshot of CodeQL language aliases (`src/known-language-aliases.json`) that is updated by the "Update bundle" workflow.  This will have future uses, but for now we just update the `start-proxy` Action to use this instead of a hardcoded map.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
