### PR TITLE
CI: Automatically cancel non-generated workflows

### DIFF
--- a/.github/workflows/check-expected-release-files.yml
+++ b/.github/workflows/check-expected-release-files.yml
@@ -9,6 +9,10 @@ on:
     # by other workflows.
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -24,6 +24,10 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/debug-artifacts-failure-safe.yml
+++ b/.github/workflows/debug-artifacts-failure-safe.yml
@@ -20,6 +20,10 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/debug-artifacts-safe.yml
+++ b/.github/workflows/debug-artifacts-safe.yml
@@ -19,6 +19,10 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,10 @@ on:
     types: [checks_requested]
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/python312-windows.yml
+++ b/.github/workflows/python312-windows.yml
@@ -14,6 +14,10 @@ on:
     - cron: '0 0 * * 1'
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/query-filters.yml
+++ b/.github/workflows/query-filters.yml
@@ -17,6 +17,10 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/test-codeql-bundle-all.yml
+++ b/.github/workflows/test-codeql-bundle-all.yml
@@ -18,6 +18,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
+
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Specify concurrency groups for non-generated workflows so we can cancel in-progress runs when new commits are pushed to a PR.