### PR TITLE
Improve connection tests

### DIFF
--- a/src/doc-url.ts
+++ b/src/doc-url.ts
@@ -8,6 +8,7 @@ export enum DocUrl {
   CODEQL_BUILD_MODES = "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#codeql-build-modes",
   DEFINE_ENV_VARIABLES = "https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow",
   DELETE_ACTIONS_CACHE_ENTRIES = "https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches#deleting-cache-entries",
+  PRIVATE_REGISTRY_LOGS = "https://docs.github.com/en/code-security/reference/code-scanning/code-scanning-logs#diagnostic-information-for-private-package-registries",
   SCANNING_ON_PUSH = "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#scanning-on-push",
   SPECIFY_BUILD_STEPS_MANUALLY = "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#about-specifying-build-steps-manually",
   SYSTEM_REQUIREMENTS = "https://codeql.github.com/docs/codeql-overview/system-requirements/",

--- a/src/start-proxy-action.ts
+++ b/src/start-proxy-action.ts
@@ -111,7 +111,7 @@ async function run(startedAt: Date) {
       logger,
     );
 
-    // Check that the private registries are reachable.
+    // Perform best-effort checks that the private registries are reachable.
     await checkConnections(logger, proxyInfo);
 
     // Report success if we have reached this point.

--- a/src/start-proxy/reachability.test.ts
+++ b/src/start-proxy/reachability.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./../testing-utils";
 import {
   checkConnections,
+  connectionTestConfig,
   ReachabilityBackend,
   ReachabilityError,
 } from "./reachability";
@@ -117,4 +118,35 @@ test("checkConnections - handles invalid URLs", async (t) => {
     `Skipping check for localhost since it is not a valid URL.`,
     `Finished testing connections`,
   ]);
+});
+
+test("checkConnections - appends extra paths", async (t) => {
+  const backend = new MockReachabilityBackend();
+  const checkConnection = sinon.stub(backend, "checkConnection").resolves(200);
+
+  const messages = await withRecordingLoggerAsync(async (logger) => {
+    const reachable = await checkConnections(
+      logger,
+      {
+        ...proxyInfo,
+        registries: [{ ...nugetFeed, url: "https://api.nuget.org/" }],
+      },
+      backend,
+    );
+  });
+  checkExpectedLogMessages(t, messages, [
+    `Testing connection to https://api.nuget.org/`,
+    `Successfully tested connection to https://api.nuget.org/`,
+    `Finished testing connections`,
+  ]);
+
+  t.true(
+    checkConnection.calledWith(
+      sinon.match(
+        new URL(
+          `https://api.nuget.org/${connectionTestConfig["nuget_feed"]?.path}`,
+        ),
+      ),
+    ),
+  );
 });

--- a/src/start-proxy/reachability.test.ts
+++ b/src/start-proxy/reachability.test.ts
@@ -125,7 +125,7 @@ test("checkConnections - appends extra paths", async (t) => {
   const checkConnection = sinon.stub(backend, "checkConnection").resolves(200);
 
   const messages = await withRecordingLoggerAsync(async (logger) => {
-    const reachable = await checkConnections(
+    await checkConnections(
       logger,
       {
         ...proxyInfo,

--- a/src/start-proxy/reachability.ts
+++ b/src/start-proxy/reachability.ts
@@ -41,7 +41,7 @@ class NetworkReachabilityBackend implements ReachabilityBackend {
         url,
         {
           agent: this.agent,
-          method: "HEAD",
+          method: "GET",
           ca: this.proxy.cert,
           timeout: 5 * 1000, // 5 seconds
         },

--- a/src/start-proxy/reachability.ts
+++ b/src/start-proxy/reachability.ts
@@ -7,6 +7,35 @@ import { getErrorMessage } from "../util";
 
 import { getAddressString, ProxyInfo, Registry } from "./types";
 
+/** Represents registry-specific connection test configurations. */
+export interface ConnectionTestConfig {
+  /** An optional path to append to the end of the base url. */
+  path?: string;
+}
+
+/** A partial mapping of registry types to extra connection test configurations. */
+export const connectionTestConfig: Partial<
+  Record<string, ConnectionTestConfig>
+> = {
+  nuget_feed: { path: "v3/index.json" },
+};
+
+/**
+ * Applies the registry-specific check configuration to the base URL, if any and applicable.
+ */
+export function makeTestUrl(
+  config: ConnectionTestConfig | undefined,
+  base: URL,
+): URL {
+  if (config?.path === undefined) {
+    return base;
+  }
+  if (base.pathname.endsWith(config.path)) {
+    return base;
+  }
+  return new URL(config.path, base);
+}
+
 export class ReachabilityError extends Error {
   constructor(public readonly statusCode?: number | undefined) {
     super();
@@ -92,6 +121,7 @@ export async function checkConnections(
     }
 
     for (const registry of proxy.registries) {
+      const config = connectionTestConfig[registry.type];
       const address = getAddressString(registry);
       const url = URL.parse(address);
 
@@ -102,9 +132,11 @@ export async function checkConnections(
         continue;
       }
 
+      const testUrl = makeTestUrl(config, url);
+
       try {
         logger.debug(`Testing connection to ${url}...`);
-        const statusCode = await backend.checkConnection(url);
+        const statusCode = await backend.checkConnection(testUrl);
 
         logger.info(`Successfully tested connection to ${url} (${statusCode})`);
         result.add(registry);

--- a/src/start-proxy/reachability.ts
+++ b/src/start-proxy/reachability.ts
@@ -2,6 +2,7 @@ import * as https from "https";
 
 import { HttpsProxyAgent } from "https-proxy-agent";
 
+import { DocUrl } from "../doc-url";
 import { Logger } from "../logging";
 import { getErrorMessage } from "../util";
 
@@ -114,6 +115,13 @@ export async function checkConnections(
   // Don't do anything if there are no registries.
   if (proxy.registries.length === 0) return result;
 
+  // Start a log group and print a message with a disclaimer with a link to the
+  // relevant documentation that these checks are a best-effort process.
+  logger.startGroup("Testing connections via the proxy");
+  logger.info(
+    `The connection tests performed here are best-effort only and failures here may not affect the subsequent analysis. See ${DocUrl.PRIVATE_REGISTRY_LOGS} for more information.`,
+  );
+
   try {
     // Initialise a networking backend if no backend was provided.
     if (backend === undefined) {
@@ -158,5 +166,6 @@ export async function checkConnections(
     );
   }
 
+  logger.endGroup();
   return result;
 }


### PR DESCRIPTION
A few minor improvements to the private registry connection checks:

- Use `GET` instead of `HEAD` requests, for better compatibility. Some registries don't like `HEAD` requests. We still call `res.destroy()` immediately after inspecting the status code, so never read the response body. So using `GET` over `HEAD` should have a minimal impact on performance.
- For NuGet feeds, we now test the service index instead of the base URL. The service index should always be present and is more reliable than making a request to the base URL.
- Some logging improvements.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
