### PR TITLE
Cache CLI version information across Actions steps

### DIFF
--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -523,7 +523,7 @@ async function getCodeQLForCmd(
       return cmd;
     },
     async getVersion() {
-      let result = util.getCachedCodeQlVersion();
+      let result = util.getCachedCodeQlVersion(cmd);
       if (result === undefined) {
         const output = await runCli(cmd, ["version", "--format=json"], {
           noStreamStdout: true,
@@ -535,12 +535,13 @@ async function getCodeQLForCmd(
             `Invalid JSON output from \`version --format=json\`: ${output}`,
           );
         }
-        util.cacheCodeQlVersion(result);
+        util.cacheCodeQlVersion(cmd, result);
       }
       return result;
     },
     async printVersion() {
-      await runCli(cmd, ["version", "--format=json"]);
+      // Reuse the cached version information rather than invoking the CLI again.
+      core.info(JSON.stringify(await this.getVersion(), null, 2));
     },
     async supportsFeature(feature: ToolsFeature) {
       return isSupportedToolsFeature(await this.getVersion(), feature);

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,6 +17,12 @@ export enum EnvVar {
    */
   CLI_VERBOSITY = "CODEQL_VERBOSITY",
 
+  /**
+   * `PersistedVersionInfo` for the CodeQL CLI, so later Actions steps can reuse it instead of
+   * invoking `codeql version` again.
+   */
+  CODEQL_VERSION_INFO = "CODEQL_ACTION_CLI_VERSION_INFO",
+
   /** Whether the CodeQL Action has invoked the Go autobuilder. */
   DID_AUTOBUILD_GOLANG = "CODEQL_ACTION_DID_AUTOBUILD_GOLANG",
 

--- a/src/testing-utils.ts
+++ b/src/testing-utils.ts
@@ -32,6 +32,7 @@ import {
   GitHubVariant,
   GitHubVersion,
   HTTPError,
+  resetCachedCodeQlVersion,
 } from "./util";
 
 export const SAMPLE_DOTCOM_API_DETAILS = {
@@ -100,6 +101,10 @@ export function setupTests(testFn: TestFn<any>) {
     // Set an empty CodeQL object so that all method calls will fail
     // unless the test explicitly sets one up.
     codeql.setCodeQL({});
+
+    // Reset the in-process CodeQL version cache so that it doesn't leak between
+    // tests, which each represent a separate Actions step in production.
+    resetCachedCodeQlVersion();
 
     // Replace stdout and stderr so we can record output during tests
     t.context.testOutput = "";

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -532,3 +532,26 @@ test("Failure.orElse returns the default value for a failure result", (t) => {
   const result = new util.Failure(new Error("test error"));
   t.is(result.orElse("default value"), "default value");
 });
+
+test("getCachedCodeQlVersion reuses a version persisted by an earlier step", (t) => {
+  process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
+    cmd: "/path/to/codeql",
+    version: { version: "2.20.0" },
+  });
+  t.deepEqual(util.getCachedCodeQlVersion("/path/to/codeql"), {
+    version: "2.20.0",
+  });
+});
+
+test("getCachedCodeQlVersion ignores a persisted version from a different CLI", (t) => {
+  process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
+    cmd: "/path/to/other-codeql",
+    version: { version: "2.20.0" },
+  });
+  t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
+});
+
+test("getCachedCodeQlVersion ignores a malformed persisted value", (t) => {
+  process.env[EnvVar.CODEQL_VERSION_INFO] = "not valid json";
+  t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
+});

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -533,25 +533,57 @@ test("Failure.orElse returns the default value for a failure result", (t) => {
   t.is(result.orElse("default value"), "default value");
 });
 
-test("getCachedCodeQlVersion reuses a version persisted by an earlier step", (t) => {
-  process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
-    cmd: "/path/to/codeql",
-    version: { version: "2.20.0" },
-  });
-  t.deepEqual(util.getCachedCodeQlVersion("/path/to/codeql"), {
-    version: "2.20.0",
-  });
-});
+test.serial(
+  "getCachedCodeQlVersion reuses a version persisted by an earlier step",
+  (t) => {
+    process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
+      cmd: "/path/to/codeql",
+      version: { version: "2.20.0" },
+    });
+    t.deepEqual(util.getCachedCodeQlVersion("/path/to/codeql"), {
+      version: "2.20.0",
+    });
+  },
+);
 
-test("getCachedCodeQlVersion ignores a persisted version from a different CLI", (t) => {
-  process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
-    cmd: "/path/to/other-codeql",
-    version: { version: "2.20.0" },
-  });
-  t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
-});
+test.serial(
+  "getCachedCodeQlVersion ignores a persisted version from a different CLI",
+  (t) => {
+    process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
+      cmd: "/path/to/other-codeql",
+      version: { version: "2.20.0" },
+    });
+    t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
+  },
+);
 
-test("getCachedCodeQlVersion ignores a malformed persisted value", (t) => {
-  process.env[EnvVar.CODEQL_VERSION_INFO] = "not valid json";
-  t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
-});
+test.serial(
+  "getCachedCodeQlVersion ignores a malformed persisted value",
+  (t) => {
+    process.env[EnvVar.CODEQL_VERSION_INFO] = "not valid json";
+    t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
+  },
+);
+
+test.serial(
+  "getCachedCodeQlVersion ignores a persisted value with the wrong structure",
+  (t) => {
+    for (const value of [
+      JSON.stringify({ cmd: "/path/to/codeql" }),
+      JSON.stringify({ cmd: "/path/to/codeql", version: {} }),
+      JSON.stringify({ cmd: "/path/to/codeql", version: { version: 2 } }),
+      JSON.stringify({ version: { version: "2.20.0" } }),
+      JSON.stringify({
+        cmd: "/path/to/codeql",
+        version: { version: "2.20.0", overlayVersion: "1" },
+      }),
+      JSON.stringify({
+        cmd: "/path/to/codeql",
+        version: { version: "2.20.0", features: "nope" },
+      }),
+    ]) {
+      process.env[EnvVar.CODEQL_VERSION_INFO] = value;
+      t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined, value);
+    }
+  },
+);

