### PR TITLE
Fix ghs_ token regex: rebuild lib/ bundle and add missing hyphen

### DIFF
--- a/src/artifact-scanner.test.ts
+++ b/src/artifact-scanner.test.ts
@@ -23,6 +23,9 @@ test("makeTestToken", (t) => {
   t.is(makeTestToken(255).length, 255);
 });
 
+const NEW_FORMAT_GHS_TOKEN =
+  "ghs_abc123.def456.ghi789_abc123.def456.ghi789";
+
 test("isAuthToken", (t) => {
   // Undefined for strings that aren't tokens
   t.is(isAuthToken("some string"), undefined);
@@ -32,9 +35,10 @@ test("isAuthToken", (t) => {
   // Token types for strings that are tokens.
   t.is(isAuthToken(`ghp_${makeTestToken()}`), TokenType.PersonalAccessClassic);
   t.is(isAuthToken(`ghp_${makeTestToken()}`), TokenType.PersonalAccessClassic);
+  t.is(isAuthToken(NEW_FORMAT_GHS_TOKEN), TokenType.ServerToServer);
   t.is(
     isAuthToken(`ghs_${makeTestToken(255)}`),
-    TokenType.AppInstallationAccess,
+    TokenType.ServerToServer,
   );
   t.is(
     isAuthToken(`github_pat_${makeTestToken(22)}_${makeTestToken(59)}`),
@@ -51,6 +55,15 @@ test("isAuthToken", (t) => {
       GITHUB_PAT_CLASSIC_PATTERN,
     ]),
     undefined,
+  );
+  t.is(
+    isAuthToken(NEW_FORMAT_GHS_TOKEN, [
+      {
+        type: TokenType.AppInstallationAccess,
+        pattern: /ghs_[A-Za-z0-9._]{36,}/g,
+      },
+    ]),
+    TokenType.AppInstallationAccess,
   );
 });
 
@@ -76,15 +89,11 @@ const testTokens = [
   },
   {
     type: TokenType.ServerToServer,
-    value: `ghs_${makeTestToken()}`,
+    value: NEW_FORMAT_GHS_TOKEN,
   },
   {
     type: TokenType.Refresh,
     value: `ghr_${makeTestToken()}`,
-  },
-  {
-    type: TokenType.AppInstallationAccess,
-    value: `ghs_${makeTestToken(255)}`,
   },
 ];
 

--- a/src/artifact-scanner.test.ts
+++ b/src/artifact-scanner.test.ts
@@ -52,15 +52,6 @@ test("isAuthToken", (t) => {
     ]),
     undefined,
   );
