### PR TITLE
Improve type checking of test macros

### DIFF
--- a/src/codeql.test.ts
+++ b/src/codeql.test.ts
@@ -17,6 +17,7 @@ import {
   AugmentationProperties,
   generateCodeScanningConfig,
   defaultAugmentationProperties,
+  UserConfig,
 } from "./config/db-config";
 import type { Config } from "./config-utils";
 import * as defaults from "./defaults.json";
@@ -545,7 +546,7 @@ const injectedConfigMacro = test.macro({
     t: ExecutionContext<unknown>,
     augmentationProperties: AugmentationProperties,
     configOverride: Partial<Config>,
-    expectedConfig: any,
+    expectedConfig: UserConfig,
   ) => {
     await util.withTmpDir(async (tempDir) => {
       sinon.stub(actionsUtil, "isDefaultSetup").resolves(false);
@@ -600,7 +601,7 @@ function testInjectedConfig(
   title: string,
   augmentationProperties: AugmentationProperties,
   configOverride: Partial<Config>,
-  expectedConfig: any,
+  expectedConfig: UserConfig,
 ) {
   test.serial(
     title,

--- a/src/codeql.test.ts
+++ b/src/codeql.test.ts
@@ -590,9 +590,29 @@ const injectedConfigMacro = test.macro({
     `databaseInitCluster() injected config: ${providedTitle}`,
 });
 
-test.serial(
+/**
+ * Wraps `injectedConfigMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testInjectedConfig(
+  title: string,
+  augmentationProperties: AugmentationProperties,
+  configOverride: Partial<Config>,
+  expectedConfig: any,
+) {
+  test.serial(
+    title,
+    injectedConfigMacro,
+    augmentationProperties,
+    configOverride,
+    expectedConfig,
+  );
+}
+
+testInjectedConfig(
   "basic",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
   },
@@ -600,9 +620,8 @@ test.serial(
   {},
 );
 
-test.serial(
+testInjectedConfig(
   "injected packs from input",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     packsInput: ["xxx", "yyy"],
@@ -613,9 +632,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "injected packs from input with existing packs combines",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     packsInputCombines: true,
@@ -635,9 +653,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "injected packs from input with existing packs overrides",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     packsInput: ["xxx", "yyy"],
@@ -655,9 +672,8 @@ test.serial(
 );
 
 // similar, but with queries
-test.serial(
+testInjectedConfig(
   "injected queries from input",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInput: [{ uses: "xxx" }, { uses: "yyy" }],
@@ -675,9 +691,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "injected queries from input overrides",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInput: [{ uses: "xxx" }, { uses: "yyy" }],
@@ -699,9 +714,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "injected queries from input combines",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -727,9 +741,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "injected queries from input combines 2",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -749,9 +762,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "injected queries and packs, but empty",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -768,9 +780,8 @@ test.serial(
   {},
 );
 
-test.serial(
+testInjectedConfig(
   "repo property queries have the highest precedence",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -790,9 +801,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "repo property queries combines with queries input",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: false,
@@ -817,9 +827,8 @@ test.serial(
   },
 );
 
-test.serial(
+testInjectedConfig(
   "repo property queries combines everything else",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -1134,8 +1134,28 @@ const checkOverlayEnablementMacro = test.macro({
   title: (_, title) => `checkOverlayEnablement: ${title}`,
 });
 
-test.serial(
-  checkOverlayEnablementMacro,
+/**
+ * Wraps `checkOverlayEnablementMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testCheckOverlayEnablement(
+  title: string,
+  setupOverrides: Partial<OverlayDatabaseModeTestSetup>,
+  expected:
+    | {
+        overlayDatabaseMode: OverlayDatabaseMode;
+        useOverlayDatabaseCaching: boolean;
+      }
+    | {
+        disabledReason: OverlayDisabledReason;
+      },
+) {
+  test.serial(checkOverlayEnablementMacro, title, setupOverrides, expected);
+}
+
+testCheckOverlayEnablement(
   "Environment variable override - Overlay",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1146,8 +1166,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Environment variable override - OverlayBase",
   {
     overlayDatabaseEnvVar: "overlay-base",
@@ -1158,8 +1177,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Environment variable override - None",
   {
     overlayDatabaseEnvVar: "none",
@@ -1169,8 +1187,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Ignore invalid environment variable",
   {
     overlayDatabaseEnvVar: "invalid-mode",
@@ -1180,8 +1197,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Ignore feature flag when analyzing non-default branch",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1192,8 +1208,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay-base database on default branch when feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1206,8 +1221,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay-base database on default branch when feature enabled with custom analysis",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1223,8 +1237,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay-base database on default branch when code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1240,8 +1253,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch if runner disk space is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1260,8 +1272,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch if we can't determine runner disk space",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1277,8 +1288,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay-base database on default branch if runner disk space is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1299,8 +1309,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch if runner disk space is below v2 limit and v2 resource checks enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1320,8 +1329,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay-base database on default branch if runner disk space is between v2 and v1 limits and v2 resource checks enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1342,8 +1350,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch if runner disk space is between v2 and v1 limits and v2 resource checks not enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1362,8 +1369,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch if memory flag is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1379,8 +1385,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay-base database on default branch if memory flag is too low but CodeQL >= 2.24.3",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1398,8 +1403,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay-base database on default branch if memory flag is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1417,8 +1421,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when cached status indicates previous failure",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1435,8 +1438,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when cached status indicates previous failure",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1453,8 +1455,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when code-scanning feature enabled with disable-default-queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1472,8 +1473,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when code-scanning feature enabled with packs",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1491,8 +1491,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when code-scanning feature enabled with queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1510,8 +1509,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when code-scanning feature enabled with query-filters",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1529,8 +1527,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when only language-specific feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1542,8 +1539,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when only code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1555,8 +1551,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay-base database on default branch when language-specific feature disabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1568,8 +1563,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay analysis on PR when feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1582,8 +1576,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay analysis on PR when feature enabled with custom analysis",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1599,8 +1592,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay analysis on PR when code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1616,8 +1608,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR if runner disk space is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1636,8 +1627,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay analysis on PR if runner disk space is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1658,8 +1648,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR if we can't determine runner disk space",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1675,8 +1664,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR if memory flag is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1692,8 +1680,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay analysis on PR if memory flag is too low but CodeQL >= 2.24.3",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1711,8 +1698,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay analysis on PR if memory flag is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1730,8 +1716,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when code-scanning feature enabled with disable-default-queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1749,8 +1734,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when code-scanning feature enabled with packs",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1768,8 +1752,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when code-scanning feature enabled with queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1787,8 +1770,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when code-scanning feature enabled with query-filters",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1806,8 +1788,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when only language-specific feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1819,8 +1800,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when only code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1832,8 +1812,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis on PR when language-specific feature disabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1845,8 +1824,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay PR analysis by env",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1857,8 +1835,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay PR analysis by env on a runner with low disk space",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1870,8 +1847,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay PR analysis by feature flag",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1884,8 +1860,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Fallback due to autobuild with traced language",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1897,8 +1872,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Fallback due to no build mode with traced language",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1910,8 +1884,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Fallback due to old CodeQL version",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1922,8 +1895,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Fallback due to missing git root",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1934,8 +1906,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Fallback due to old git version with submodules",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1947,8 +1918,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Fallback when git version cannot be determined and repo has submodules",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1960,8 +1930,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay enabled when git version cannot be determined and repo has no submodules",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1974,8 +1943,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay when disabled via repository property",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1990,8 +1958,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Overlay not disabled when repository property is false",
   {
     languages: [BuiltInLanguage.javascript],
@@ -2007,8 +1974,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "Environment variable override takes precedence over repository property",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -2023,9 +1989,8 @@ test.serial(
 );
 
 // Exercise language-specific overlay analysis features code paths
-for (const language in BuiltInLanguage) {
-  test.serial(
-    checkOverlayEnablementMacro,
+for (const language of Object.values(BuiltInLanguage)) {
+  testCheckOverlayEnablement(
     `Check default overlay analysis feature for ${language}`,
     {
       languages: [language],
@@ -2042,8 +2007,7 @@ for (const language in BuiltInLanguage) {
 // overlay analysis enabled, even when the base overlay feature flag is on.
 // Using swift here as it doesn't currently have overlay support — update this if
 // swift gains overlay support.
-test.serial(
-  checkOverlayEnablementMacro,
+testCheckOverlayEnablement(
   "No overlay analysis for language without per-language overlay feature flag",
   {
     languages: [BuiltInLanguage.swift],

--- a/src/config/db-config.test.ts
+++ b/src/config/db-config.test.ts
@@ -31,6 +31,21 @@ const parsePacksMacro = test.macro({
 });
 
 /**
+ * Wraps `parsePacksMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testParsePacks(
+  title: string,
+  packsInput: string,
+  languages: Language[],
+  expected: dbConfig.Packs | undefined,
+) {
+  test(title, parsePacksMacro, packsInput, languages, expected);
+}
+
+/**
  * Test macro for testing when the packs block is invalid
  */
 const parsePacksErrorMacro = test.macro({
@@ -61,13 +76,12 @@ const invalidPackNameMacro = test.macro({
     `Invalid pack string: ${arg}`,
 });
 
-test("no packs", parsePacksMacro, "", [], undefined);
-test("two packs", parsePacksMacro, "a/b,c/d@1.2.3", [BuiltInLanguage.cpp], {
+testParsePacks("no packs", "", [], undefined);
+testParsePacks("two packs", "a/b,c/d@1.2.3", [BuiltInLanguage.cpp], {
   [BuiltInLanguage.cpp]: ["a/b", "c/d@1.2.3"],
 });
-test(
+testParsePacks(
   "two packs with spaces",
-  parsePacksMacro,
   " a/b , c/d@1.2.3 ",
   [BuiltInLanguage.cpp],
   {
@@ -85,9 +99,8 @@ test(
   ),
 );
 
-test(
+testParsePacks(
   "packs with other valid names",
-  parsePacksMacro,
   [
     // ranges are ok
     "c/d@1.0",

--- a/src/config/db-config.test.ts
+++ b/src/config/db-config.test.ts
@@ -257,8 +257,32 @@ const calculateAugmentationMacro = test.macro({
   title: (_, title) => `Calculate Augmentation: ${title}`,
 });
 
-test(
-  calculateAugmentationMacro,
+/**
+ * Wraps `calculateAugmentationMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testCalculateAugmentation(
+  title: string,
+  rawPacksInput: string | undefined,
+  rawQueriesInput: string | undefined,
+  languages: Language[],
+  repositoryProperties: RepositoryProperties,
+  expectedAugmentationProperties: dbConfig.AugmentationProperties,
+) {
+  test(
+    calculateAugmentationMacro,
+    title,
+    rawPacksInput,
+    rawQueriesInput,
+    languages,
+    repositoryProperties,
+    expectedAugmentationProperties,
+  );
+}
+
+testCalculateAugmentation(
   "All empty",
   undefined,
   undefined,
@@ -269,8 +293,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+testCalculateAugmentation(
   "With queries",
   undefined,
   " a, b , c, d",
@@ -282,8 +305,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+testCalculateAugmentation(
   "With queries combining",
   undefined,
   "   +   a, b , c, d ",
@@ -296,8 +318,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+testCalculateAugmentation(
   "With packs",
   "   codeql/a , codeql/b   , codeql/c  , codeql/d  ",
   undefined,
@@ -309,8 +330,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+testCalculateAugmentation(
   "With packs combining",
   "   +   codeql/a, codeql/b, codeql/c, codeql/d",
   undefined,
@@ -323,8 +343,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+testCalculateAugmentation(
   "With repo property queries",
   undefined,
   undefined,
@@ -341,8 +360,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+testCalculateAugmentation(
   "With repo property queries combining",
   undefined,
   undefined,

--- a/src/config/db-config.test.ts
+++ b/src/config/db-config.test.ts
@@ -401,8 +401,32 @@ const calculateAugmentationErrorMacro = test.macro({
   title: (_, title) => `Calculate Augmentation Error: ${title}`,
 });
 
-test(
-  calculateAugmentationErrorMacro,
+/**
+ * Wraps `calculateAugmentationErrorMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testCalculateAugmentationError(
+  title: string,
+  rawPacksInput: string | undefined,
+  rawQueriesInput: string | undefined,
+  languages: Language[],
+  repositoryProperties: RepositoryProperties,
+  expectedError: RegExp | string,
+) {
+  test(
+    calculateAugmentationErrorMacro,
+    title,
+    rawPacksInput,
+    rawQueriesInput,
+    languages,
+    repositoryProperties,
+    expectedError,
+  );
+}
+
+testCalculateAugmentationError(
   "Plus (+) with nothing else (queries)",
   undefined,
   "   +   ",
@@ -411,8 +435,7 @@ test(
   /The workflow property "queries" is invalid/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+testCalculateAugmentationError(
   "Plus (+) with nothing else (packs)",
   "   +   ",
   undefined,
@@ -421,8 +444,7 @@ test(
   /The workflow property "packs" is invalid/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+testCalculateAugmentationError(
   "Plus (+) with nothing else (repo property queries)",
   undefined,
   undefined,
@@ -433,8 +455,7 @@ test(
   /The repository property "github-codeql-extra-queries" is invalid/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+testCalculateAugmentationError(
   "Packs input with multiple languages",
   "   +  a/b, c/d ",
   undefined,
@@ -443,8 +464,7 @@ test(
   /Cannot specify a 'packs' input in a multi-language analysis/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+testCalculateAugmentationError(
   "Packs input with no languages",
   "   +  a/b, c/d ",
   undefined,
@@ -453,8 +473,7 @@ test(
   /No languages specified/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+testCalculateAugmentationError(
   "Invalid packs",
   " a-pack-without-a-scope ",
   undefined,

--- a/src/config/db-config.test.ts
+++ b/src/config/db-config.test.ts
@@ -62,6 +62,21 @@ const parsePacksErrorMacro = test.macro({
 });
 
 /**
+ * Wraps `parsePacksErrorMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testParsePacksError(
+  title: string,
+  packsInput: string,
+  languages: Language[],
+  expected: RegExp,
+) {
+  test(title, parsePacksErrorMacro, packsInput, languages, expected);
+}
+
+/**
  * Test macro for testing when the packs block is invalid
  */
 const invalidPackNameMacro = test.macro({
@@ -88,9 +103,8 @@ testParsePacks(
     [BuiltInLanguage.cpp]: ["a/b", "c/d@1.2.3"],
   },
 );
-test(
+testParsePacksError(
   "two packs with language",
-  parsePacksErrorMacro,
   "a/b,c/d@1.2.3",
   [BuiltInLanguage.cpp, BuiltInLanguage.java],
   new RegExp(

--- a/src/config/db-config.test.ts
+++ b/src/config/db-config.test.ts
@@ -200,27 +200,37 @@ const packSpecPrettyPrintingMacro = test.macro({
   ) => `Prettyprint pack spec: '${packStr}'`,
 });
 
-test(packSpecPrettyPrintingMacro, "a/b", {
+/**
+ * Wraps `packSpecPrettyPrintingMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testPackSpecPrettyPrinting(packStr: string, packObj: dbConfig.Pack) {
+  test(packSpecPrettyPrintingMacro, packStr, packObj);
+}
+
+testPackSpecPrettyPrinting("a/b", {
   name: "a/b",
   version: undefined,
   path: undefined,
 });
-test(packSpecPrettyPrintingMacro, "a/b@~1.2.3", {
+testPackSpecPrettyPrinting("a/b@~1.2.3", {
   name: "a/b",
   version: "~1.2.3",
   path: undefined,
 });
-test(packSpecPrettyPrintingMacro, "a/b@~1.2.3:abc/def", {
+testPackSpecPrettyPrinting("a/b@~1.2.3:abc/def", {
   name: "a/b",
   version: "~1.2.3",
   path: "abc/def",
 });
-test(packSpecPrettyPrintingMacro, "a/b:abc/def", {
+testPackSpecPrettyPrinting("a/b:abc/def", {
   name: "a/b",
   version: undefined,
   path: "abc/def",
 });
-test(packSpecPrettyPrintingMacro, "    a/b:abc/def    ", {
+testPackSpecPrettyPrinting("    a/b:abc/def    ", {
   name: "a/b",
   version: undefined,
   path: "abc/def",

--- a/src/config/db-config.test.ts
+++ b/src/config/db-config.test.ts
@@ -91,6 +91,16 @@ const invalidPackNameMacro = test.macro({
     `Invalid pack string: ${arg}`,
 });
 
+/**
+ * Wraps `invalidPackNameMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testInvalidPackName(name: string) {
+  test(invalidPackNameMacro, name);
+}
+
 testParsePacks("no packs", "", [], undefined);
 testParsePacks("two packs", "a/b,c/d@1.2.3", [BuiltInLanguage.cpp], {
   [BuiltInLanguage.cpp]: ["a/b", "c/d@1.2.3"],
@@ -150,18 +160,18 @@ testParsePacks(
   },
 );
 
-test(invalidPackNameMacro, "c"); // all packs require at least a scope and a name
-test(invalidPackNameMacro, "c-/d");
-test(invalidPackNameMacro, "-c/d");
-test(invalidPackNameMacro, "c/d_d");
-test(invalidPackNameMacro, "c/d@@");
-test(invalidPackNameMacro, "c/d@1.0.0:");
-test(invalidPackNameMacro, "c/d:");
-test(invalidPackNameMacro, "c/d:/a");
-test(invalidPackNameMacro, "@1.0.0:a");
-test(invalidPackNameMacro, "c/d@../a");
-test(invalidPackNameMacro, "c/d@b/../a");
-test(invalidPackNameMacro, "c/d:z@1");
+testInvalidPackName("c"); // all packs require at least a scope and a name
+testInvalidPackName("c-/d");
+testInvalidPackName("-c/d");
+testInvalidPackName("c/d_d");
+testInvalidPackName("c/d@@");
+testInvalidPackName("c/d@1.0.0:");
+testInvalidPackName("c/d:");
+testInvalidPackName("c/d:/a");
+testInvalidPackName("@1.0.0:a");
+testInvalidPackName("c/d@../a");
+testInvalidPackName("c/d@b/../a");
+testInvalidPackName("c/d:z@1");
 
 /**
  * Test macro for pretty printing pack specs

--- a/src/diff-informed-analysis-utils.test.ts
+++ b/src/diff-informed-analysis-utils.test.ts
@@ -42,7 +42,7 @@ const defaultTestCase: DiffInformedAnalysisTestCase = {
   codeQLVersion: "2.21.0",
 };
 
-const testShouldPerformDiffInformedAnalysis = test.macro({
+const shouldPerformDiffInformedAnalysisMacro = test.macro({
   exec: async (
     t: ExecutionContext,
     _title: string,
@@ -97,15 +97,32 @@ const testShouldPerformDiffInformedAnalysis = test.macro({
   title: (_, title) => `shouldPerformDiffInformedAnalysis: ${title}`,
 });
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+/**
+ * Wraps `shouldPerformDiffInformedAnalysisMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testShouldPerformDiffInformedAnalysis(
+  title: string,
+  partialTestCase: Partial<DiffInformedAnalysisTestCase>,
+  expectedResult: boolean,
+) {
+  test.serial(
+    shouldPerformDiffInformedAnalysisMacro,
+    title,
+    partialTestCase,
+    expectedResult,
+  );
+}
+
+testShouldPerformDiffInformedAnalysis(
   "returns true in the default test case",
   {},
   true,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns false when feature flag is disabled from the API",
   {
     featureEnabled: false,
@@ -113,8 +130,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns false when CODEQL_ACTION_DIFF_INFORMED_QUERIES is set to false",
   {
     featureEnabled: true,
@@ -123,8 +139,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns true when CODEQL_ACTION_DIFF_INFORMED_QUERIES is set to true",
   {
     featureEnabled: false,
@@ -133,8 +148,7 @@ test.serial(
   true,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns false for CodeQL version 2.20.0",
   {
     codeQLVersion: "2.20.0",
@@ -142,8 +156,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns false for invalid GHES version",
   {
     gitHubVersion: {
@@ -154,8 +167,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns false for GHES version 3.18.5",
   {
     gitHubVersion: {
@@ -166,8 +178,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns true for GHES version 3.19.0",
   {
     gitHubVersion: {
@@ -178,8 +189,7 @@ test.serial(
   true,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis(
   "returns false when not a pull request",
   {
     pullRequestBranches: undefined,

--- a/src/init-action-post-helper.test.ts
+++ b/src/init-action-post-helper.test.ts
@@ -796,7 +796,7 @@ test.serial(
   },
 );
 
-const skippedUploadTest = test.macro({
+const skippedUploadMacro = test.macro({
   exec: async (
     t: ExecutionContext<unknown>,
     config: Partial<configUtils.Config>,
@@ -823,9 +823,22 @@ const skippedUploadTest = test.macro({
     `tryUploadSarifIfRunFailed - skips upload ${providedTitle}`,
 });
 
-test.serial(
+/**
+ * Wraps `skippedUploadMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testSkippedUpload(
+  title: string,
+  config: Partial<configUtils.Config>,
+  expectedSkippedReason: string,
+) {
+  test.serial(title, skippedUploadMacro, config, expectedSkippedReason);
+}
+
+testSkippedUpload(
   "without CodeQL command",
-  skippedUploadTest,
   // No codeQLCmd
   {
     analysisKinds: [AnalysisKind.RiskAssessment],
@@ -834,9 +847,8 @@ test.serial(
   "CodeQL command not found",
 );
 
-test.serial(
+testSkippedUpload(
   "if no language is configured",
-  skippedUploadTest,
   // No explicit language configuration
   {
     analysisKinds: [AnalysisKind.RiskAssessment],
@@ -845,9 +857,8 @@ test.serial(
   "Unexpectedly, the configuration is not for a single language.",
 );
 
-test.serial(
+testSkippedUpload(
   "if multiple languages is configured",
-  skippedUploadTest,
   // Multiple explicit languages configured
   {
     analysisKinds: [AnalysisKind.RiskAssessment],

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -158,7 +158,7 @@ type PackInfo = {
   qlpackFileName?: string;
 };
 
-const testCheckPacksForOverlayCompatibility = test.macro({
+const checkPacksForOverlayCompatibilityMacro = test.macro({
   exec: async (
     t: ExecutionContext,
     _title: string,
@@ -237,8 +237,25 @@ const testCheckPacksForOverlayCompatibility = test.macro({
   title: (_, title) => `checkPacksForOverlayCompatibility: ${title}`,
 });
 
-test(
-  testCheckPacksForOverlayCompatibility,
+/**
+ * Wraps `checkPacksForOverlayCompatibilityMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testCheckPacksForOverlayCompatibility(
+  title: string,
+  args: {
+    cliOverlayVersion: number | undefined;
+    languages: BuiltInLanguage[];
+    packs: Record<string, PackInfo>;
+    expectedResult: boolean;
+  },
+) {
+  test(checkPacksForOverlayCompatibilityMacro, title, args);
+}
+
+testCheckPacksForOverlayCompatibility(
   "returns false when CLI does not support overlay",
   {
     cliOverlayVersion: undefined,
@@ -253,8 +270,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when there are no query packs",
   {
     cliOverlayVersion: 2,
@@ -264,8 +280,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack has not been compiled",
   {
     cliOverlayVersion: 2,
@@ -281,8 +296,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack has expected overlay version",
   {
     cliOverlayVersion: 2,
@@ -297,8 +311,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query packs for all languages to analyze are compatible",
   {
     cliOverlayVersion: 2,
@@ -317,8 +330,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack for a language not analyzed is incompatible",
   {
     cliOverlayVersion: 2,
@@ -337,8 +349,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack for a language to analyze is incompatible",
   {
     cliOverlayVersion: 2,
@@ -357,8 +368,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack is missing .packinfo",
   {
     cliOverlayVersion: 2,
@@ -377,8 +387,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack has different overlay version",
   {
     cliOverlayVersion: 2,
@@ -397,8 +406,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack is missing overlayVersion in .packinfo",
   {
     cliOverlayVersion: 2,
@@ -417,8 +425,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when .packinfo is not valid JSON",
   {
     cliOverlayVersion: 2,
@@ -437,8 +444,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack uses codeql-pack.yml filename",
   {
     cliOverlayVersion: 2,

--- a/src/overlay/caching.test.ts
+++ b/src/overlay/caching.test.ts
@@ -51,7 +51,7 @@ const defaultDownloadTestCase: DownloadOverlayBaseDatabaseTestCase = {
   resolveDatabaseOutput: { overlayBaseSpecifier: "20250626:XXX" },
 };
 
-const testDownloadOverlayBaseDatabaseFromCache = test.macro({
+const downloadOverlayBaseDatabaseFromCacheMacro = test.macro({
   exec: async (
     t,
     _title: string,
@@ -145,15 +145,32 @@ const testDownloadOverlayBaseDatabaseFromCache = test.macro({
   title: (_, title) => `downloadOverlayBaseDatabaseFromCache: ${title}`,
 });
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+/**
+ * Wraps `downloadOverlayBaseDatabaseFromCacheMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testDownloadOverlayBaseDatabaseFromCache(
+  title: string,
+  partialTestCase: Partial<DownloadOverlayBaseDatabaseTestCase>,
+  expectDownloadSuccess: boolean,
+) {
+  test.serial(
+    downloadOverlayBaseDatabaseFromCacheMacro,
+    title,
+    partialTestCase,
+    expectDownloadSuccess,
+  );
+}
+
+testDownloadOverlayBaseDatabaseFromCache(
   "returns stats when successful",
   {},
   true,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when mode is OverlayDatabaseMode.OverlayBase",
   {
     overlayDatabaseMode: OverlayDatabaseMode.OverlayBase,
@@ -161,8 +178,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when mode is OverlayDatabaseMode.None",
   {
     overlayDatabaseMode: OverlayDatabaseMode.None,
@@ -170,8 +186,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when caching is disabled",
   {
     useOverlayDatabaseCaching: false,
@@ -179,8 +194,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined in test mode",
   {
     isInTestMode: true,
@@ -188,8 +202,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when cache miss",
   {
     restoreCacheResult: undefined,
@@ -197,8 +210,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when download fails",
   {
     restoreCacheResult: new Error("Download failed"),
@@ -206,8 +218,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when downloaded database is invalid",
   {
     hasBaseDatabaseOidsFile: false,
@@ -215,8 +226,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when downloaded database doesn't have an overlayBaseSpecifier",
   {
     resolveDatabaseOutput: {},
@@ -224,8 +234,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when resolving database metadata fails",
   {
     resolveDatabaseOutput: new Error("Failed to resolve database metadata"),
@@ -233,8 +242,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache(
   "returns undefined when filesystem error occurs",
   {
     tryGetFolderBytesSucceeds: false,

--- a/src/setup-codeql.test.ts
+++ b/src/setup-codeql.test.ts
@@ -533,9 +533,31 @@ const toolcacheInputFallbackMacro = test.macro({
     `getCodeQLSource falls back to downloading the CLI if ${providedTitle}`,
 });
 
-test.serial(
+/**
+ * Wraps `toolcacheInputFallbackMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testToolcacheInputFallback(
+  title: string,
+  featureList: Feature[],
+  environment: Record<string, string>,
+  testVersions: string[],
+  expectedMessages: string[],
+) {
+  test.serial(
+    title,
+    toolcacheInputFallbackMacro,
+    featureList,
+    environment,
+    testVersions,
+    expectedMessages,
+  );
+}
+
+testToolcacheInputFallback(
   "the toolcache doesn't have a CodeQL CLI when tools == toolcache",
-  toolcacheInputFallbackMacro,
   [Feature.AllowToolcacheInput],
   { GITHUB_EVENT_NAME: "dynamic" },
   [],
@@ -545,9 +567,8 @@ test.serial(
   ],
 );
 
-test.serial(
+testToolcacheInputFallback(
   "the workflow trigger is not `dynamic`",
-  toolcacheInputFallbackMacro,
   [Feature.AllowToolcacheInput],
   { GITHUB_EVENT_NAME: "pull_request" },
   [],
@@ -556,9 +577,8 @@ test.serial(
   ],
 );
 
-test.serial(
+testToolcacheInputFallback(
   "the feature flag is not enabled",
-  toolcacheInputFallbackMacro,
   [],
   { GITHUB_EVENT_NAME: "dynamic" },
   [],

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -32,7 +32,7 @@ import {
 
 setupTests(test);
 
-const sendFailedStatusReportTest = test.macro({
+const sendFailedStatusReportMacro = test.macro({
   exec: async (
     t: ExecutionContext<unknown>,
     err: Error,
@@ -88,16 +88,35 @@ const sendFailedStatusReportTest = test.macro({
   title: (providedTitle = "") => `sendFailedStatusReport - ${providedTitle}`,
 });
 
-test.serial(
+/**
+ * Wraps `sendFailedStatusReportMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testSendFailedStatusReport(
+  title: string,
+  err: Error,
+  expectedMessage: string,
+  expectedStatus: statusReport.ActionStatus = "failure",
+) {
+  test.serial(
+    title,
+    sendFailedStatusReportMacro,
+    err,
+    expectedMessage,
+    expectedStatus,
+  );
+}
+
+testSendFailedStatusReport(
   "reports generic error message for non-StartProxyError error",
-  sendFailedStatusReportTest,
   new Error("Something went wrong today"),
   "Error from start-proxy Action omitted (Error).",
 );
 
-test.serial(
+testSendFailedStatusReport(
   "reports generic error message for non-StartProxyError error with safe error message",
-  sendFailedStatusReportTest,
   new Error(
     startProxyExports.getStartProxyErrorMessage(
       startProxyExports.StartProxyErrorType.DownloadFailed,
@@ -106,9 +125,8 @@ test.serial(
   "Error from start-proxy Action omitted (Error).",
 );
 
-test.serial(
+testSendFailedStatusReport(
   "reports generic error message for ConfigurationError error",
-  sendFailedStatusReportTest,
   new ConfigurationError("Something went wrong today"),
   "Error from start-proxy Action omitted (ConfigurationError).",
   "user-error",

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -458,9 +458,26 @@ const getCredentialsMacro = test.macro({
   title: (providedTitle = "") => `getCredentials - ${providedTitle}`,
 });
 
-test(
+/**
+ * Wraps `getCredentialsMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test(macro, ...)`, the precise
+ * types of the arguments are erased.
+ */
+function testGetCredentials(
+  title: string,
+  credentials: startProxyExports.RawCredential[],
+  checkAccepted: (
+    t: ExecutionContext<unknown>,
+    logger: RecordingLogger,
+    results: startProxyExports.Credential[],
+  ) => void,
+) {
+  test(title, getCredentialsMacro, credentials, checkAccepted);
+}
+
+testGetCredentials(
   "warns for PAT-like password without a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",
@@ -488,9 +505,8 @@ test(
   },
 );
 
-test(
+testGetCredentials(
   "no warning for PAT-like password with a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",
@@ -520,9 +536,8 @@ test(
   },
 );
 
-test(
+testGetCredentials(
   "warns for PAT-like token without a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",
@@ -550,9 +565,8 @@ test(
   },
 );
 
-test(
+testGetCredentials(
   "no warning for PAT-like token with a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -828,7 +828,7 @@ test.serial(
   },
 );
 
-const wrapFailureTest = test.macro({
+const wrapFailureMacro = test.macro({
   exec: async (
     t: ExecutionContext<unknown>,
     setup: () => void,
@@ -845,6 +845,20 @@ const wrapFailureTest = test.macro({
   title: (providedTitle) => `${providedTitle} - wraps errors on failure`,
 });
 
+/**
+ * Wraps `wrapFailureMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testWrapFailure(
+  title: string,
+  setup: () => void,
+  fn: (logger: Logger) => Promise<void>,
+) {
+  test.serial(title, wrapFailureMacro, setup, fn);
+}
+
 test.serial("downloadProxy - returns file path on success", async (t) => {
   await withRecordingLoggerAsync(async (logger) => {
     const testPath = "/some/path";
@@ -859,9 +873,8 @@ test.serial("downloadProxy - returns file path on success", async (t) => {
   });
 });
 
-test.serial(
+testWrapFailure(
   "downloadProxy",
-  wrapFailureTest,
   () => {
     sinon.stub(toolcache, "downloadTool").throws();
   },
@@ -880,9 +893,8 @@ test.serial("extractProxy - returns file path on success", async (t) => {
   });
 });
 
-test.serial(
+testWrapFailure(
   "extractProxy",
-  wrapFailureTest,
   () => {
     sinon.stub(toolcache, "extractTar").throws();
   },
@@ -906,9 +918,8 @@ test.serial("cacheProxy - returns file path on success", async (t) => {
   });
 });
 
-test.serial(
+testWrapFailure(
   "cacheProxy",
-  wrapFailureTest,
   () => {
     sinon.stub(toolcache, "cacheDir").throws();
   },

--- a/src/status-report.test.ts
+++ b/src/status-report.test.ts
@@ -291,7 +291,7 @@ test.serial(
   },
 );
 
-const testCreateInitWithConfigStatusReport = test.macro({
+const createInitWithConfigStatusReportMacro = test.macro({
   exec: async (
     t,
     _title: string,
@@ -340,8 +340,26 @@ const testCreateInitWithConfigStatusReport = test.macro({
   title: (_, title) => `createInitWithConfigStatusReport: ${title}`,
 });
 
-test.serial(
-  testCreateInitWithConfigStatusReport,
+/**
+ * Wraps `createInitWithConfigStatusReportMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testCreateInitWithConfigStatusReport(
+  title: string,
+  config: Config,
+  expectedReportProperties: Partial<InitWithConfigStatusReport>,
+) {
+  test.serial(
+    createInitWithConfigStatusReportMacro,
+    title,
+    config,
+    expectedReportProperties,
+  );
+}
+
+testCreateInitWithConfigStatusReport(
   "returns a value",
   createTestConfig({
     buildMode: BuildMode.None,
@@ -355,8 +373,7 @@ test.serial(
   },
 );
 
-test.serial(
-  testCreateInitWithConfigStatusReport,
+testCreateInitWithConfigStatusReport(
   "includes packs for a single language",
   createTestConfig({
     buildMode: BuildMode.None,
@@ -372,8 +389,7 @@ test.serial(
   },
 );
 
-test.serial(
-  testCreateInitWithConfigStatusReport,
+testCreateInitWithConfigStatusReport(
   "includes packs for multiple languages",
   createTestConfig({
     buildMode: BuildMode.None,

--- a/src/upload-sarif.test.ts
+++ b/src/upload-sarif.test.ts
@@ -123,9 +123,29 @@ const postProcessAndUploadSarifMacro = test.macro({
   title: (providedTitle = "") => `processAndUploadSarif - ${providedTitle}`,
 });
 
-test.serial(
+/**
+ * Wraps `postProcessAndUploadSarifMacro` to improve type checking.
+ *
+ * When the macro is invoked directly, e.g. via `test.serial(macro, ...)`, the
+ * precise types of the arguments are erased.
+ */
+function testPostProcessAndUploadSarif(
+  title: string,
+  sarifFiles: string[],
+  sarifPath: ((tempDir: string) => string) | undefined,
+  expectedResult: Partial<Record<AnalysisKind, UploadSarifExpectedResult>>,
+) {
+  test.serial(
+    title,
+    postProcessAndUploadSarifMacro,
+    sarifFiles,
+    sarifPath,
+    expectedResult,
+  );
+}
+
+testPostProcessAndUploadSarif(
   "SARIF file",
-  postProcessAndUploadSarifMacro,
   ["test.sarif"],
   (tempDir) => path.join(tempDir, "test.sarif"),
   {
@@ -138,9 +158,8 @@ test.serial(
   },
 );
 
-test.serial(
+testPostProcessAndUploadSarif(
   "JSON file",
-  postProcessAndUploadSarifMacro,
   ["test.json"],
   (tempDir) => path.join(tempDir, "test.json"),
   {
@@ -153,9 +172,8 @@ test.serial(
   },
 );
 
-test.serial(
+testPostProcessAndUploadSarif(
   "Code Scanning files",
-  postProcessAndUploadSarifMacro,
   ["test.json", "test.sarif"],
   undefined,
   {
@@ -169,9 +187,8 @@ test.serial(
   },
 );
 
-test.serial(
+testPostProcessAndUploadSarif(
   "Code Quality file",
-  postProcessAndUploadSarifMacro,
   ["test.quality.sarif"],
   (tempDir) => path.join(tempDir, "test.quality.sarif"),
   {
@@ -184,9 +201,8 @@ test.serial(
   },
 );
 
-test.serial(
+testPostProcessAndUploadSarif(
   "Mixed files",
-  postProcessAndUploadSarifMacro,
   ["test.sarif", "test.quality.sarif"],
   undefined,
   {


### PR DESCRIPTION
When invoked via `test` or `test.serial`, detailed argument types are erased and we lose some type safety.

This PR wraps macro invocations in helper functions to ensure each of the arguments to the macros is type checked properly.

Dev/test only change.

