### PR TITLE
Add more strongly typed wrapper around `test.macro`

### DIFF
--- a/.vscode/tests.code-snippets
+++ b/.vscode/tests.code-snippets
@@ -19,7 +19,7 @@
     "scope": "javascript, typescript",
     "prefix": "testMacro",
     "body": [
-      "const ${1:nameMacro} = test.macro({",
+      "const ${1:nameMacro} = makeMacro({",
       "  exec: async (t: ExecutionContext<unknown>) => {},",
       "",
       "  title: (providedTitle = \"\") => `${2:common title} - \\${providedTitle}`,",

--- a/src/codeql.test.ts
+++ b/src/codeql.test.ts
@@ -33,6 +33,7 @@ import {
   mockBundleDownloadApi,
   makeVersionInfo,
   createTestConfig,
+  makeMacro,
 } from "./testing-utils";
 import { ToolsDownloadStatusReport } from "./tools-download";
 import * as util from "./util";
@@ -540,7 +541,7 @@ test.serial("getExtraOptions throws for bad content", (t) => {
 });
 
 // Test macro for ensuring different variants of injected augmented configurations
-const injectedConfigMacro = test.macro({
+const injectedConfigMacro = makeMacro({
   exec: async (
     t: ExecutionContext<unknown>,
     augmentationProperties: AugmentationProperties,
@@ -590,9 +591,8 @@ const injectedConfigMacro = test.macro({
     `databaseInitCluster() injected config: ${providedTitle}`,
 });
 
-test.serial(
+injectedConfigMacro.serial(
   "basic",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
   },
@@ -600,9 +600,8 @@ test.serial(
   {},
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "injected packs from input",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     packsInput: ["xxx", "yyy"],
@@ -613,9 +612,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "injected packs from input with existing packs combines",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     packsInputCombines: true,
@@ -635,9 +633,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "injected packs from input with existing packs overrides",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     packsInput: ["xxx", "yyy"],
@@ -655,9 +652,8 @@ test.serial(
 );
 
 // similar, but with queries
-test.serial(
+injectedConfigMacro.serial(
   "injected queries from input",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInput: [{ uses: "xxx" }, { uses: "yyy" }],
@@ -675,9 +671,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "injected queries from input overrides",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInput: [{ uses: "xxx" }, { uses: "yyy" }],
@@ -699,9 +694,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "injected queries from input combines",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -727,9 +721,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "injected queries from input combines 2",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -749,9 +742,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "injected queries and packs, but empty",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -768,9 +760,8 @@ test.serial(
   {},
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "repo property queries have the highest precedence",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,
@@ -790,9 +781,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "repo property queries combines with queries input",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: false,
@@ -817,9 +807,8 @@ test.serial(
   },
 );
 
-test.serial(
+injectedConfigMacro.serial(
   "repo property queries combines everything else",
-  injectedConfigMacro,
   {
     ...defaultAugmentationProperties,
     queriesInputCombines: true,

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -34,6 +34,7 @@ import {
   LoggedMessage,
   mockCodeQLVersion,
   createTestConfig,
+  makeMacro,
 } from "./testing-utils";
 import {
   GitHubVariant,
@@ -1034,10 +1035,9 @@ const defaultOverlayDatabaseModeTestSetup: OverlayDatabaseModeTestSetup = {
   repositoryProperties: {},
 };
 
-const checkOverlayEnablementMacro = test.macro({
+const checkOverlayEnablementMacro = makeMacro({
   exec: async (
     t: ExecutionContext,
-    _title: string,
     setupOverrides: Partial<OverlayDatabaseModeTestSetup>,
     expected:
       | {
@@ -1131,11 +1131,10 @@ const checkOverlayEnablementMacro = test.macro({
       }
     });
   },
-  title: (_, title) => `checkOverlayEnablement: ${title}`,
+  title: (title) => `checkOverlayEnablement: ${title}`,
 });
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Environment variable override - Overlay",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1146,8 +1145,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Environment variable override - OverlayBase",
   {
     overlayDatabaseEnvVar: "overlay-base",
@@ -1158,8 +1156,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Environment variable override - None",
   {
     overlayDatabaseEnvVar: "none",
@@ -1169,8 +1166,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Ignore invalid environment variable",
   {
     overlayDatabaseEnvVar: "invalid-mode",
@@ -1180,8 +1176,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Ignore feature flag when analyzing non-default branch",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1192,8 +1187,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay-base database on default branch when feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1206,8 +1200,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay-base database on default branch when feature enabled with custom analysis",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1223,8 +1216,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay-base database on default branch when code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1240,8 +1232,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch if runner disk space is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1260,8 +1251,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch if we can't determine runner disk space",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1277,8 +1267,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay-base database on default branch if runner disk space is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1299,8 +1288,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch if runner disk space is below v2 limit and v2 resource checks enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1320,8 +1308,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay-base database on default branch if runner disk space is between v2 and v1 limits and v2 resource checks enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1342,8 +1329,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch if runner disk space is between v2 and v1 limits and v2 resource checks not enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1362,8 +1348,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch if memory flag is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1379,8 +1364,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay-base database on default branch if memory flag is too low but CodeQL >= 2.24.3",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1398,8 +1382,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay-base database on default branch if memory flag is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1417,8 +1400,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when cached status indicates previous failure",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1435,8 +1417,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when cached status indicates previous failure",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1453,8 +1434,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when code-scanning feature enabled with disable-default-queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1472,8 +1452,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when code-scanning feature enabled with packs",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1491,8 +1470,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when code-scanning feature enabled with queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1510,8 +1488,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when code-scanning feature enabled with query-filters",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1529,8 +1506,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when only language-specific feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1542,8 +1518,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when only code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1555,8 +1530,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay-base database on default branch when language-specific feature disabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1568,8 +1542,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay analysis on PR when feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1582,8 +1555,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay analysis on PR when feature enabled with custom analysis",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1599,8 +1571,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay analysis on PR when code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1616,8 +1587,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR if runner disk space is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1636,8 +1606,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay analysis on PR if runner disk space is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1658,8 +1627,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR if we can't determine runner disk space",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1675,8 +1643,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR if memory flag is too low",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1692,8 +1659,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay analysis on PR if memory flag is too low but CodeQL >= 2.24.3",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1711,8 +1677,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay analysis on PR if memory flag is too low and skip resource checks flag is enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1730,8 +1695,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when code-scanning feature enabled with disable-default-queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1749,8 +1713,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when code-scanning feature enabled with packs",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1768,8 +1731,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when code-scanning feature enabled with queries",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1787,8 +1749,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when code-scanning feature enabled with query-filters",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1806,8 +1767,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when only language-specific feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1819,8 +1779,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when only code-scanning feature enabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1832,8 +1791,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis on PR when language-specific feature disabled",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1845,8 +1803,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay PR analysis by env",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1857,8 +1814,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay PR analysis by env on a runner with low disk space",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1870,8 +1826,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay PR analysis by feature flag",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1884,8 +1839,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Fallback due to autobuild with traced language",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1897,8 +1851,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Fallback due to no build mode with traced language",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1910,8 +1863,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Fallback due to old CodeQL version",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1922,8 +1874,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Fallback due to missing git root",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1934,8 +1885,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Fallback due to old git version with submodules",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1947,8 +1897,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Fallback when git version cannot be determined and repo has submodules",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1960,8 +1909,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay enabled when git version cannot be determined and repo has no submodules",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -1974,8 +1922,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay when disabled via repository property",
   {
     languages: [BuiltInLanguage.javascript],
@@ -1990,8 +1937,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Overlay not disabled when repository property is false",
   {
     languages: [BuiltInLanguage.javascript],
@@ -2007,8 +1953,7 @@ test.serial(
   },
 );
 
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "Environment variable override takes precedence over repository property",
   {
     overlayDatabaseEnvVar: "overlay",
@@ -2024,8 +1969,7 @@ test.serial(
 
 // Exercise language-specific overlay analysis features code paths
 for (const language in BuiltInLanguage) {
-  test.serial(
-    checkOverlayEnablementMacro,
+  checkOverlayEnablementMacro.serial(
     `Check default overlay analysis feature for ${language}`,
     {
       languages: [language],
@@ -2042,8 +1986,7 @@ for (const language in BuiltInLanguage) {
 // overlay analysis enabled, even when the base overlay feature flag is on.
 // Using swift here as it doesn't currently have overlay support — update this if
 // swift gains overlay support.
-test.serial(
-  checkOverlayEnablementMacro,
+checkOverlayEnablementMacro.serial(
   "No overlay analysis for language without per-language overlay feature flag",
   {
     languages: [BuiltInLanguage.swift],

--- a/src/config/db-config.test.ts
+++ b/src/config/db-config.test.ts
@@ -7,6 +7,7 @@ import {
   checkExpectedLogMessages,
   getRecordingLogger,
   LoggedMessage,
+  makeMacro,
 } from "../testing-utils";
 import { ConfigurationError, prettyPrintPack } from "../util";
 
@@ -15,7 +16,7 @@ import * as dbConfig from "./db-config";
 /**
  * Test macro for ensuring the packs block is valid
  */
-const parsePacksMacro = test.macro({
+const parsePacksMacro = makeMacro({
   exec: (
     t: ExecutionContext<unknown>,
     packsInput: string,
@@ -33,7 +34,7 @@ const parsePacksMacro = test.macro({
 /**
  * Test macro for testing when the packs block is invalid
  */
-const parsePacksErrorMacro = test.macro({
+const parsePacksErrorMacro = makeMacro({
   exec: (
     t: ExecutionContext<unknown>,
     packsInput: string,
@@ -49,34 +50,32 @@ const parsePacksErrorMacro = test.macro({
 /**
  * Test macro for testing when the packs block is invalid
  */
-const invalidPackNameMacro = test.macro({
-  exec: (t: ExecutionContext, name: string) =>
-    parsePacksErrorMacro.exec(
+const invalidPackNameMacro = makeMacro({
+  exec: (t: ExecutionContext, arg: string) =>
+    parsePacksErrorMacro.fn(
       t,
-      name,
+      arg,
       [BuiltInLanguage.cpp],
-      new RegExp(`^"${name}" is not a valid pack$`),
+      new RegExp(`^"${arg}" is not a valid pack$`),
     ),
   title: (_providedTitle: string | undefined, arg: string | undefined) =>
     `Invalid pack string: ${arg}`,
 });
 
-test("no packs", parsePacksMacro, "", [], undefined);
-test("two packs", parsePacksMacro, "a/b,c/d@1.2.3", [BuiltInLanguage.cpp], {
+parsePacksMacro("no packs", "", [], undefined);
+parsePacksMacro("two packs", "a/b,c/d@1.2.3", [BuiltInLanguage.cpp], {
   [BuiltInLanguage.cpp]: ["a/b", "c/d@1.2.3"],
 });
-test(
+parsePacksMacro(
   "two packs with spaces",
-  parsePacksMacro,
   " a/b , c/d@1.2.3 ",
   [BuiltInLanguage.cpp],
   {
     [BuiltInLanguage.cpp]: ["a/b", "c/d@1.2.3"],
   },
 );
-test(
+parsePacksErrorMacro(
   "two packs with language",
-  parsePacksErrorMacro,
   "a/b,c/d@1.2.3",
   [BuiltInLanguage.cpp, BuiltInLanguage.java],
   new RegExp(
@@ -85,9 +84,8 @@ test(
   ),
 );
 
-test(
+parsePacksMacro(
   "packs with other valid names",
-  parsePacksMacro,
   [
     // ranges are ok
     "c/d@1.0",
@@ -123,23 +121,23 @@ test(
   },
 );
 
-test(invalidPackNameMacro, "c"); // all packs require at least a scope and a name
-test(invalidPackNameMacro, "c-/d");
-test(invalidPackNameMacro, "-c/d");
-test(invalidPackNameMacro, "c/d_d");
-test(invalidPackNameMacro, "c/d@@");
-test(invalidPackNameMacro, "c/d@1.0.0:");
-test(invalidPackNameMacro, "c/d:");
-test(invalidPackNameMacro, "c/d:/a");
-test(invalidPackNameMacro, "@1.0.0:a");
-test(invalidPackNameMacro, "c/d@../a");
-test(invalidPackNameMacro, "c/d@b/../a");
-test(invalidPackNameMacro, "c/d:z@1");
+invalidPackNameMacro.test("c"); // all packs require at least a scope and a name
+invalidPackNameMacro.test("c-/d");
+invalidPackNameMacro.test("-c/d");
+invalidPackNameMacro.test("c/d_d");
+invalidPackNameMacro.test("c/d@@");
+invalidPackNameMacro.test("c/d@1.0.0:");
+invalidPackNameMacro.test("c/d:");
+invalidPackNameMacro.test("c/d:/a");
+invalidPackNameMacro.test("@1.0.0:a");
+invalidPackNameMacro.test("c/d@../a");
+invalidPackNameMacro.test("c/d@b/../a");
+invalidPackNameMacro.test("c/d:z@1");
 
 /**
  * Test macro for pretty printing pack specs
  */
-const packSpecPrettyPrintingMacro = test.macro({
+const packSpecPrettyPrintingMacro = makeMacro({
   exec: (t: ExecutionContext, packStr: string, packObj: dbConfig.Pack) => {
     const parsed = dbConfig.parsePacksSpecification(packStr);
     t.deepEqual(parsed, packObj, "parsed pack spec is correct");
@@ -163,36 +161,35 @@ const packSpecPrettyPrintingMacro = test.macro({
   ) => `Prettyprint pack spec: '${packStr}'`,
 });
 
-test(packSpecPrettyPrintingMacro, "a/b", {
+packSpecPrettyPrintingMacro.test("a/b", {
   name: "a/b",
   version: undefined,
   path: undefined,
 });
-test(packSpecPrettyPrintingMacro, "a/b@~1.2.3", {
+packSpecPrettyPrintingMacro.test("a/b@~1.2.3", {
   name: "a/b",
   version: "~1.2.3",
   path: undefined,
 });
-test(packSpecPrettyPrintingMacro, "a/b@~1.2.3:abc/def", {
+packSpecPrettyPrintingMacro.test("a/b@~1.2.3:abc/def", {
   name: "a/b",
   version: "~1.2.3",
   path: "abc/def",
 });
-test(packSpecPrettyPrintingMacro, "a/b:abc/def", {
+packSpecPrettyPrintingMacro.test("a/b:abc/def", {
   name: "a/b",
   version: undefined,
   path: "abc/def",
 });
-test(packSpecPrettyPrintingMacro, "    a/b:abc/def    ", {
+packSpecPrettyPrintingMacro.test("    a/b:abc/def    ", {
   name: "a/b",
   version: undefined,
   path: "abc/def",
 });
 
-const calculateAugmentationMacro = test.macro({
+const calculateAugmentationMacro = makeMacro({
   exec: async (
     t: ExecutionContext,
-    _title: string,
     rawPacksInput: string | undefined,
     rawQueriesInput: string | undefined,
     languages: Language[],
@@ -207,11 +204,10 @@ const calculateAugmentationMacro = test.macro({
     );
     t.deepEqual(actualAugmentationProperties, expectedAugmentationProperties);
   },
-  title: (_, title) => `Calculate Augmentation: ${title}`,
+  title: (title) => `Calculate Augmentation: ${title}`,
 });
 
-test(
-  calculateAugmentationMacro,
+calculateAugmentationMacro(
   "All empty",
   undefined,
   undefined,
@@ -222,8 +218,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+calculateAugmentationMacro(
   "With queries",
   undefined,
   " a, b , c, d",
@@ -235,8 +230,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+calculateAugmentationMacro(
   "With queries combining",
   undefined,
   "   +   a, b , c, d ",
@@ -249,8 +243,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+calculateAugmentationMacro(
   "With packs",
   "   codeql/a , codeql/b   , codeql/c  , codeql/d  ",
   undefined,
@@ -262,8 +255,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+calculateAugmentationMacro(
   "With packs combining",
   "   +   codeql/a, codeql/b, codeql/c, codeql/d",
   undefined,
@@ -276,8 +268,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+calculateAugmentationMacro(
   "With repo property queries",
   undefined,
   undefined,
@@ -294,8 +285,7 @@ test(
   },
 );
 
-test(
-  calculateAugmentationMacro,
+calculateAugmentationMacro(
   "With repo property queries combining",
   undefined,
   undefined,
@@ -312,10 +302,9 @@ test(
   },
 );
 
-const calculateAugmentationErrorMacro = test.macro({
+const calculateAugmentationErrorMacro = makeMacro({
   exec: async (
     t: ExecutionContext,
-    _title: string,
     rawPacksInput: string | undefined,
     rawQueriesInput: string | undefined,
     languages: Language[],
@@ -333,11 +322,10 @@ const calculateAugmentationErrorMacro = test.macro({
       { message: expectedError },
     );
   },
-  title: (_, title) => `Calculate Augmentation Error: ${title}`,
+  title: (title) => `Calculate Augmentation Error: ${title}`,
 });
 
-test(
-  calculateAugmentationErrorMacro,
+calculateAugmentationErrorMacro(
   "Plus (+) with nothing else (queries)",
   undefined,
   "   +   ",
@@ -346,8 +334,7 @@ test(
   /The workflow property "queries" is invalid/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+calculateAugmentationErrorMacro(
   "Plus (+) with nothing else (packs)",
   "   +   ",
   undefined,
@@ -356,8 +343,7 @@ test(
   /The workflow property "packs" is invalid/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+calculateAugmentationErrorMacro(
   "Plus (+) with nothing else (repo property queries)",
   undefined,
   undefined,
@@ -368,8 +354,7 @@ test(
   /The repository property "github-codeql-extra-queries" is invalid/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+calculateAugmentationErrorMacro(
   "Packs input with multiple languages",
   "   +  a/b, c/d ",
   undefined,
@@ -378,8 +363,7 @@ test(
   /Cannot specify a 'packs' input in a multi-language analysis/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+calculateAugmentationErrorMacro(
   "Packs input with no languages",
   "   +  a/b, c/d ",
   undefined,
@@ -388,8 +372,7 @@ test(
   /No languages specified/,
 );
 
-test(
-  calculateAugmentationErrorMacro,
+calculateAugmentationErrorMacro(
   "Invalid packs",
   " a-pack-without-a-scope ",
   undefined,

--- a/src/diff-informed-analysis-utils.test.ts
+++ b/src/diff-informed-analysis-utils.test.ts
@@ -16,6 +16,7 @@ import {
   mockCodeQLVersion,
   mockFeatureFlagApiEndpoint,
   setupActionsVars,
+  makeMacro,
 } from "./testing-utils";
 import { GitHubVariant, withTmpDir } from "./util";
 import type { GitHubVersion } from "./util";
@@ -42,10 +43,9 @@ const defaultTestCase: DiffInformedAnalysisTestCase = {
   codeQLVersion: "2.21.0",
 };
 
-const testShouldPerformDiffInformedAnalysis = test.macro({
+const testShouldPerformDiffInformedAnalysis = makeMacro({
   exec: async (
     t: ExecutionContext,
-    _title: string,
     partialTestCase: Partial<DiffInformedAnalysisTestCase>,
     expectedResult: boolean,
   ) => {
@@ -94,18 +94,16 @@ const testShouldPerformDiffInformedAnalysis = test.macro({
       getPullRequestBranchesStub.restore();
     });
   },
-  title: (_, title) => `shouldPerformDiffInformedAnalysis: ${title}`,
+  title: (title) => `shouldPerformDiffInformedAnalysis: ${title}`,
 });
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns true in the default test case",
   {},
   true,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns false when feature flag is disabled from the API",
   {
     featureEnabled: false,
@@ -113,8 +111,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns false when CODEQL_ACTION_DIFF_INFORMED_QUERIES is set to false",
   {
     featureEnabled: true,
@@ -123,8 +120,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns true when CODEQL_ACTION_DIFF_INFORMED_QUERIES is set to true",
   {
     featureEnabled: false,
@@ -133,8 +129,7 @@ test.serial(
   true,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns false for CodeQL version 2.20.0",
   {
     codeQLVersion: "2.20.0",
@@ -142,8 +137,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns false for invalid GHES version",
   {
     gitHubVersion: {
@@ -154,8 +148,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns false for GHES version 3.18.5",
   {
     gitHubVersion: {
@@ -166,8 +159,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns true for GHES version 3.19.0",
   {
     gitHubVersion: {
@@ -178,8 +170,7 @@ test.serial(
   true,
 );
 
-test.serial(
-  testShouldPerformDiffInformedAnalysis,
+testShouldPerformDiffInformedAnalysis.serial(
   "returns false when not a pull request",
   {
     pullRequestBranches: undefined,

--- a/src/init-action-post-helper.test.ts
+++ b/src/init-action-post-helper.test.ts
@@ -19,6 +19,7 @@ import {
   createFeatures,
   createTestConfig,
   DEFAULT_ACTIONS_VARS,
+  makeMacro,
   makeVersionInfo,
   RecordingLogger,
   setupActionsVars,
@@ -796,7 +797,7 @@ test.serial(
   },
 );
 
-const skippedUploadTest = test.macro({
+const skippedUploadTest = makeMacro({
   exec: async (
     t: ExecutionContext<unknown>,
     config: Partial<configUtils.Config>,
@@ -823,9 +824,8 @@ const skippedUploadTest = test.macro({
     `tryUploadSarifIfRunFailed - skips upload ${providedTitle}`,
 });
 
-test.serial(
+skippedUploadTest.serial(
   "without CodeQL command",
-  skippedUploadTest,
   // No codeQLCmd
   {
     analysisKinds: [AnalysisKind.RiskAssessment],
@@ -834,9 +834,8 @@ test.serial(
   "CodeQL command not found",
 );
 
-test.serial(
+skippedUploadTest.serial(
   "if no language is configured",
-  skippedUploadTest,
   // No explicit language configuration
   {
     analysisKinds: [AnalysisKind.RiskAssessment],
@@ -845,9 +844,8 @@ test.serial(
   "Unexpectedly, the configuration is not for a single language.",
 );
 
-test.serial(
+skippedUploadTest.serial(
   "if multiple languages is configured",
-  skippedUploadTest,
   // Multiple explicit languages configured
   {
     analysisKinds: [AnalysisKind.RiskAssessment],

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -22,6 +22,7 @@ import {
   createTestConfig,
   getRecordingLogger,
   setupTests,
+  makeMacro,
 } from "./testing-utils";
 import { ConfigurationError, withTmpDir } from "./util";
 
@@ -158,10 +159,9 @@ type PackInfo = {
   qlpackFileName?: string;
 };
 
-const testCheckPacksForOverlayCompatibility = test.macro({
+const testCheckPacksForOverlayCompatibility = makeMacro({
   exec: async (
     t: ExecutionContext,
-    _title: string,
     {
       cliOverlayVersion,
       languages,
@@ -234,11 +234,10 @@ const testCheckPacksForOverlayCompatibility = test.macro({
       );
     });
   },
-  title: (_, title) => `checkPacksForOverlayCompatibility: ${title}`,
+  title: (title) => `checkPacksForOverlayCompatibility: ${title}`,
 });
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when CLI does not support overlay",
   {
     cliOverlayVersion: undefined,
@@ -253,8 +252,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when there are no query packs",
   {
     cliOverlayVersion: 2,
@@ -264,8 +262,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack has not been compiled",
   {
     cliOverlayVersion: 2,
@@ -281,8 +278,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack has expected overlay version",
   {
     cliOverlayVersion: 2,
@@ -297,8 +293,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query packs for all languages to analyze are compatible",
   {
     cliOverlayVersion: 2,
@@ -317,8 +312,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack for a language not analyzed is incompatible",
   {
     cliOverlayVersion: 2,
@@ -337,8 +331,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack for a language to analyze is incompatible",
   {
     cliOverlayVersion: 2,
@@ -357,8 +350,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack is missing .packinfo",
   {
     cliOverlayVersion: 2,
@@ -377,8 +369,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack has different overlay version",
   {
     cliOverlayVersion: 2,
@@ -397,8 +388,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when query pack is missing overlayVersion in .packinfo",
   {
     cliOverlayVersion: 2,
@@ -417,8 +407,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns false when .packinfo is not valid JSON",
   {
     cliOverlayVersion: 2,
@@ -437,8 +426,7 @@ test(
   },
 );
 
-test(
-  testCheckPacksForOverlayCompatibility,
+testCheckPacksForOverlayCompatibility(
   "returns true when query pack uses codeql-pack.yml filename",
   {
     cliOverlayVersion: 2,

--- a/src/overlay/caching.test.ts
+++ b/src/overlay/caching.test.ts
@@ -13,6 +13,7 @@ import { BuiltInLanguage } from "../languages";
 import { getRunnerLogger } from "../logging";
 import {
   createTestConfig,
+  makeMacro,
   mockCodeQLVersion,
   setupTests,
 } from "../testing-utils";
@@ -51,10 +52,9 @@ const defaultDownloadTestCase: DownloadOverlayBaseDatabaseTestCase = {
   resolveDatabaseOutput: { overlayBaseSpecifier: "20250626:XXX" },
 };
 
-const testDownloadOverlayBaseDatabaseFromCache = test.macro({
+const testDownloadOverlayBaseDatabaseFromCache = makeMacro({
   exec: async (
     t,
-    _title: string,
     partialTestCase: Partial<DownloadOverlayBaseDatabaseTestCase>,
     expectDownloadSuccess: boolean,
   ) => {
@@ -142,18 +142,16 @@ const testDownloadOverlayBaseDatabaseFromCache = test.macro({
       }
     });
   },
-  title: (_, title) => `downloadOverlayBaseDatabaseFromCache: ${title}`,
+  title: (title) => `downloadOverlayBaseDatabaseFromCache: ${title}`,
 });
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns stats when successful",
   {},
   true,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when mode is OverlayDatabaseMode.OverlayBase",
   {
     overlayDatabaseMode: OverlayDatabaseMode.OverlayBase,
@@ -161,8 +159,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when mode is OverlayDatabaseMode.None",
   {
     overlayDatabaseMode: OverlayDatabaseMode.None,
@@ -170,8 +167,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when caching is disabled",
   {
     useOverlayDatabaseCaching: false,
@@ -179,8 +175,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined in test mode",
   {
     isInTestMode: true,
@@ -188,8 +183,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when cache miss",
   {
     restoreCacheResult: undefined,
@@ -197,8 +191,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when download fails",
   {
     restoreCacheResult: new Error("Download failed"),
@@ -206,8 +199,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when downloaded database is invalid",
   {
     hasBaseDatabaseOidsFile: false,
@@ -215,8 +207,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when downloaded database doesn't have an overlayBaseSpecifier",
   {
     resolveDatabaseOutput: {},
@@ -224,8 +215,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when resolving database metadata fails",
   {
     resolveDatabaseOutput: new Error("Failed to resolve database metadata"),
@@ -233,8 +223,7 @@ test.serial(
   false,
 );
 
-test.serial(
-  testDownloadOverlayBaseDatabaseFromCache,
+testDownloadOverlayBaseDatabaseFromCache.serial(
   "returns undefined when filesystem error occurs",
   {
     tryGetFolderBytesSucceeds: false,

--- a/src/setup-codeql.test.ts
+++ b/src/setup-codeql.test.ts
@@ -20,6 +20,7 @@ import {
   createFeatures,
   getRecordingLogger,
   initializeFeatures,
+  makeMacro,
   mockBundleDownloadApi,
   setupActionsVars,
   setupTests,
@@ -473,7 +474,7 @@ test.serial(
   },
 );
 
-const toolcacheInputFallbackMacro = test.macro({
+const toolcacheInputFallbackMacro = makeMacro({
   exec: async (
     t: ExecutionContext<unknown>,
     featureList: Feature[],
@@ -533,9 +534,8 @@ const toolcacheInputFallbackMacro = test.macro({
     `getCodeQLSource falls back to downloading the CLI if ${providedTitle}`,
 });
 
-test.serial(
+toolcacheInputFallbackMacro.serial(
   "the toolcache doesn't have a CodeQL CLI when tools == toolcache",
-  toolcacheInputFallbackMacro,
   [Feature.AllowToolcacheInput],
   { GITHUB_EVENT_NAME: "dynamic" },
   [],
@@ -545,9 +545,8 @@ test.serial(
   ],
 );
 
-test.serial(
+toolcacheInputFallbackMacro.serial(
   "the workflow trigger is not `dynamic`",
-  toolcacheInputFallbackMacro,
   [Feature.AllowToolcacheInput],
   { GITHUB_EVENT_NAME: "pull_request" },
   [],
@@ -556,9 +555,8 @@ test.serial(
   ],
 );
 
-test.serial(
+toolcacheInputFallbackMacro.serial(
   "the feature flag is not enabled",
-  toolcacheInputFallbackMacro,
   [],
   { GITHUB_EVENT_NAME: "dynamic" },
   [],

--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -18,6 +18,7 @@ import {
   assertNotLogged,
   checkExpectedLogMessages,
   createFeatures,
+  makeMacro,
   makeTestToken,
   RecordingLogger,
   setupTests,
@@ -32,7 +33,7 @@ import {
 
 setupTests(test);
 
-const sendFailedStatusReportTest = test.macro({
+const sendFailedStatusReportTest = makeMacro({
   exec: async (
     t: ExecutionContext<unknown>,
     err: Error,
@@ -88,16 +89,14 @@ const sendFailedStatusReportTest = test.macro({
   title: (providedTitle = "") => `sendFailedStatusReport - ${providedTitle}`,
 });
 
-test.serial(
+sendFailedStatusReportTest.serial(
   "reports generic error message for non-StartProxyError error",
-  sendFailedStatusReportTest,
   new Error("Something went wrong today"),
   "Error from start-proxy Action omitted (Error).",
 );
 
-test.serial(
+sendFailedStatusReportTest.serial(
   "reports generic error message for non-StartProxyError error with safe error message",
-  sendFailedStatusReportTest,
   new Error(
     startProxyExports.getStartProxyErrorMessage(
       startProxyExports.StartProxyErrorType.DownloadFailed,
@@ -106,9 +105,8 @@ test.serial(
   "Error from start-proxy Action omitted (Error).",
 );
 
-test.serial(
+sendFailedStatusReportTest.serial(
   "reports generic error message for ConfigurationError error",
-  sendFailedStatusReportTest,
   new ConfigurationError("Something went wrong today"),
   "Error from start-proxy Action omitted (ConfigurationError).",
   "user-error",
@@ -414,7 +412,7 @@ test("getCredentials accepts OIDC configurations", (t) => {
   }
 });
 
-const getCredentialsMacro = test.macro({
+const getCredentialsMacro = makeMacro({
   exec: async (
     t: ExecutionContext<unknown>,
     credentials: startProxyExports.RawCredential[],
@@ -440,9 +438,8 @@ const getCredentialsMacro = test.macro({
   title: (providedTitle = "") => `getCredentials - ${providedTitle}`,
 });
 
-test(
+getCredentialsMacro(
   "warns for PAT-like password without a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",
@@ -470,9 +467,8 @@ test(
   },
 );
 
-test(
+getCredentialsMacro(
   "no warning for PAT-like password with a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",
@@ -502,9 +498,8 @@ test(
   },
 );
 
-test(
+getCredentialsMacro(
   "warns for PAT-like token without a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",
@@ -532,9 +527,8 @@ test(
   },
 );
 
-test(
+getCredentialsMacro(
   "no warning for PAT-like token with a username",
-  getCredentialsMacro,
   [
     {
       type: "git_server",
@@ -796,7 +790,7 @@ test.serial(
   },
 );
 
-const wrapFailureTest = test.macro({
+const wrapFailureTest = makeMacro({
   exec: async (
     t: ExecutionContext<unknown>,
     setup: () => void,
@@ -827,9 +821,8 @@ test.serial("downloadProxy - returns file path on success", async (t) => {
   });
 });
 
-test.serial(
+wrapFailureTest.serial(
   "downloadProxy",
-  wrapFailureTest,
   () => {
     sinon.stub(toolcache, "downloadTool").throws();
   },
@@ -848,9 +841,8 @@ test.serial("extractProxy - returns file path on success", async (t) => {
   });
 });
 
-test.serial(
+wrapFailureTest.serial(
   "extractProxy",
-  wrapFailureTest,
   () => {
     sinon.stub(toolcache, "extractTar").throws();
   },
@@ -874,9 +866,8 @@ test.serial("cacheProxy - returns file path on success", async (t) => {
   });
 });
 
-test.serial(
+wrapFailureTest.serial(
   "cacheProxy",
-  wrapFailureTest,
   () => {
     sinon.stub(toolcache, "cacheDir").throws();
   },

--- a/src/status-report.test.ts
+++ b/src/status-report.test.ts
@@ -19,6 +19,7 @@ import {
   setupTests,
   setupActionsVars,
   createTestConfig,
+  makeMacro,
 } from "./testing-utils";
 import { BuildMode, ConfigurationError, withTmpDir, wrapError } from "./util";
 
@@ -291,10 +292,9 @@ test.serial(
   },
 );
 
-const testCreateInitWithConfigStatusReport = test.macro({
+const testCreateInitWithConfigStatusReport = makeMacro({
   exec: async (
     t,
-    _title: string,
     config: Config,
     expectedReportProperties: Partial<InitWithConfigStatusReport>,
   ) => {
@@ -337,11 +337,10 @@ const testCreateInitWithConfigStatusReport = test.macro({
       }
     });
   },
-  title: (_, title) => `createInitWithConfigStatusReport: ${title}`,
+  title: (title) => `createInitWithConfigStatusReport: ${title}`,
 });
 
-test.serial(
-  testCreateInitWithConfigStatusReport,
+testCreateInitWithConfigStatusReport.serial(
   "returns a value",
   createTestConfig({
     buildMode: BuildMode.None,
@@ -355,8 +354,7 @@ test.serial(
   },
 );
 
-test.serial(
-  testCreateInitWithConfigStatusReport,
+testCreateInitWithConfigStatusReport.serial(
   "includes packs for a single language",
   createTestConfig({
     buildMode: BuildMode.None,
@@ -372,8 +370,7 @@ test.serial(
   },
 );
 
-test.serial(
-  testCreateInitWithConfigStatusReport,
+testCreateInitWithConfigStatusReport.serial(
   "includes packs for multiple languages",
   createTestConfig({
     buildMode: BuildMode.None,

--- a/src/testing-utils.ts
+++ b/src/testing-utils.ts
@@ -2,7 +2,11 @@ import { TextDecoder } from "node:util";
 import path from "path";
 
 import * as github from "@actions/github";
-import { ExecutionContext, TestFn } from "ava";
+import test, {
+  type ExecutionContext,
+  type MacroDeclarationOptions,
+  type TestFn,
+} from "ava";
 import nock from "nock";
 import * as sinon from "sinon";
 
@@ -85,8 +89,8 @@ function wrapOutput(context: TestContext) {
   };
 }
 
-export function setupTests(test: TestFn<any>) {
-  const typedTest = test as TestFn<TestContext>;
+export function setupTests(testFn: TestFn<any>) {
+  const typedTest = testFn as TestFn<TestContext>;
 
   typedTest.beforeEach((t) => {
     // Set an empty CodeQL object so that all method calls will fail
@@ -137,6 +141,26 @@ export function setupTests(test: TestFn<any>) {
     // Undo any modifications to the env
     process.env = t.context.env;
   });
+}
+
+/**
+ * Declare a reusable test implementation, with better type safety than `test.macro`.
+ */
+export function makeMacro<Args extends unknown[]>(
+  decl: MacroDeclarationOptions<Args, unknown>,
+) {
+  const m = test.macro<Args>(decl);
+
+  const wrapper = (name: string, ...args: Args) => test(name, m, ...args);
+  wrapper.test = (...args: Args) => test(m, ...args);
+  wrapper.serial = (name: string, ...args: Args) =>
+    test.serial(name, m, ...args);
+  // Make the implementation available as `fn`. We don't call it `exec` so
+  // that results from this function are not valid arguments to `test`
+  // or `test.serial`.
+  wrapper.fn = decl.exec;
+
+  return wrapper;
 }
 
 /**

--- a/src/upload-sarif.test.ts
+++ b/src/upload-sarif.test.ts
@@ -6,7 +6,7 @@ import * as sinon from "sinon";
 
 import { AnalysisKind, getAnalysisConfig } from "./analyses";
 import { getRunnerLogger } from "./logging";
-import { createFeatures, setupTests } from "./testing-utils";
+import { createFeatures, makeMacro, setupTests } from "./testing-utils";
 import { UploadResult } from "./upload-lib";
 import * as uploadLib from "./upload-lib";
 import { postProcessAndUploadSarif } from "./upload-sarif";
@@ -43,7 +43,7 @@ function mockPostProcessSarifFiles() {
   return postProcessSarifFiles;
 }
 
-const postProcessAndUploadSarifMacro = test.macro({
+const postProcessAndUploadSarifMacro = makeMacro({
   exec: async (
     t: ExecutionContext<unknown>,
     sarifFiles: string[],
@@ -123,9 +123,8 @@ const postProcessAndUploadSarifMacro = test.macro({
   title: (providedTitle = "") => `processAndUploadSarif - ${providedTitle}`,
 });
 
-test.serial(
+postProcessAndUploadSarifMacro.serial(
   "SARIF file",
-  postProcessAndUploadSarifMacro,
   ["test.sarif"],
   (tempDir) => path.join(tempDir, "test.sarif"),
   {
@@ -138,9 +137,8 @@ test.serial(
   },
 );
 
-test.serial(
+postProcessAndUploadSarifMacro.serial(
   "JSON file",
-  postProcessAndUploadSarifMacro,
   ["test.json"],
   (tempDir) => path.join(tempDir, "test.json"),
   {
@@ -153,9 +151,8 @@ test.serial(
   },
 );
 
-test.serial(
+postProcessAndUploadSarifMacro.serial(
   "Code Scanning files",
-  postProcessAndUploadSarifMacro,
   ["test.json", "test.sarif"],
   undefined,
   {
@@ -169,9 +166,8 @@ test.serial(
   },
 );
 
-test.serial(
+postProcessAndUploadSarifMacro.serial(
   "Code Quality file",
-  postProcessAndUploadSarifMacro,
   ["test.quality.sarif"],
   (tempDir) => path.join(tempDir, "test.quality.sarif"),
   {
@@ -184,9 +180,8 @@ test.serial(
   },
 );
 
-test.serial(
+postProcessAndUploadSarifMacro.serial(
   "Mixed files",
-  postProcessAndUploadSarifMacro,
   ["test.sarif", "test.quality.sarif"],
   undefined,
   {


### PR DESCRIPTION
When defining a test macro using `test.macro`, the argument types are not strongly enforced when the macro is used with `test`, `test.serial`, etc. 

This PR adds a `makeMacro` helper which returns a wrapper around a macro that enforces the argument types.

Replaces #3873.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Other** - Please provide details.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
