### PR TITLE
Private registries: Add support for Cloudsmith and GCP OIDC configurations

### DIFF
--- a/.github/codeql/codeql-config-javascript.yml
+++ b/.github/codeql/codeql-config-javascript.yml
@@ -1,5 +1,5 @@
 name: "CodeQL config"
-queries: 
+queries:
   - name: Run custom queries
     uses: ./queries
   # Run all extra query suites, both because we want to
@@ -13,3 +13,5 @@ queries:
 paths-ignore:
   - lib
   - tests
+  - "**/*.test.ts"
+  - "**/testing-util.ts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ See the [releases page](https://github.com/github/codeql-action/releases) for th
 
 ## [UNRELEASED]
 
-No user facing changes.
+- Configurations for private registries that use Cloudsmith or GCP OIDC are now accepted. [#3850](https://github.com/github/codeql-action/pull/3850)
 
 ## 4.35.2 - 15 Apr 2026
 

--- a/src/json/index.test.ts
+++ b/src/json/index.test.ts
@@ -1,0 +1,46 @@
+import test from "ava";
+
+import { setupTests } from "../testing-utils";
+
+import * as json from ".";
+
+setupTests(test);
+
+const testSchema = {
+  requiredKey: json.string,
+};
+
+const optionalSchema = {
+  optionalKey: json.optional(json.string),
+};
+
+test("validateSchema - required properties are required", async (t) => {
+  t.false(json.validateSchema(testSchema, {}));
+  t.false(json.validateSchema(testSchema, { requiredKey: undefined }));
+  t.false(json.validateSchema(testSchema, { requiredKey: null }));
+  t.false(json.validateSchema(testSchema, { requiredKey: 0 }));
+  t.false(json.validateSchema(testSchema, { requiredKey: 123 }));
+  t.false(json.validateSchema(testSchema, { requiredKey: false }));
+  t.false(json.validateSchema(testSchema, { requiredKey: true }));
+  t.false(json.validateSchema(testSchema, { requiredKey: [] }));
+  t.false(json.validateSchema(testSchema, { requiredKey: {} }));
+  t.true(json.validateSchema(testSchema, { requiredKey: "" }));
+  t.true(json.validateSchema(testSchema, { requiredKey: "foo" }));
+});
+
+test("validateSchema - optional properties are optional", async (t) => {
+  // Optional fields may be absent
+  t.true(json.validateSchema(optionalSchema, {}));
+  t.true(json.validateSchema(optionalSchema, { optionalKey: undefined }));
+  t.true(json.validateSchema(optionalSchema, { optionalKey: null }));
+
+  // But, if present, should have the expected type
+  t.false(json.validateSchema(optionalSchema, { optionalKey: 0 }));
+  t.false(json.validateSchema(optionalSchema, { optionalKey: 123 }));
+  t.false(json.validateSchema(optionalSchema, { optionalKey: false }));
+  t.false(json.validateSchema(optionalSchema, { optionalKey: true }));
+  t.false(json.validateSchema(optionalSchema, { optionalKey: [] }));
+  t.false(json.validateSchema(optionalSchema, { optionalKey: {} }));
+  t.true(json.validateSchema(optionalSchema, { optionalKey: "" }));
+  t.true(json.validateSchema(optionalSchema, { optionalKey: "foo" }));
+});

--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -36,3 +36,77 @@ export function isStringOrUndefined(
 ): value is string | undefined {
   return value === undefined || isString(value);
 }
+
+/**
+ * Represents a field of type `T` in a schema.
+ * Carries a validation function and flag indicating whether the field is required or not.
+ */
+export type Validator<T> = {
+  validate: (val: unknown) => val is T;
+  required: boolean;
+};
+
+/** Extracts `T` from `Validator<T>`. */
+export type UnwrapValidator<V> =
+  V extends Validator<infer A>
+    ? V["required"] extends true
+      ? A
+      : A | undefined
+    : never;
+
+/** A validator for string fields in schemas. */
+export const string = {
+  validate: isString,
+  required: true,
+} as const satisfies Validator<string>;
+
+/** Transforms a validator to be optional. */
+export function optional<T>(validator: Validator<T>) {
+  return {
+    validate: (val: unknown) => {
+      return val === undefined || val === null || validator.validate(val);
+    },
+    required: false,
+  } as const satisfies Validator<T | undefined | null>;
+}
+
+/** Represents an arbitrary object schema. */
+export type Schema = Record<string, Validator<any>>;
+
+/** Constructs an object type corresponding to a schema. */
+export type FromSchema<S extends Schema> = {
+  [K in keyof S]: UnwrapValidator<S[K]>;
+};
+
+/**
+ * Validates `obj` against `schema`.
+ *
+ * @param schema The schema to validate against.
+ * @param obj The object to validate.
+ * @returns Asserts that `obj` is of the `schema`'s type if validation is successful.
+ */
+export function validateSchema<S extends Schema>(
+  schema: S,
+  obj: UnvalidatedObject<any>,
+): obj is FromSchema<S> {
+  for (const [key, validator] of Object.entries(schema)) {
+    const hasKey = key in obj;
+
+    // If the property is required, but absent, fail.
+    if (validator.required && !hasKey) {
+      return false;
+    }
+
+    // If the property is required, but undefined or null, fail.
+    if (validator.required && (obj[key] === undefined || obj[key] === null)) {
+      return false;
+    }
+
+    // If the property is present, validate it.
+    if (hasKey && !validator.validate(obj[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -79,7 +79,7 @@ export type FromSchema<S extends Schema> = {
 };
 
 /**
- * Validates `obj` against `schema`.
+ * Validates that `obj` satisfies at least `schema`. Additional keys are accepted.
  *
  * @param schema The schema to validate against.
  * @param obj The object to validate.

--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -47,12 +47,7 @@ export type Validator<T> = {
 };
 
 /** Extracts `T` from `Validator<T>`. */
-export type UnwrapValidator<V> =
-  V extends Validator<infer A>
-    ? V["required"] extends true
-      ? A
-      : A | undefined
-    : never;
+export type UnwrapValidator<V> = V extends Validator<infer A> ? A : never;
 
 /** A validator for string fields in schemas. */
 export const string = {
@@ -73,10 +68,20 @@ export function optional<T>(validator: Validator<T>) {
 /** Represents an arbitrary object schema. */
 export type Schema = Record<string, Validator<any>>;
 
+/** Extracts the required keys from `S`. */
+export type RequiredKeys<S extends Schema> = {
+  [K in keyof S]: S[K]["required"] extends true ? K : never;
+}[keyof S];
+
+/** Extracts optional keys from `S`. */
+export type OptionalKeys<S extends Schema> = {
+  [K in keyof S]: S[K]["required"] extends true ? never : K;
+}[keyof S];
+
 /** Constructs an object type corresponding to a schema. */
 export type FromSchema<S extends Schema> = {
-  [K in keyof S]: UnwrapValidator<S[K]>;
-};
+  [K in RequiredKeys<S>]: UnwrapValidator<S[K]>;
+} & { [K in OptionalKeys<S>]?: UnwrapValidator<S[K]> };
 
 /**
  * Validates that `obj` satisfies at least `schema`. Additional keys are accepted.

--- a/src/json/testing-util.ts
+++ b/src/json/testing-util.ts
@@ -1,0 +1,15 @@
+import * as json from ".";
+
+export function makeFromSchema<S extends json.Schema>(
+  includeOptional: boolean,
+  schema: S,
+): json.FromSchema<S> {
+  const result = {};
+  for (const [key, validator] of Object.entries(schema)) {
+    if (!validator.required && !includeOptional) {
+      continue;
+    }
+    result[key] = `value-for-${key}`;
+  }
+  return result as json.FromSchema<S>;
+}

--- a/src/json/testing-util.ts
+++ b/src/json/testing-util.ts
@@ -61,8 +61,17 @@ export function withSchemaMatrix<S extends json.Schema>(
     `value-for-${String(key)}`,
   ];
 
-  // Constructs an array of test objects, starting with `required` and adding
-  // acceptable values for any
+  // Constructs an array of test objects, starting with `required` and combining it with all
+  // possible states of each optional property. For example, with default settings:
+  //
+  // For { requiredKey: string }, we get: `[{ requiredKey: "some-string-value" }]`
+  //
+  // For { requiredKey: string, optionalKey?: string }, we get:
+  // [ { requiredKey: "some-string-value" },
+  //   { requiredKey: "some-string-value", optionalKey: undefined },
+  //   { requiredKey: "some-string-value", optionalKey: null },
+  //   { requiredKey: "some-string-value", optionalKey: "some-value" },
+  // ]
   const permutations = (keys: Array<keyof S>) => {
     if (keys.length === 0) return [required];
 

--- a/src/json/testing-util.ts
+++ b/src/json/testing-util.ts
@@ -1,5 +1,15 @@
+import { ExecutionContext } from "ava";
+
 import * as json from ".";
 
+/**
+ * Constructs an object based on `schema` for unit tests.
+ * Assumes that all keys in `schema` have string values.
+ *
+ * @param includeOptional Whether to include optional properties.
+ * @param schema The schema to base the object on.
+ * @returns An object that satisfies `schema`.
+ */
 export function makeFromSchema<S extends json.Schema>(
   includeOptional: boolean,
   schema: S,
@@ -12,4 +22,76 @@ export function makeFromSchema<S extends json.Schema>(
     result[key] = `value-for-${key}`;
   }
   return result as json.FromSchema<S>;
+}
+
+/** Options for `withSchemaMatrix`. */
+export interface SchemaMatrixOptions {
+  /** Whether cases where the properties are entirely absent should be excluded. */
+  excludeAbsent?: boolean;
+}
+
+/**
+ * Constructs a test matrix of possible objects for `schema`: all required properties
+ * plus all permutations of possible states for the optional properties.
+ *
+ * @param schema The schema to construct a test matrix for.
+ * @param body The test body to call with each value from the test matrix.
+ */
+export function withSchemaMatrix<S extends json.Schema>(
+  t: ExecutionContext<any>,
+  schema: S,
+  opts: SchemaMatrixOptions,
+  body: (value: json.FromSchema<S>) => void,
+): void {
+  // Construct a base object that includes all required properties.
+  const required = makeFromSchema(false, schema);
+
+  // Identify optional properties.
+  const optionalKeys: Array<keyof S> = [];
+
+  for (const [key, validator] of Object.entries(schema)) {
+    if (!validator.required) {
+      optionalKeys.push(key);
+    }
+  }
+
+  const optionalValues = (key: keyof S) => [
+    null,
+    undefined,
+    `value-for-${String(key)}`,
+  ];
+
+  // Constructs an array of test objects, starting with `required` and adding
+  // acceptable values for any
+  const permutations = (keys: Array<keyof S>) => {
+    if (keys.length === 0) return [required];
+
+    const bases = permutations(keys.slice(1));
+    const result: Array<json.FromSchema<S>> = [];
+
+    const optionalKey = keys[0];
+    for (const base of bases) {
+      if (!opts.excludeAbsent) {
+        // Optional keys can be absent entirely.
+        result.push(base);
+      }
+
+      // Or be present and have one of the `optionalValues`.
+      for (const optionalValue of optionalValues(optionalKey)) {
+        result.push({ ...base, [optionalKey]: optionalValue });
+      }
+    }
+    return result;
+  };
+
+  // Call `body` for all test cases.
+  const testCases = permutations(optionalKeys);
+  for (const testCase of testCases) {
+    try {
+      body(testCase);
+    } catch (err) {
+      t.log(testCase);
+      throw err;
+    }
+  }
 }

--- a/src/start-proxy-action.ts
+++ b/src/start-proxy-action.ts
@@ -198,6 +198,7 @@ async function startProxy(
     .map((credential) => ({
       type: credential.type,
       url: credential.url,
+      "replaces-base": credential["replaces-base"],
     }));
   core.setOutput("proxy_urls", JSON.stringify(registry_urls));
 

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -351,112 +351,37 @@ test("getCredentials throws an error when non-printable characters are used", as
   }
 });
 
-const validAzureCredential: startProxyExports.AzureConfig = {
-  "tenant-id": "12345678-1234-1234-1234-123456789012",
-  "client-id": "abcdef01-2345-6789-abcd-ef0123456789",
-};
+for (const oidcSchemaInfo of startProxyExports.oidcSchemas) {
+  test(`getCredentials throws when non-printable characters are used (${oidcSchemaInfo.name} OIDC)`, (t) => {
+    const validCredential = makeFromSchema(true, oidcSchemaInfo.schema);
+    for (const key of Object.keys(validCredential)) {
+      const invalidAuthConfig = {
+        ...validCredential,
+        [key]: "123\x00",
+      };
+      const invalidCredential: startProxyExports.RawCredential = {
+        type: "nuget_feed",
+        host: `${key}.nuget.pkg.github.com`,
+        ...invalidAuthConfig,
+      };
+      const credentialsInput = toEncodedJSON([invalidCredential]);
 
-const validAwsCredential: startProxyExports.AWSConfig = {
-  "aws-region": "us-east-1",
-  "account-id": "123456789012",
-  "role-name": "MY_ROLE",
-  domain: "MY_DOMAIN",
-  "domain-owner": "987654321098",
-  audience: "custom-audience",
-};
-
-const validJFrogCredential: startProxyExports.JFrogConfig = {
-  "jfrog-oidc-provider-name": "MY_PROVIDER",
-  audience: "jfrog-audience",
-  "identity-mapping-name": "my-mapping",
-};
-
-test("getCredentials throws an error when non-printable characters are used for Azure OIDC", (t) => {
-  for (const key of Object.keys(validAzureCredential)) {
-    const invalidAzureCredential = {
-      ...validAzureCredential,
-      [key]: "123\x00",
-    };
-    const invalidCredential: startProxyExports.RawCredential = {
-      type: "nuget_feed",
-      host: `${key}.nuget.pkg.github.com`,
-      ...invalidAzureCredential,
-    };
-    const credentialsInput = toEncodedJSON([invalidCredential]);
-
-    t.throws(
-      () =>
-        startProxyExports.getCredentials(
-          getRunnerLogger(true),
-          undefined,
-          credentialsInput,
-          undefined,
-        ),
-      {
-        message:
-          "Invalid credentials - fields must contain only printable characters",
-      },
-    );
-  }
-});
-
-test("getCredentials throws an error when non-printable characters are used for AWS OIDC", (t) => {
-  for (const key of Object.keys(validAwsCredential)) {
-    const invalidAwsCredential = {
-      ...validAwsCredential,
-      [key]: "123\x00",
-    };
-    const invalidCredential: startProxyExports.RawCredential = {
-      type: "nuget_feed",
-      host: `${key}.nuget.pkg.github.com`,
-      ...invalidAwsCredential,
-    };
-    const credentialsInput = toEncodedJSON([invalidCredential]);
-
-    t.throws(
-      () =>
-        startProxyExports.getCredentials(
-          getRunnerLogger(true),
-          undefined,
-          credentialsInput,
-          undefined,
-        ),
-      {
-        message:
-          "Invalid credentials - fields must contain only printable characters",
-      },
-    );
-  }
-});
-
-test("getCredentials throws an error when non-printable characters are used for JFrog OIDC", (t) => {
-  for (const key of Object.keys(validJFrogCredential)) {
-    const invalidJFrogCredential = {
-      ...validJFrogCredential,
-      [key]: "123\x00",
-    };
-    const invalidCredential: startProxyExports.RawCredential = {
-      type: "nuget_feed",
-      host: `${key}.nuget.pkg.github.com`,
-      ...invalidJFrogCredential,
-    };
-    const credentialsInput = toEncodedJSON([invalidCredential]);
-
-    t.throws(
-      () =>
-        startProxyExports.getCredentials(
-          getRunnerLogger(true),
-          undefined,
-          credentialsInput,
-          undefined,
-        ),
-      {
-        message:
-          "Invalid credentials - fields must contain only printable characters",
-      },
-    );
-  }
-});
+      t.throws(
+        () =>
+          startProxyExports.getCredentials(
+            getRunnerLogger(true),
+            undefined,
+            credentialsInput,
+            undefined,
+          ),
+        {
+          message:
+            "Invalid credentials - fields must contain only printable characters",
+        },
+      );
+    }
+  });
+}
 
 test("getCredentials accepts OIDC configurations", (t) => {
   const oidcConfigurations = startProxyExports.oidcSchemas.map(

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -8,6 +8,7 @@ import sinon from "sinon";
 import * as apiClient from "./api-client";
 import * as defaults from "./defaults.json";
 import { setUpFeatureFlagTests } from "./feature-flags/testing-util";
+import { UnvalidatedObject, validateSchema } from "./json";
 import { makeFromSchema } from "./json/testing-util";
 import { BuiltInLanguage } from "./languages";
 import { getRunnerLogger, Logger } from "./logging";
@@ -472,12 +473,20 @@ test("getCredentials accepts OIDC configurations", (t) => {
     toEncodedJSON(oidcConfigurations),
     BuiltInLanguage.csharp,
   );
-  t.is(credentials.length, 3);
+  t.is(credentials.length, startProxyExports.oidcSchemas.length);
 
   t.assert(credentials.every((c) => c.type === "nuget_feed"));
-  t.assert(credentials.some((c) => startProxyExports.isAzureConfig(c)));
-  t.assert(credentials.some((c) => startProxyExports.isAWSConfig(c)));
-  t.assert(credentials.some((c) => startProxyExports.isJFrogConfig(c)));
+
+  for (const oidcSchemaInfo of startProxyExports.oidcSchemas) {
+    t.assert(
+      credentials.some((c) =>
+        validateSchema(
+          oidcSchemaInfo.schema,
+          c as unknown as UnvalidatedObject<any>,
+        ),
+      ),
+    );
+  }
 });
 
 const getCredentialsMacro = test.macro({

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -532,7 +532,7 @@ test(
     t.is(results[0].type, "git_server");
     t.is(results[0].host, "https://github.com/");
 
-    if (startProxyExports.isUsernamePassword(results[0])) {
+    if (startProxyExports.hasUsernameAndPassword(results[0])) {
       t.assert(results[0].password?.startsWith("ghp_"));
     } else {
       t.fail("Expected a `UsernamePassword`-based credential.");
@@ -563,7 +563,7 @@ test(
     t.is(results[0].type, "git_server");
     t.is(results[0].host, "https://github.com/");
 
-    if (startProxyExports.isUsernamePassword(results[0])) {
+    if (startProxyExports.hasUsernameAndPassword(results[0])) {
       t.assert(results[0].password?.startsWith("ghp_"));
     } else {
       t.fail("Expected a `UsernamePassword`-based credential.");

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -639,6 +639,76 @@ test(
   },
 );
 
+test("getCredentials validates 'replaces-base' correctly", async (t) => {
+  // Valid cases.
+  const credentialsInput = toEncodedJSON([
+    {
+      type: "maven_repository",
+      host: "maven1.pkg.github.com",
+      token: "abc",
+      "replaces-base": false,
+    },
+    {
+      type: "maven_repository",
+      host: "maven2.pkg.github.com",
+      token: "def",
+      "replaces-base": true,
+    },
+    {
+      type: "maven_repository",
+      host: "maven3.pkg.github.com",
+      token: "ghi",
+    },
+  ]);
+
+  const credentials = startProxyExports.getCredentials(
+    getRunnerLogger(true),
+    undefined,
+    credentialsInput,
+    BuiltInLanguage.java,
+    false,
+  );
+
+  t.is(credentials.length, 3);
+  t.true(credentials.some((c) => c["replaces-base"] === true));
+  t.true(credentials.some((c) => c["replaces-base"] === false));
+  t.true(credentials.some((c) => c["replaces-base"] === undefined));
+
+  // Invalid cases.
+  const baseInvalid = {
+    type: "maven_repository",
+    host: "maven4.pkg.github.com",
+    token: "jkl",
+  };
+  t.throws(() =>
+    startProxyExports.getCredentials(
+      getRunnerLogger(true),
+      undefined,
+      toEncodedJSON([{ ...baseInvalid, "replaces-base": null }]),
+      BuiltInLanguage.actions,
+      false,
+    ),
+  );
+  t.throws(() =>
+    startProxyExports.getCredentials(
+      getRunnerLogger(true),
+      undefined,
+      toEncodedJSON([{ ...baseInvalid, "replaces-base": 123 }]),
+      BuiltInLanguage.actions,
+      false,
+    ),
+  );
+  t.throws(() =>
+    startProxyExports.getCredentials(
+      getRunnerLogger(true),
+      undefined,
+      toEncodedJSON([{ ...baseInvalid, "replaces-base": "true" }]),
+      BuiltInLanguage.actions,
+      false,
+    ),
+  );
+});
+
 test("getCredentials returns all credentials for Actions when using LANGUAGE_TO_REGISTRY_TYPE", async (t) => {
   const credentialsInput = toEncodedJSON(mixedCredentials);
 

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -8,6 +8,7 @@ import sinon from "sinon";
 import * as apiClient from "./api-client";
 import * as defaults from "./defaults.json";
 import { setUpFeatureFlagTests } from "./feature-flags/testing-util";
+import { makeFromSchema } from "./json/testing-util";
 import { BuiltInLanguage } from "./languages";
 import { getRunnerLogger, Logger } from "./logging";
 import * as startProxyExports from "./start-proxy";
@@ -457,23 +458,13 @@ test("getCredentials throws an error when non-printable characters are used for 
 });
 
 test("getCredentials accepts OIDC configurations", (t) => {
-  const oidcConfigurations = [
-    {
+  const oidcConfigurations = startProxyExports.oidcSchemas.map(
+    (schemaInfo) => ({
       type: "nuget_feed",
-      host: "azure.pkg.github.com",
-      ...validAzureCredential,
-    },
-    {
-      type: "nuget_feed",
-      host: "aws.pkg.github.com",
-      ...validAwsCredential,
-    },
-    {
-      type: "nuget_feed",
-      host: "jfrog.pkg.github.com",
-      ...validJFrogCredential,
-    },
-  ];
+      host: `${schemaInfo.name.toLowerCase()}.pkg.github.com`,
+      ...makeFromSchema(true, schemaInfo.schema),
+    }),
+  );
 
   const credentials = startProxyExports.getCredentials(
     getRunnerLogger(true),

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -347,8 +347,21 @@ export function getCredentials(
       );
     }
 
+    // Construct the base credential object.
+    const baseCredential: Omit<Registry, keyof Address> = { type: e.type };
+
+    if (isDefined(e["replaces-base"])) {
+      if (typeof e["replaces-base"] === "boolean") {
+        baseCredential["replaces-base"] = e["replaces-base"];
+      } else {
+        throw new ConfigurationError(
+          "Invalid credentials - 'replaces-base' must be a boolean",
+        );
+      }
+    }
+
     out.push({
-      type: e.type,
+      ...baseCredential,
       ...authConfig,
       ...address,
     });

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -24,8 +24,8 @@ import {
   Address,
   Registry,
   Credential,
-  isToken,
-  isUsernamePassword,
+  hasToken,
+  hasUsernameAndPassword,
   hasUsername,
   RawCredential,
 } from "./start-proxy/types";
@@ -331,11 +331,11 @@ export function getCredentials(
     const noUsername =
       !hasUsername(authConfig) || !isDefined(authConfig.username);
     const passwordIsPAT =
-      isUsernamePassword(authConfig) &&
+      hasUsernameAndPassword(authConfig) &&
       isDefined(authConfig.password) &&
       isPAT(authConfig.password);
     const tokenIsPAT =
-      isToken(authConfig) &&
+      hasToken(authConfig) &&
       isDefined(authConfig.token) &&
       isPAT(authConfig.token);
 

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -350,8 +350,12 @@ export function getCredentials(
     // Construct the base credential object.
     const baseCredential: Omit<Registry, keyof Address> = { type: e.type };
 
-    if (isDefined(e["replaces-base"])) {
-      if (typeof e["replaces-base"] === "boolean") {
+    // If "replaces-base" is present, it must be a boolean.
+    if ("replaces-base" in e) {
+      if (
+        isDefined(e["replaces-base"]) &&
+        typeof e["replaces-base"] === "boolean"
+      ) {
         baseCredential["replaces-base"] = e["replaces-base"];
       } else {
         throw new ConfigurationError(

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -24,20 +24,12 @@ import {
   Address,
   Registry,
   Credential,
-  AuthConfig,
   isToken,
-  isAzureConfig,
-  Token,
-  UsernamePassword,
-  AzureConfig,
-  isAWSConfig,
-  AWSConfig,
-  isJFrogConfig,
-  JFrogConfig,
   isUsernamePassword,
   hasUsername,
   RawCredential,
 } from "./start-proxy/types";
+import { getAuthConfig } from "./start-proxy/validation";
 import {
   ActionName,
   createStatusReportBase,
@@ -248,75 +240,6 @@ function getRegistryAddress(
     throw new ConfigurationError(
       "Invalid credentials - must specify host or url",
     );
-  }
-}
-
-/** Extracts an `AuthConfig` value from `config`. */
-export function getAuthConfig(
-  config: json.UnvalidatedObject<AuthConfig>,
-): AuthConfig {
-  // Start by checking for the OIDC configurations, since they have required properties
-  // which we can use to identify them.
-  if (isAzureConfig(config)) {
-    return {
-      "tenant-id": config["tenant-id"],
-      "client-id": config["client-id"],
-    } satisfies AzureConfig;
-  } else if (isAWSConfig(config)) {
-    return {
-      "aws-region": config["aws-region"],
-      "account-id": config["account-id"],
-      "role-name": config["role-name"],
-      domain: config.domain,
-      "domain-owner": config["domain-owner"],
-      audience: config.audience,
-    } satisfies AWSConfig;
-  } else if (isJFrogConfig(config)) {
-    return {
-      "jfrog-oidc-provider-name": config["jfrog-oidc-provider-name"],
-      "identity-mapping-name": config["identity-mapping-name"],
-      audience: config.audience,
-    } satisfies JFrogConfig;
-  } else if (isToken(config)) {
-    // There are three scenarios for non-OIDC authentication based on the registry type:
-    //
-    // 1. `username`+`token`
-    // 2. A `token` that combines the username and actual token, separated by ':'.
-    // 3. `username`+`password`
-    //
-    // In all three cases, all fields are optional. If the `token` field is present,
-    // we accept the configuration as a `Token` typed configuration, with the `token`
-    // value and an optional `username`. Otherwise, we accept the configuration
-    // typed as `UsernamePassword` (in the `else` clause below) with optional
-    // username and password. I.e. a private registry type that uses 1. or 2.,
-    // but has no `token` configured, will get accepted as `UsernamePassword` here.
-
-    if (isDefined(config.token)) {
-      // Mask token to reduce chance of accidental leakage in logs, if we have one.
-      core.setSecret(config.token);
-    }
-
-    return { username: config.username, token: config.token } satisfies Token;
-  } else {
-    let username: string | undefined = undefined;
-    let password: string | undefined = undefined;
-
-    // Both "username" and "password" are optional. If we have reached this point, we need
-    // to validate which of them are present and that they have the correct type if so.
-    if ("password" in config && json.isString(config.password)) {
-      // Mask password to reduce chance of accidental leakage in logs, if we have one.
-      core.setSecret(config.password);
-      password = config.password;
-    }
-    if ("username" in config && json.isString(config.username)) {
-      username = config.username;
-    }
-
-    // Return the `UsernamePassword` object. Both username and password may be undefined.
-    return {
-      username,
-      password,
-    } satisfies UsernamePassword;
   }
 }
 

--- a/src/start-proxy/types.test.ts
+++ b/src/start-proxy/types.test.ts
@@ -1,5 +1,6 @@
 import test from "ava";
 
+import { makeFromSchema } from "../json/testing-util";
 import { setupTests } from "../testing-utils";
 
 import * as types from "./types";
@@ -103,6 +104,24 @@ test("credentialToStr - pretty-prints valid JFrog OIDC configurations", (t) => {
 
   t.is(
     "Type: maven_credential; Url: https://localhost; JFrog Provider: MY_PROVIDER; JFrog Identity Mapping: my-mapping; JFrog Audience: jfrog-audience;",
+    str,
+  );
+});
+
+test("credentialToStr - pretty-prints valid Cloudsmith OIDC configurations", (t) => {
+  const credential: types.Credential = {
+    type: "maven_credential",
+    url: "https://localhost",
+    ...(makeFromSchema(
+      true,
+      types.cloudsmithConfigSchema,
+    ) as types.CloudsmithConfig),
+  };
+
+  const str = types.credentialToStr(credential);
+
+  t.is(
+    "Type: maven_credential; Url: https://localhost; Cloudsmith Namespace: value-for-namespace; Cloudsmith Service Slug: value-for-service-slug; Cloudsmith API Host: value-for-api-host;",
     str,
   );
 });

--- a/src/start-proxy/types.test.ts
+++ b/src/start-proxy/types.test.ts
@@ -145,7 +145,6 @@ test("credentialToStr - hides passwords", (t) => {
   const secret = "password123";
   const credential = {
     type: "maven_credential",
-    username: null,
     password: secret,
     url: "https://localhost",
   } satisfies types.Credential;
@@ -160,7 +159,6 @@ test("credentialToStr - hides tokens", (t) => {
   const secret = "password123";
   const credential = {
     type: "maven_credential",
-    username: null,
     token: secret,
     url: "https://localhost",
   } satisfies types.Credential;

--- a/src/start-proxy/types.test.ts
+++ b/src/start-proxy/types.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 
-import { makeFromSchema } from "../json/testing-util";
+import { makeFromSchema, withSchemaMatrix } from "../json/testing-util";
 import { setupTests } from "../testing-utils";
 
 import * as types from "./types";
@@ -26,6 +26,38 @@ const validJFrogCredential: types.JFrogConfig = {
   audience: "jfrog-audience",
   "identity-mapping-name": "my-mapping",
 };
+
+test("hasUsername", (t) => {
+  // Reject the case where `username` is missing.
+  t.false(types.hasUsername({}));
+
+  // Test all cases where `username` is present.
+  withSchemaMatrix(
+    t,
+    types.usernameSchema,
+    { excludeAbsent: true },
+    (value) => {
+      t.true(types.hasUsername(value));
+    },
+  );
+});
+
+test("hasUsernameAndPassword", (t) => {
+  // Reject cases where `username` or `password` are missing.
+  t.false(types.hasUsernameAndPassword({}));
+  t.false(types.hasUsernameAndPassword({ username: "foo" }));
+  t.false(types.hasUsernameAndPassword({ password: "foo" }));
+
+  // Test all cases where both `username` and `password` are present.
+  withSchemaMatrix(
+    t,
+    types.usernamePasswordSchema,
+    { excludeAbsent: true },
+    (value) => {
+      t.true(types.hasUsernameAndPassword(value));
+    },
+  );
+});
 
 test("credentialToStr - pretty-prints valid username+password configurations", (t) => {
   const secret = "password123";

--- a/src/start-proxy/types.test.ts
+++ b/src/start-proxy/types.test.ts
@@ -111,9 +111,10 @@ test("credentialToStr - hides passwords", (t) => {
   const secret = "password123";
   const credential = {
     type: "maven_credential",
+    username: null,
     password: secret,
     url: "https://localhost",
-  };
+  } satisfies types.Credential;
 
   const str = types.credentialToStr(credential);
 
@@ -125,9 +126,10 @@ test("credentialToStr - hides tokens", (t) => {
   const secret = "password123";
   const credential = {
     type: "maven_credential",
+    username: null,
     token: secret,
     url: "https://localhost",
-  };
+  } satisfies types.Credential;
 
   const str = types.credentialToStr(credential);
 

--- a/src/start-proxy/types.test.ts
+++ b/src/start-proxy/types.test.ts
@@ -126,6 +126,21 @@ test("credentialToStr - pretty-prints valid Cloudsmith OIDC configurations", (t)
   );
 });
 
+test("credentialToStr - pretty-prints valid GCP OIDC configurations", (t) => {
+  const credential: types.Credential = {
+    type: "maven_credential",
+    url: "https://localhost",
+    ...(makeFromSchema(true, types.gcpConfigSchema) as types.GCPConfig),
+  };
+
+  const str = types.credentialToStr(credential);
+
+  t.is(
+    "Type: maven_credential; Url: https://localhost; GCP Workload Identity Provider: value-for-workload-identity-provider; GCP Service Account: value-for-service-account; GCP Audience: value-for-audience;",
+    str,
+  );
+});
+
 test("credentialToStr - hides passwords", (t) => {
   const secret = "password123";
   const credential = {

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -18,10 +18,11 @@ export const usernameSchema = {
 /** Usernames may be present for both authentication with tokens or passwords. */
 export type Username = json.FromSchema<typeof usernameSchema>;
 
-/** Decides whether `config` has a username. */
-export function hasUsername(
-  config: UnvalidatedObject<unknown>,
-): config is Username {
+/**
+ * Narrows `config` to `Username` if `config` has a `username` property.
+ * Not used for validation. Assumes that `config` is already a validated `AuthConfig`.
+ */
+export function hasUsername(config: AuthConfig): config is Username {
   return "username" in config;
 }
 
@@ -38,11 +39,14 @@ export const usernamePasswordSchema = {
  */
 export type UsernamePassword = json.FromSchema<typeof usernamePasswordSchema>;
 
-/** Decides whether `config` is based on a username and password. */
-export function isUsernamePassword(
+/**
+ * Narrows `config` to `UsernamePassword` if it has a `username` and `password` property.
+ * Not used for validation. Assumes that `config` is already a validated `AuthConfig`.
+ */
+export function hasUsernameAndPassword(
   config: AuthConfig,
 ): config is UsernamePassword {
-  return json.validateSchema(usernamePasswordSchema, config);
+  return hasUsername(config) && "password" in config;
 }
 
 /** A schema for credential objects for token-based authentication. */
@@ -57,6 +61,14 @@ export const tokenSchema = {
  * Both username and token are optional.
  */
 export type Token = json.FromSchema<typeof tokenSchema>;
+
+/**
+ * Narrows `config` to `Token` if it has a `token` property.
+ * Not used for validation. Assumes that `config` is already a validated `AuthConfig`.
+ */
+export function hasToken(config: AuthConfig): config is Token {
+  return "token" in config;
+}
 
 /** Decides whether `config` is token-based. */
 export function isToken(
@@ -205,7 +217,7 @@ export function credentialToStr(credential: Credential): string {
       isDefined(credential.password) ? "***" : undefined,
     );
   }
-  if (isToken(credential)) {
+  if (hasToken(credential)) {
     appendIfDefined("Token", isDefined(credential.token) ? "***" : undefined);
   }
 

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -9,53 +9,60 @@ import { isDefined } from "../util";
  */
 export type RawCredential = UnvalidatedObject<Credential>;
 
-/** Usernames may be present for both authentication with tokens or passwords. */
-export type Username = {
+/** A schema for credential objects with a username. */
+export const usernameSchema = {
   /** The username needed to authenticate to the package registry, if any. */
-  username?: string;
-};
+  username: json.optional(json.string),
+} as const satisfies json.Schema;
+
+/** Usernames may be present for both authentication with tokens or passwords. */
+export type Username = json.FromSchema<typeof usernameSchema>;
 
 /** Decides whether `config` has a username. */
-export function hasUsername(config: AuthConfig): config is Username {
+export function hasUsername(
+  config: UnvalidatedObject<unknown>,
+): config is Username {
   return "username" in config;
 }
+
+/** A schema for credential objects with a username and password. */
+export const usernamePasswordSchema = {
+  /** The password needed to authenticate to the package registry, if any. */
+  password: json.optional(json.string),
+  ...usernameSchema,
+} as const satisfies json.Schema;
 
 /**
  * Fields expected for authentication based on a username and password.
  * Both username and password are optional.
  */
-export type UsernamePassword = {
-  /** The password needed to authenticate to the package registry, if any. */
-  password?: string;
-} & Username;
+export type UsernamePassword = json.FromSchema<typeof usernamePasswordSchema>;
 
 /** Decides whether `config` is based on a username and password. */
 export function isUsernamePassword(
   config: AuthConfig,
 ): config is UsernamePassword {
-  return hasUsername(config) && "password" in config;
+  return json.validateSchema(usernamePasswordSchema, config);
 }
+
+/** A schema for credential objects for token-based authentication. */
+export const tokenSchema = {
+  /** The token needed to authenticate to the package registry, if any. */
+  token: json.optional(json.string),
+  ...usernameSchema,
+} as const satisfies json.Schema;
 
 /**
  * Fields expected for token-based authentication.
  * Both username and token are optional.
  */
-export type Token = {
-  /** The token needed to authenticate to the package registry, if any. */
-  token?: string;
-} & Username;
+export type Token = json.FromSchema<typeof tokenSchema>;
 
 /** Decides whether `config` is token-based. */
 export function isToken(
   config: UnvalidatedObject<AuthConfig>,
 ): config is Token {
-  // The "username" field is optional, but should be a string if present.
-  if ("username" in config && !json.isStringOrUndefined(config.username)) {
-    return false;
-  }
-
-  // The "token" field is required, and must be a string or undefined.
-  return "token" in config && json.isStringOrUndefined(config.token);
+  return "token" in config && json.validateSchema(tokenSchema, config);
 }
 
 /** A schema for Azure OIDC configurations. */

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -118,15 +118,33 @@ export function isJFrogConfig(
   return json.validateSchema(jfrogConfigSchema, config);
 }
 
+/** A schema for Cloudsmith OIDC configurations. */
+export const cloudsmithConfigSchema = {
+  namespace: json.string,
+  "service-slug": json.string,
+  "api-host": json.string,
+} as const satisfies json.Schema;
+
+/** Configuration for Cloudsmith OIDC. */
+export type CloudsmithConfig = json.FromSchema<typeof cloudsmithConfigSchema>;
+
+/** Decides whether `config` is a Cloudsmith OIDC configuration. */
+export function isCloudsmithConfig(
+  config: UnvalidatedObject<AuthConfig>,
+): config is CloudsmithConfig {
+  return json.validateSchema(cloudsmithConfigSchema, config);
+}
+
 /** An array of all OIDC configuration schemas along with output-friendly names. */
 export const oidcSchemas = [
   { schema: azureConfigSchema, name: "Azure" },
   { schema: awsConfigSchema, name: "AWS" },
   { schema: jfrogConfigSchema, name: "JFrog" },
+  { schema: cloudsmithConfigSchema, name: "Cloudsmith" },
 ];
 
 /** Represents all supported OIDC configurations. */
-export type OIDC = AzureConfig | AWSConfig | JFrogConfig;
+export type OIDC = AzureConfig | AWSConfig | JFrogConfig | CloudsmithConfig;
 
 /** All authentication-related fields. */
 export type AuthConfig = UsernamePassword | Token | OIDC;
@@ -185,6 +203,10 @@ export function credentialToStr(credential: Credential): string {
       credential["identity-mapping-name"],
     );
     appendIfDefined("JFrog Audience", credential.audience);
+  } else if (isCloudsmithConfig(credential)) {
+    appendIfDefined("Cloudsmith Namespace", credential.namespace);
+    appendIfDefined("Cloudsmith Service Slug", credential["service-slug"]);
+    appendIfDefined("Cloudsmith API Host", credential["api-host"]);
   }
 
   return result;

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -135,16 +135,39 @@ export function isCloudsmithConfig(
   return json.validateSchema(cloudsmithConfigSchema, config);
 }
 
+/** A schema for GCP OIDC configurations. */
+export const gcpConfigSchema = {
+  "workload-identity-provider": json.string,
+  "service-account": json.optional(json.string),
+  audience: json.optional(json.string),
+} as const satisfies json.Schema;
+
+/** Configuration for GCP OIDC. */
+export type GCPConfig = json.FromSchema<typeof gcpConfigSchema>;
+
+/** Decides whether `config` is a GCP OIDC configuration. */
+export function isGCPConfig(
+  config: UnvalidatedObject<AuthConfig>,
+): config is GCPConfig {
+  return json.validateSchema(gcpConfigSchema, config);
+}
+
 /** An array of all OIDC configuration schemas along with output-friendly names. */
 export const oidcSchemas = [
   { schema: azureConfigSchema, name: "Azure" },
   { schema: awsConfigSchema, name: "AWS" },
   { schema: jfrogConfigSchema, name: "JFrog" },
   { schema: cloudsmithConfigSchema, name: "Cloudsmith" },
+  { schema: gcpConfigSchema, name: "GCP" },
 ];
 
 /** Represents all supported OIDC configurations. */
-export type OIDC = AzureConfig | AWSConfig | JFrogConfig | CloudsmithConfig;
+export type OIDC =
+  | AzureConfig
+  | AWSConfig
+  | JFrogConfig
+  | CloudsmithConfig
+  | GCPConfig;
 
 /** All authentication-related fields. */
 export type AuthConfig = UsernamePassword | Token | OIDC;
@@ -207,6 +230,13 @@ export function credentialToStr(credential: Credential): string {
     appendIfDefined("Cloudsmith Namespace", credential.namespace);
     appendIfDefined("Cloudsmith Service Slug", credential["service-slug"]);
     appendIfDefined("Cloudsmith API Host", credential["api-host"]);
+  } else if (isGCPConfig(credential)) {
+    appendIfDefined(
+      "GCP Workload Identity Provider",
+      credential["workload-identity-provider"],
+    );
+    appendIfDefined("GCP Service Account", credential["service-account"]);
+    appendIfDefined("GCP Audience", credential.audience);
   }
 
   return result;

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -58,91 +58,57 @@ export function isToken(
   return "token" in config && json.isStringOrUndefined(config.token);
 }
 
+/** A schema for Azure OIDC configurations. */
+export const azureConfigSchema = {
+  "tenant-id": json.string,
+  "client-id": json.string,
+} as const satisfies json.Schema;
+
 /** Configuration for Azure OIDC. */
-export type AzureConfig = { "tenant-id": string; "client-id": string };
+export type AzureConfig = json.FromSchema<typeof azureConfigSchema>;
 
 /** Decides whether `config` is an Azure OIDC configuration. */
 export function isAzureConfig(
   config: UnvalidatedObject<AuthConfig>,
 ): config is AzureConfig {
-  return (
-    "tenant-id" in config &&
-    "client-id" in config &&
-    isDefined(config["tenant-id"]) &&
-    isDefined(config["client-id"]) &&
-    json.isString(config["tenant-id"]) &&
-    json.isString(config["client-id"])
-  );
+  return json.validateSchema(azureConfigSchema, config);
 }
 
+/** A schema for AWS OIDC configurations. */
+export const awsConfigSchema = {
+  "aws-region": json.string,
+  "account-id": json.string,
+  "role-name": json.string,
+  domain: json.string,
+  "domain-owner": json.string,
+  audience: json.optional(json.string),
+} as const satisfies json.Schema;
+
 /** Configuration for AWS OIDC. */
-export type AWSConfig = {
-  "aws-region": string;
-  "account-id": string;
-  "role-name": string;
-  domain: string;
-  "domain-owner": string;
-  audience?: string;
-};
+export type AWSConfig = json.FromSchema<typeof awsConfigSchema>;
 
 /** Decides whether `config` is an AWS OIDC configuration. */
 export function isAWSConfig(
   config: UnvalidatedObject<AuthConfig>,
 ): config is AWSConfig {
-  // All of these properties are required.
-  const requiredProperties = [
-    "aws-region",
-    "account-id",
-    "role-name",
-    "domain",
-    "domain-owner",
-  ];
-
-  for (const property of requiredProperties) {
-    if (
-      !(property in config) ||
-      !isDefined(config[property]) ||
-      !json.isString(config[property])
-    ) {
-      return false;
-    }
-  }
-
-  // The "audience" field is optional, but should be a string if present.
-  if ("audience" in config && !json.isStringOrUndefined(config.audience)) {
-    return false;
-  }
-
-  return true;
+  return json.validateSchema(awsConfigSchema, config);
 }
 
+/** A schema for JFrog OIDC configurations. */
+export const jfrogConfigSchema = {
+  "jfrog-oidc-provider-name": json.string,
+  audience: json.optional(json.string),
+  "identity-mapping-name": json.optional(json.string),
+} as const satisfies json.Schema;
+
 /** Configuration for JFrog OIDC. */
-export type JFrogConfig = {
-  "jfrog-oidc-provider-name": string;
-  audience?: string;
-  "identity-mapping-name"?: string;
-};
+export type JFrogConfig = json.FromSchema<typeof jfrogConfigSchema>;
 
 /** Decides whether `config` is a JFrog OIDC configuration. */
 export function isJFrogConfig(
   config: UnvalidatedObject<AuthConfig>,
 ): config is JFrogConfig {
-  // The "audience" and "identity-mapping-name" fields are optional, but should be strings if present.
-  if ("audience" in config && !json.isStringOrUndefined(config.audience)) {
-    return false;
-  }
-  if (
-    "identity-mapping-name" in config &&
-    !json.isStringOrUndefined(config["identity-mapping-name"])
-  ) {
-    return false;
-  }
-
-  return (
-    "jfrog-oidc-provider-name" in config &&
-    isDefined(config["jfrog-oidc-provider-name"]) &&
-    json.isString(config["jfrog-oidc-provider-name"])
-  );
+  return json.validateSchema(jfrogConfigSchema, config);
 }
 
 /** Represents all supported OIDC configurations. */
@@ -165,7 +131,7 @@ export type Credential = AuthConfig & Registry;
 export function credentialToStr(credential: Credential): string {
   let result: string = `Type: ${credential.type};`;
 
-  const appendIfDefined = (name: string, val: string | undefined) => {
+  const appendIfDefined = (name: string, val: string | undefined | null) => {
     if (isDefined(val)) {
       result += ` ${name}: ${val};`;
     }

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -246,6 +246,8 @@ export function credentialToStr(credential: Credential): string {
 export type Registry = {
   /** The type of the package registry. */
   type: string;
+  /** Whether the registry replaces the base registry for the ecosystem. */
+  "replaces-base"?: boolean;
 } & Address;
 
 // If a registry has an `url`, then that takes precedence over the `host` which may or may

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -118,6 +118,13 @@ export function isJFrogConfig(
   return json.validateSchema(jfrogConfigSchema, config);
 }
 
+/** An array of all OIDC configuration schemas along with output-friendly names. */
+export const oidcSchemas = [
+  { schema: azureConfigSchema, name: "Azure" },
+  { schema: awsConfigSchema, name: "AWS" },
+  { schema: jfrogConfigSchema, name: "JFrog" },
+];
+
 /** Represents all supported OIDC configurations. */
 export type OIDC = AzureConfig | AWSConfig | JFrogConfig;
 

--- a/src/start-proxy/validation.test.ts
+++ b/src/start-proxy/validation.test.ts
@@ -1,0 +1,88 @@
+import test from "ava";
+
+import * as json from "../json";
+import { setupTests } from "../testing-utils";
+
+import * as types from "./types";
+import { getAuthConfig } from "./validation";
+
+setupTests(test);
+
+function makeFromSchema(
+  includeOptional: boolean,
+  schema: json.Schema,
+): json.FromSchema<typeof schema> {
+  const result = {};
+  for (const [key, validator] of Object.entries(schema)) {
+    if (!validator.required && !includeOptional) {
+      continue;
+    }
+    result[key] = `value-for-${key}`;
+  }
+  return result;
+}
+
+const schemaTests = [
+  { schema: types.azureConfigSchema, name: "isAzureConfig" },
+  { schema: types.awsConfigSchema, name: "isAWSConfig" },
+  { schema: types.jfrogConfigSchema, name: "isJFrogConfig" },
+] as Array<{ schema: json.Schema; name: string }>;
+
+for (const schemaTest of schemaTests) {
+  for (const includeOptional of [true, false]) {
+    const minimalName = includeOptional ? "full" : "minimal";
+
+    test(`getAuthConfig - ${schemaTest.name} - ${minimalName}`, async (t) => {
+      const config = makeFromSchema(includeOptional, schemaTest.schema);
+
+      t.deepEqual(
+        getAuthConfig({
+          ...config,
+          unexpected: "unexpected-value",
+        } as json.UnvalidatedObject<types.AuthConfig>),
+        config,
+      );
+    });
+  }
+}
+
+test("getAuthConfig - token", async (t) => {
+  const config = makeFromSchema(true, types.tokenSchema);
+
+  t.deepEqual(
+    getAuthConfig({
+      ...config,
+      unexpected: "unexpected-value",
+    } as json.UnvalidatedObject<types.AuthConfig>),
+    config,
+  );
+});
+
+test("getAuthConfig - username and password", async (t) => {
+  const config = makeFromSchema(true, types.usernamePasswordSchema);
+
+  t.deepEqual(
+    getAuthConfig({
+      ...config,
+      unexpected: "unexpected-value",
+    } as json.UnvalidatedObject<types.AuthConfig>),
+    config,
+  );
+});
+
+test("getAuthConfig - empty", async (t) => {
+  const config = makeFromSchema(false, types.usernamePasswordSchema);
+
+  // Since the purpose of constructing the `AuthConfig` values is for
+  // serialisation to JSON so that they can be passed to the proxy as configuration,
+  // we only care that the stringified JSON representations are the same.
+  t.deepEqual(
+    JSON.stringify(
+      getAuthConfig({
+        ...config,
+        unexpected: "unexpected-value",
+      } as json.UnvalidatedObject<types.AuthConfig>),
+    ),
+    JSON.stringify({}),
+  );
+});

--- a/src/start-proxy/validation.test.ts
+++ b/src/start-proxy/validation.test.ts
@@ -1,6 +1,7 @@
 import test from "ava";
 
 import * as json from "../json";
+import { makeFromSchema } from "../json/testing-util";
 import { setupTests } from "../testing-utils";
 
 import * as types from "./types";
@@ -8,27 +9,7 @@ import { getAuthConfig } from "./validation";
 
 setupTests(test);
 
-function makeFromSchema(
-  includeOptional: boolean,
-  schema: json.Schema,
-): json.FromSchema<typeof schema> {
-  const result = {};
-  for (const [key, validator] of Object.entries(schema)) {
-    if (!validator.required && !includeOptional) {
-      continue;
-    }
-    result[key] = `value-for-${key}`;
-  }
-  return result;
-}
-
-const schemaTests = [
-  { schema: types.azureConfigSchema, name: "isAzureConfig" },
-  { schema: types.awsConfigSchema, name: "isAWSConfig" },
-  { schema: types.jfrogConfigSchema, name: "isJFrogConfig" },
-] as Array<{ schema: json.Schema; name: string }>;
-
-for (const schemaTest of schemaTests) {
+for (const schemaTest of types.oidcSchemas) {
   for (const includeOptional of [true, false]) {
     const minimalName = includeOptional ? "full" : "minimal";
 
@@ -39,7 +20,7 @@ for (const schemaTest of schemaTests) {
         getAuthConfig({
           ...config,
           unexpected: "unexpected-value",
-        } as json.UnvalidatedObject<types.AuthConfig>),
+        } as unknown as json.UnvalidatedObject<types.AuthConfig>),
         config,
       );
     });

--- a/src/start-proxy/validation.ts
+++ b/src/start-proxy/validation.ts
@@ -3,7 +3,7 @@ import * as core from "@actions/core";
 import * as json from "../json";
 import { isDefined } from "../util";
 
-import type { AuthConfig, Token, UsernamePassword } from "./types";
+import type { AuthConfig, UsernamePassword } from "./types";
 import * as types from "./types";
 
 /** Constructs a new object from `obj` with only keys that exist in `schema`. */
@@ -55,7 +55,7 @@ export function getAuthConfig(
       core.setSecret(config.token);
     }
 
-    return { username: config.username, token: config.token } satisfies Token;
+    return cloneCredential(types.tokenSchema, config);
   } else {
     let username: string | undefined = undefined;
     let password: string | undefined = undefined;

--- a/src/start-proxy/validation.ts
+++ b/src/start-proxy/validation.ts
@@ -1,0 +1,83 @@
+import * as core from "@actions/core";
+
+import * as json from "../json";
+import { isDefined } from "../util";
+
+import type {
+  AuthConfig,
+  AWSConfig,
+  AzureConfig,
+  JFrogConfig,
+  Token,
+  UsernamePassword,
+} from "./types";
+import * as types from "./types";
+
+/** Extracts an `AuthConfig` value from `config`. */
+export function getAuthConfig(
+  config: json.UnvalidatedObject<AuthConfig>,
+): AuthConfig {
+  // Start by checking for the OIDC configurations, since they have required properties
+  // which we can use to identify them.
+  if (types.isAzureConfig(config)) {
+    return {
+      "tenant-id": config["tenant-id"],
+      "client-id": config["client-id"],
+    } satisfies AzureConfig;
+  } else if (types.isAWSConfig(config)) {
+    return {
+      "aws-region": config["aws-region"],
+      "account-id": config["account-id"],
+      "role-name": config["role-name"],
+      domain: config.domain,
+      "domain-owner": config["domain-owner"],
+      audience: config.audience,
+    } satisfies AWSConfig;
+  } else if (types.isJFrogConfig(config)) {
+    return {
+      "jfrog-oidc-provider-name": config["jfrog-oidc-provider-name"],
+      "identity-mapping-name": config["identity-mapping-name"],
+      audience: config.audience,
+    } satisfies JFrogConfig;
+  } else if (types.isToken(config)) {
+    // There are three scenarios for non-OIDC authentication based on the registry type:
+    //
+    // 1. `username`+`token`
+    // 2. A `token` that combines the username and actual token, separated by ':'.
+    // 3. `username`+`password`
+    //
+    // In all three cases, all fields are optional. If the `token` field is present,
+    // we accept the configuration as a `Token` typed configuration, with the `token`
+    // value and an optional `username`. Otherwise, we accept the configuration
+    // typed as `UsernamePassword` (in the `else` clause below) with optional
+    // username and password. I.e. a private registry type that uses 1. or 2.,
+    // but has no `token` configured, will get accepted as `UsernamePassword` here.
+
+    if (isDefined(config.token)) {
+      // Mask token to reduce chance of accidental leakage in logs, if we have one.
+      core.setSecret(config.token);
+    }
+
+    return { username: config.username, token: config.token } satisfies Token;
+  } else {
+    let username: string | undefined = undefined;
+    let password: string | undefined = undefined;
+
+    // Both "username" and "password" are optional. If we have reached this point, we need
+    // to validate which of them are present and that they have the correct type if so.
+    if ("password" in config && json.isString(config.password)) {
+      // Mask password to reduce chance of accidental leakage in logs, if we have one.
+      core.setSecret(config.password);
+      password = config.password;
+    }
+    if ("username" in config && json.isString(config.username)) {
+      username = config.username;
+    }
+
+    // Return the `UsernamePassword` object. Both username and password may be undefined.
+    return {
+      username,
+      password,
+    } satisfies UsernamePassword;
+  }
+}

--- a/src/start-proxy/validation.ts
+++ b/src/start-proxy/validation.ts
@@ -3,15 +3,26 @@ import * as core from "@actions/core";
 import * as json from "../json";
 import { isDefined } from "../util";
 
-import type {
-  AuthConfig,
-  AWSConfig,
-  AzureConfig,
-  JFrogConfig,
-  Token,
-  UsernamePassword,
-} from "./types";
+import type { AuthConfig, Token, UsernamePassword } from "./types";
 import * as types from "./types";
+
+/** Constructs a new object from `obj` with only keys that exist in `schema`. */
+export function cloneCredential<
+  T extends json.FromSchema<S>,
+  S extends json.Schema,
+>(schema: S, obj: T): T {
+  const result = {};
+
+  for (const key of Object.keys(schema)) {
+    // Skip keys that don't exist or don't have a value.
+    if (!isDefined(obj[key])) {
+      continue;
+    }
+    result[key] = obj[key];
+  }
+
+  return result as T;
+}
 
 /** Extracts an `AuthConfig` value from `config`. */
 export function getAuthConfig(
@@ -20,25 +31,11 @@ export function getAuthConfig(
   // Start by checking for the OIDC configurations, since they have required properties
   // which we can use to identify them.
   if (types.isAzureConfig(config)) {
-    return {
-      "tenant-id": config["tenant-id"],
-      "client-id": config["client-id"],
-    } satisfies AzureConfig;
+    return cloneCredential(types.azureConfigSchema, config);
   } else if (types.isAWSConfig(config)) {
-    return {
-      "aws-region": config["aws-region"],
-      "account-id": config["account-id"],
-      "role-name": config["role-name"],
-      domain: config.domain,
-      "domain-owner": config["domain-owner"],
-      audience: config.audience,
-    } satisfies AWSConfig;
+    return cloneCredential(types.awsConfigSchema, config);
   } else if (types.isJFrogConfig(config)) {
-    return {
-      "jfrog-oidc-provider-name": config["jfrog-oidc-provider-name"],
-      "identity-mapping-name": config["identity-mapping-name"],
-      audience: config.audience,
-    } satisfies JFrogConfig;
+    return cloneCredential(types.jfrogConfigSchema, config);
   } else if (types.isToken(config)) {
     // There are three scenarios for non-OIDC authentication based on the registry type:
     //

--- a/src/start-proxy/validation.ts
+++ b/src/start-proxy/validation.ts
@@ -7,10 +7,10 @@ import type { AuthConfig, UsernamePassword } from "./types";
 import * as types from "./types";
 
 /** Constructs a new object from `obj` with only keys that exist in `schema`. */
-export function cloneCredential<
-  T extends json.FromSchema<S>,
-  S extends json.Schema,
->(schema: S, obj: T): T {
+export function cloneCredential<S extends json.Schema>(
+  schema: S,
+  obj: json.FromSchema<S>,
+): json.FromSchema<S> {
   const result = {};
 
   for (const key of Object.keys(schema)) {
@@ -21,7 +21,7 @@ export function cloneCredential<
     result[key] = obj[key];
   }
 
-  return result as T;
+  return result as json.FromSchema<S>;
 }
 
 /** Extracts an `AuthConfig` value from `config`. */

--- a/src/start-proxy/validation.ts
+++ b/src/start-proxy/validation.ts
@@ -30,13 +30,14 @@ export function getAuthConfig(
 ): AuthConfig {
   // Start by checking for the OIDC configurations, since they have required properties
   // which we can use to identify them.
-  if (types.isAzureConfig(config)) {
-    return cloneCredential(types.azureConfigSchema, config);
-  } else if (types.isAWSConfig(config)) {
-    return cloneCredential(types.awsConfigSchema, config);
-  } else if (types.isJFrogConfig(config)) {
-    return cloneCredential(types.jfrogConfigSchema, config);
-  } else if (types.isToken(config)) {
+  for (const oidcSchema of types.oidcSchemas) {
+    if (json.validateSchema(oidcSchema.schema, config)) {
+      return cloneCredential(oidcSchema.schema, config);
+    }
+  }
+
+  // Otherwise, try the basic configuration types.
+  if (types.isToken(config)) {
     // There are three scenarios for non-OIDC authentication based on the registry type:
     //
     // 1. `username`+`token`


### PR DESCRIPTION
This PR primarily adds validation for Cloudsmith and GCP OIDC configurations, so that they can be correctly propagated to the authentication proxy for private package registries when given to the `start-proxy` action as input in GitHub-managed workflows.

The first few commits add a lightweight JSON schema implementation to simplify the specification and validation of different credential objects. The existing private registry configuration types are then migrated to make use of this.

We take advantage of this to simplify some of the validation and testing logic so that we have to update fewer places when adding new configuration types.

Then we add the two new configuration types.

Finally, we add validation for the `replaces-base` setting, which has been around for a while, but wasn't accepted until now.

I'd suggest reviewing this commit-by-commit.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
