### PR TITLE
Change waitForProcessing to use exponential backoff

### DIFF
--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -858,7 +858,9 @@ export async function waitForProcessing(
 
     // Do an initial wait because processing will always take a minimum of 2-3 seconds
     let statusCheckBackoff = STATUS_CHECK_INITIAL_BACKOFF_MILLISECONDS;
-    await util.delay(statusCheckBackoff, { allowProcessExit: false });
+    if (process.env["NODE_ENV"] !== "test") {
+      await util.delay(statusCheckBackoff, { allowProcessExit: false });
+    }
 
     for (
       let statusCheckCount = 1;

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -829,8 +829,10 @@ function dumpSarifFile(
   fs.writeFileSync(outputFile, sarifPayload);
 }
 
-const STATUS_CHECK_FREQUENCY_MILLISECONDS = 5 * 1000;
-const STATUS_CHECK_TIMEOUT_MILLISECONDS = 2 * 60 * 1000;
+// Should lead to status checks after 5s, 15s, 35s, 75s, and 155s.
+const STATUS_CHECK_INITIAL_BACKOFF_MILLISECONDS = 5 * 1000;
+const STATUS_CHECK_BACKOFF_MULTIPLIER = 2;
+const STATUS_CHECK_MAX_TRIES = 5;
 
 type ProcessingStatus = "pending" | "complete" | "failed";
 
@@ -854,20 +856,15 @@ export async function waitForProcessing(
   try {
     const client = api.getApiClient();
 
-    const statusCheckingStarted = Date.now();
-    while (true) {
-      if (
-        Date.now() >
-        statusCheckingStarted + STATUS_CHECK_TIMEOUT_MILLISECONDS
-      ) {
-        // If the analysis hasn't finished processing in the allotted time, we continue anyway rather than failing.
-        // It's possible the analysis will eventually finish processing, but it's not worth spending more
-        // Actions time waiting.
-        logger.warning(
-          "Timed out waiting for analysis to finish processing. Continuing.",
-        );
-        break;
-      }
+    // Do an initial wait because processing will always take a minimum of 2-3 seconds
+    let statusCheckBackoff = STATUS_CHECK_INITIAL_BACKOFF_MILLISECONDS;
+    await util.delay(statusCheckBackoff, { allowProcessExit: false });
+
+    for (
+      let statusCheckCount = 1;
+      statusCheckCount <= STATUS_CHECK_MAX_TRIES;
+      statusCheckCount++
+    ) {
       let response: OctokitResponse<any> | undefined = undefined;
       try {
         response = await client.request(
@@ -912,9 +909,18 @@ export async function waitForProcessing(
         util.assertNever(status);
       }
 
-      await util.delay(STATUS_CHECK_FREQUENCY_MILLISECONDS, {
-        allowProcessExit: false,
-      });
+      if (statusCheckCount === STATUS_CHECK_MAX_TRIES) {
+        // If the analysis hasn't finished processing in the allotted time, we continue anyway rather than failing.
+        // It's possible the analysis will eventually finish processing, but it's not worth spending more
+        // Actions time waiting.
+        logger.warning(
+          "Timed out waiting for analysis to finish processing. Continuing.",
+        );
+        break;
+      } else {
+        statusCheckBackoff *= STATUS_CHECK_BACKOFF_MULTIPLIER;
+        await util.delay(statusCheckBackoff, { allowProcessExit: false });
+      }
     }
   } finally {
     logger.endGroup();


### PR DESCRIPTION
The goal is to change `waitForProcessing` to backoff a bit more aggressively and reduce the maximum number of requests that it makes. During periods where analysis processing is being delayed, we're seeing a large number of extra GET requests that I believe are coming from here. See linked internal issue for more info.

In this PR I'm suggesting changing it to exponential backoff that'll make a maximum of 5 requests, instead of the current behaviour which can make up to 24 requests. I also add a wait before the first poll because processing will always take at least a couple of seconds so it's unlikely that an immediate poll will get anything. Let me know if you think this is reasonable. We can also tweak values to keep the maximum timeout to 2 minutes if that would be better.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Hopefully can be safely tested before merge (either by tests or on a test repository)

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.
- **Third-party analyses** - The changes affect the `upload-sarif` action.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Test repository** - This change will be tested on a test repository before merging.
- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