-  t.is(
-    isAuthToken(NEW_FORMAT_GHS_TOKEN, [
-      {
-        type: TokenType.ServerToServer,
-        pattern: /ghs_[A-Za-z0-9._-]{36,}/g,
-      },
-    ]),
-    TokenType.ServerToServer,
-  );
 });
 
 const testTokens = [
@@ -85,7 +76,15 @@ const testTokens = [
   },
   {
     type: TokenType.ServerToServer,
+    value: `ghs_${makeTestToken()}`,
+    checkPattern: "Server-to-Server",
+    label: "legacy format",
+  },
+  {
+    type: TokenType.ServerToServer,
     value: NEW_FORMAT_GHS_TOKEN,
+    checkPattern: "Server-to-Server",
+    label: "new format",
   },
   {
     type: TokenType.Refresh,
@@ -93,8 +92,11 @@ const testTokens = [
   },
 ];
 
-for (const { type, value, checkPattern } of testTokens) {
-  test(`scanArtifactsForTokens detects GitHub ${type} tokens in files`, async (t) => {
+for (const { type, value, checkPattern, label } of testTokens) {
+  const testName = label
+    ? `scanArtifactsForTokens detects GitHub ${type} (${label}) tokens in files`
+    : `scanArtifactsForTokens detects GitHub ${type} tokens in files`;
+  test(testName, async (t) => {
     const logMessages = [];
     const logger = getRecordingLogger(logMessages, { logToConsole: false });
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "scanner-test-"));

--- a/src/artifact-scanner.test.ts
+++ b/src/artifact-scanner.test.ts
@@ -55,11 +55,11 @@ test("isAuthToken", (t) => {
   t.is(
     isAuthToken(NEW_FORMAT_GHS_TOKEN, [
       {
-        type: TokenType.AppInstallationAccess,
+        type: TokenType.ServerToServer,
         pattern: /ghs_[A-Za-z0-9._-]{36,}/g,
       },
     ]),
-    TokenType.AppInstallationAccess,
+    TokenType.ServerToServer,
   );
 });
 

--- a/src/artifact-scanner.test.ts
+++ b/src/artifact-scanner.test.ts
@@ -60,7 +60,7 @@ test("isAuthToken", (t) => {
     isAuthToken(NEW_FORMAT_GHS_TOKEN, [
       {
         type: TokenType.AppInstallationAccess,
-        pattern: /ghs_[A-Za-z0-9._]{36,}/g,
+        pattern: /ghs_[A-Za-z0-9._-]{36,}/g,
       },
     ]),
     TokenType.AppInstallationAccess,

--- a/src/artifact-scanner.test.ts
+++ b/src/artifact-scanner.test.ts
@@ -23,8 +23,7 @@ test("makeTestToken", (t) => {
   t.is(makeTestToken(255).length, 255);
 });
 
-const NEW_FORMAT_GHS_TOKEN =
-  "ghs_abc123.def456.ghi789_abc123.def456.ghi789";
+const NEW_FORMAT_GHS_TOKEN = "ghs_abc123.def456.ghi789_abc123.def456.ghi789";
 
 test("isAuthToken", (t) => {
   // Undefined for strings that aren't tokens
@@ -36,10 +35,7 @@ test("isAuthToken", (t) => {
   t.is(isAuthToken(`ghp_${makeTestToken()}`), TokenType.PersonalAccessClassic);
   t.is(isAuthToken(`ghp_${makeTestToken()}`), TokenType.PersonalAccessClassic);
   t.is(isAuthToken(NEW_FORMAT_GHS_TOKEN), TokenType.ServerToServer);
-  t.is(
-    isAuthToken(`ghs_${makeTestToken(255)}`),
-    TokenType.ServerToServer,
-  );
+  t.is(isAuthToken(`ghs_${makeTestToken(255)}`), TokenType.ServerToServer);
   t.is(
     isAuthToken(`github_pat_${makeTestToken(22)}_${makeTestToken(59)}`),
     TokenType.PersonalAccessFineGrained,

--- a/src/artifact-scanner.ts
+++ b/src/artifact-scanner.ts
@@ -54,7 +54,7 @@ const GITHUB_TOKEN_PATTERNS: TokenPattern[] = [
   },
   {
     type: TokenType.ServerToServer,
-    pattern: /ghs_[A-Za-z0-9._-]{36,}/g,
+    pattern: /\bghs_[A-Za-z0-9._-]{36,516}(?![A-Za-z0-9._-])/g,
   },
   {
     type: TokenType.Refresh,
@@ -104,27 +104,16 @@ function scanFileForTokens(
   logger: Logger,
 ): TokenFinding[] {
   const findings: TokenFinding[] = [];
-  const seenMatches = new Set<number>();
   try {
     const content = fs.readFileSync(filePath, "utf8");
 
     for (const { type, pattern } of GITHUB_TOKEN_PATTERNS) {
-      const regex = new RegExp(pattern.source, pattern.flags);
-      let matchCount = 0;
-
-      for (const match of content.matchAll(regex)) {
-        const index = match.index;
-        if (index === undefined || seenMatches.has(index)) {
-          continue;
+      const matches = content.match(pattern);
+      if (matches) {
+        for (let i = 0; i < matches.length; i++) {
+          findings.push({ tokenType: type, filePath: relativePath });
         }
-
-        seenMatches.add(index);
-        findings.push({ tokenType: type, filePath: relativePath });
-        matchCount++;
-      }
-
-      if (matchCount > 0) {
-        logger.debug(`Found ${matchCount} ${type}(s) in ${relativePath}`);
+        logger.debug(`Found ${matches.length} ${type}(s) in ${relativePath}`);
       }
     }
 

--- a/src/artifact-scanner.ts
+++ b/src/artifact-scanner.ts
@@ -17,7 +17,6 @@ export enum TokenType {
   UserToServer = "User-to-Server Token",
   ServerToServer = "Server-to-Server Token",
   Refresh = "Refresh Token",
-  AppInstallationAccess = "App Installation Access Token",
 }
 
 /** A value of this type associates a token type with its pattern. */
@@ -60,10 +59,6 @@ const GITHUB_TOKEN_PATTERNS: TokenPattern[] = [
   {
     type: TokenType.Refresh,
     pattern: /\bghr_[a-zA-Z0-9]{36}\b/g,
-  },
-  {
-    type: TokenType.AppInstallationAccess,
-    pattern: /ghs_[A-Za-z0-9._-]{36,}/g,
   },
 ];
 

--- a/src/artifact-scanner.ts
+++ b/src/artifact-scanner.ts
@@ -55,7 +55,7 @@ const GITHUB_TOKEN_PATTERNS: TokenPattern[] = [
   },
   {
     type: TokenType.ServerToServer,
-    pattern: /\bghs_[a-zA-Z0-9]{36}\b/g,
+    pattern: /ghs_[A-Za-z0-9._]{36,}/g,
   },
   {
     type: TokenType.Refresh,
@@ -63,7 +63,7 @@ const GITHUB_TOKEN_PATTERNS: TokenPattern[] = [
   },
   {
     type: TokenType.AppInstallationAccess,
-    pattern: /\bghs_[a-zA-Z0-9]{255}\b/g,
+    pattern: /ghs_[A-Za-z0-9._]{36,}/g,
   },
 ];
 
@@ -109,16 +109,27 @@ function scanFileForTokens(
   logger: Logger,
 ): TokenFinding[] {
   const findings: TokenFinding[] = [];
+  const seenMatches = new Set<number>();
   try {
     const content = fs.readFileSync(filePath, "utf8");
 
     for (const { type, pattern } of GITHUB_TOKEN_PATTERNS) {
-      const matches = content.match(pattern);
-      if (matches) {
-        for (let i = 0; i < matches.length; i++) {
-          findings.push({ tokenType: type, filePath: relativePath });
+      const regex = new RegExp(pattern.source, pattern.flags);
+      let matchCount = 0;
+
+      for (const match of content.matchAll(regex)) {
+        const index = match.index;
+        if (index === undefined || seenMatches.has(index)) {
+          continue;
         }
-        logger.debug(`Found ${matches.length} ${type}(s) in ${relativePath}`);
+
+        seenMatches.add(index);
+        findings.push({ tokenType: type, filePath: relativePath });
+        matchCount++;
+      }
+
+      if (matchCount > 0) {
+        logger.debug(`Found ${matchCount} ${type}(s) in ${relativePath}`);
       }
     }
 

--- a/src/artifact-scanner.ts
+++ b/src/artifact-scanner.ts
@@ -55,7 +55,7 @@ const GITHUB_TOKEN_PATTERNS: TokenPattern[] = [
   },
   {
     type: TokenType.ServerToServer,
-    pattern: /ghs_[A-Za-z0-9._]{36,}/g,
+    pattern: /ghs_[A-Za-z0-9._-]{36,}/g,
   },
   {
     type: TokenType.Refresh,
@@ -63,7 +63,7 @@ const GITHUB_TOKEN_PATTERNS: TokenPattern[] = [
   },
   {
     type: TokenType.AppInstallationAccess,
-    pattern: /ghs_[A-Za-z0-9._]{36,}/g,
+    pattern: /ghs_[A-Za-z0-9._-]{36,}/g,
   },
 ];
 


### PR DESCRIPTION
Updates the ghs_ token regex to support the new token format which allows dots and underscores ([A-Za-z0-9._-]) and variable length (no longer fixed at 36 chars).

See the changelog: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/

Supersedes #3931 (from fork, had the correct source but stale bundle).
Fixes the compiled `lib/entry-points.js` bundle which was missing the `-` (hyphen) character in the `ghs_` token regex character class.

The source `.ts` file correctly uses `[A-Za-z0-9._-]` but the committed bundle had `[A-Za-z0-9._]` — missing the hyphen that base64url encoding (RFC 4648 §5) uses in JWT signatures.

This PR rebuilds the bundle from the source to fix the mismatch.