--- a/src/util.ts
+++ b/src/util.ts
@@ -619,15 +619,51 @@ export function asHTTPError(arg: any): HTTPError | undefined {
 
 let cachedCodeQlVersion: undefined | VersionInfo = undefined;
 
-export function cacheCodeQlVersion(version: VersionInfo): void {
+/** The persisted version together with the CLI path it was obtained from. */
+interface PersistedVersionInfo {
+  cmd: string;
+  version: VersionInfo;
+}
+
+export function cacheCodeQlVersion(cmd: string, version: VersionInfo): void {
   if (cachedCodeQlVersion !== undefined) {
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
   cachedCodeQlVersion = version;
+  // Persist the version so that subsequent Actions steps, which run in separate
+  // processes, can reuse it rather than invoking `codeql version` again. We
+  // record the CLI path so that a different step using a different CodeQL bundle
+  // doesn't pick up a stale version.
+  core.exportVariable(
+    EnvVar.CODEQL_VERSION_INFO,
+    JSON.stringify({ cmd, version }),
+  );
 }
 
-export function getCachedCodeQlVersion(): undefined | VersionInfo {
-  return cachedCodeQlVersion;
+export function getCachedCodeQlVersion(cmd?: string): undefined | VersionInfo {
+  if (cachedCodeQlVersion !== undefined) {
+    return cachedCodeQlVersion;
+  }
+  // Fall back to the value persisted by an earlier Actions step, if any. This is
+  // best-effort: any malformed or mismatched value is ignored so that the caller
+  // invokes `codeql version` instead.
+  const serialized = process.env[EnvVar.CODEQL_VERSION_INFO];
+  if (!serialized) {
+    return undefined;
+  }
+  let persisted: PersistedVersionInfo;
+  try {
+    persisted = JSON.parse(serialized) as PersistedVersionInfo;
+  } catch {
+    return undefined;
+  }
+  if (
+    typeof persisted?.version?.version !== "string" ||
+    (cmd !== undefined && persisted.cmd !== cmd)
+  ) {
+    return undefined;
+  }
+  return persisted.version;
 }
 
 export async function codeQlVersionAtLeast(

--- a/src/util.ts
+++ b/src/util.ts
@@ -619,10 +619,42 @@ export function asHTTPError(arg: any): HTTPError | undefined {
 
 let cachedCodeQlVersion: undefined | VersionInfo = undefined;
 
+/**
+ * Resets the in-process cache of the CodeQL CLI version. Only for use in tests,
+ * which exercise multiple "steps" within a single process.
+ */
+export function resetCachedCodeQlVersion(): void {
+  cachedCodeQlVersion = undefined;
+}
+
 /** The persisted version together with the CLI path it was obtained from. */
 interface PersistedVersionInfo {
   cmd: string;
   version: VersionInfo;
+}
+
+function isVersionInfo(x: unknown): x is VersionInfo {
+  const candidate = x as Partial<VersionInfo> | null;
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    typeof candidate.version === "string" &&
+    (candidate.features === undefined ||
+      (typeof candidate.features === "object" &&
+        candidate.features !== null)) &&
+    (candidate.overlayVersion === undefined ||
+      typeof candidate.overlayVersion === "number")
+  );
+}
+
+function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
+  const candidate = x as Partial<PersistedVersionInfo> | null;
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    typeof candidate.cmd === "string" &&
+    isVersionInfo(candidate.version)
+  );
 }
 
 export function cacheCodeQlVersion(cmd: string, version: VersionInfo): void {
@@ -651,19 +683,22 @@ export function getCachedCodeQlVersion(cmd?: string): undefined | VersionInfo {
   if (!serialized) {
     return undefined;
   }
-  let persisted: PersistedVersionInfo;
+  let persisted: unknown;
   try {
-    persisted = JSON.parse(serialized) as PersistedVersionInfo;
+    persisted = JSON.parse(serialized);
   } catch {
     return undefined;
   }
   if (
-    typeof persisted?.version?.version !== "string" ||
+    !isPersistedVersionInfo(persisted) ||
     (cmd !== undefined && persisted.cmd !== cmd)
   ) {
     return undefined;
   }
-  return persisted.version;
+  // Memoize the parsed value so that subsequent calls in this process don't
+  // re-parse the environment variable.
+  cachedCodeQlVersion = persisted.version;
+  return cachedCodeQlVersion;
 }
 
 export async function codeQlVersionAtLeast(


### PR DESCRIPTION
Persist CLI version information across Actions steps to avoid calling `codeql version` in each step.  This saves 3 to 6 calls (and associated JVM startups) in a typical analysis job.

We use the path to the CodeQL CLI as a cache key.  This is robust to setting up a different CLI with `init` or `setup-codeql` in the same job, but if a user hotswaps the CLI with a different mechanism and keeps the path the same, we are going to have the wrong version information.  That seems like a rare enough case to be acceptable, but if we care about this, we could introduce more data into the cache key (at the cost of some performance).

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.
- **Third-party analyses** - The changes affect the `upload-sarif` action.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
