### PR TITLE
Pin first-party Actions to SHAs

### DIFF
--- a/.github/actions/release-initialise/action.yml
+++ b/.github/actions/release-initialise/action.yml
@@ -16,13 +16,13 @@ runs:
       shell: bash
 
     - name: Set up Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
         cache: 'npm'
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
 

--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -74,13 +74,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__analysis-kinds.yml
+++ b/.github/workflows/__analysis-kinds.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -92,7 +92,7 @@ jobs:
           post-processed-sarif-path: '${{ runner.temp }}/post-processed'
 
       - name: Upload SARIF files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: |
             analysis-kinds-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.analysis-kinds }}
@@ -100,7 +100,7 @@ jobs:
           retention-days: 7
 
       - name: Upload post-processed SARIF
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: |
             post-processed-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.analysis-kinds }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Check quality query does not appear in security SARIF
         if: contains(matrix.analysis-kinds, 'code-scanning')
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SARIF_PATH: '${{ runner.temp }}/results/javascript.sarif'
           EXPECT_PRESENT: 'false'
@@ -118,7 +118,7 @@ jobs:
           script: ${{ env.CHECK_SCRIPT }}
       - name: Check quality query appears in quality SARIF
         if: contains(matrix.analysis-kinds, 'code-quality')
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SARIF_PATH: '${{ runner.temp }}/results/javascript.quality.sarif'
           EXPECT_PRESENT: 'true'

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -70,13 +70,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -64,9 +64,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Prepare test

--- a/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
+++ b/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
@@ -66,9 +66,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ inputs.java-version || '17' }}
           distribution: temurin

--- a/.github/workflows/__autobuild-working-dir.yml
+++ b/.github/workflows/__autobuild-working-dir.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__build-mode-autobuild.yml
+++ b/.github/workflows/__build-mode-autobuild.yml
@@ -66,9 +66,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: ${{ inputs.java-version || '17' }}
           distribution: temurin

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -70,13 +70,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__build-mode-none.yml
+++ b/.github/workflows/__build-mode-none.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__build-mode-rollback.yml
+++ b/.github/workflows/__build-mode-rollback.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__bundle-from-nightly.yml
+++ b/.github/workflows/__bundle-from-nightly.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__bundle-from-toolcache.yml
+++ b/.github/workflows/__bundle-from-toolcache.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -62,7 +62,7 @@ jobs:
         run: npm install @actions/tool-cache@3
       - name: Check toolcache contains CodeQL
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const toolcache = require('@actions/tool-cache');
@@ -75,7 +75,7 @@ jobs:
         with:
           tools: ${{ steps.prepare-test.outputs.tools-url }}
       - name: Check CodeQL is installed within the toolcache
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const toolcache = require('@actions/tool-cache');

--- a/.github/workflows/__bundle-toolcache.yml
+++ b/.github/workflows/__bundle-toolcache.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -63,7 +63,7 @@ jobs:
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
       - name: Remove CodeQL from toolcache
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('fs');
@@ -73,7 +73,7 @@ jobs:
       - name: Install @actions/tool-cache
         run: npm install @actions/tool-cache@3
       - name: Check toolcache does not contain CodeQL
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const toolcache = require('@actions/tool-cache');
@@ -92,7 +92,7 @@ jobs:
           output: ${{ runner.temp }}/results
           upload-database: false
       - name: Check CodeQL is installed within the toolcache
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const toolcache = require('@actions/tool-cache');

--- a/.github/workflows/__bundle-zstd.yml
+++ b/.github/workflows/__bundle-zstd.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -63,7 +63,7 @@ jobs:
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
       - name: Remove CodeQL from toolcache
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('fs');
@@ -82,13 +82,13 @@ jobs:
           output: ${{ runner.temp }}/results
           upload-database: false
       - name: Upload SARIF
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.os }}-zstd-bundle.sarif
           path: ${{ runner.temp }}/results/javascript.sarif
           retention-days: 7
       - name: Check diagnostic with expected tools URL appears in SARIF
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SARIF_PATH: ${{ runner.temp }}/results/javascript.sarif
         with:

--- a/.github/workflows/__cleanup-db-cluster-dir.yml
+++ b/.github/workflows/__cleanup-db-cluster-dir.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -70,13 +70,13 @@ jobs:
           output: '${{ runner.temp }}/results'
           upload-database: false
       - name: Upload SARIF
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: config-export-${{ matrix.os }}-${{ matrix.version }}.sarif.json
           path: '${{ runner.temp }}/results/javascript.sarif'
           retention-days: 7
       - name: Check config properties appear in SARIF
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SARIF_PATH: '${{ runner.temp }}/results/javascript.sarif'
         with:

--- a/.github/workflows/__config-input.yml
+++ b/.github/workflows/__config-input.yml
@@ -50,9 +50,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -81,13 +81,13 @@ jobs:
           output: '${{ runner.temp }}/results'
           upload-database: false
       - name: Upload SARIF
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: diagnostics-export-${{ matrix.os }}-${{ matrix.version }}.sarif.json
           path: '${{ runner.temp }}/results/javascript.sarif'
           retention-days: 7
       - name: Check diagnostics appear in SARIF
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SARIF_PATH: '${{ runner.temp }}/results/javascript.sarif'
         with:

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -74,13 +74,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
@@ -102,7 +102,7 @@ jobs:
         with:
           output: '${{ runner.temp }}/results'
       - name: Upload SARIF
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: with-baseline-information-${{ matrix.os }}-${{ matrix.version }}.sarif.json
           path: '${{ runner.temp }}/results/javascript.sarif'

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__global-proxy.yml
+++ b/.github/workflows/__global-proxy.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -72,13 +72,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -60,9 +60,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
@@ -78,7 +78,7 @@ jobs:
           languages: go
           tools: ${{ steps.prepare-test.outputs.tools-url }}
       # Deliberately change Go after the `init` step
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.20'
       - name: Build code
@@ -88,7 +88,7 @@ jobs:
           output: '${{ runner.temp }}/results'
           upload-database: false
       - name: Check diagnostic appears in SARIF
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SARIF_PATH: '${{ runner.temp }}/results/go.sarif'
         with:

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -60,9 +60,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
@@ -89,7 +89,7 @@ jobs:
           output: '${{ runner.temp }}/results'
           upload-database: false
       - name: Check diagnostic appears in SARIF
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SARIF_PATH: '${{ runner.temp }}/results/go.sarif'
         with:

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -60,9 +60,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -80,9 +80,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -80,9 +80,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -80,9 +80,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__job-run-uuid-sarif.yml
+++ b/.github/workflows/__job-run-uuid-sarif.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -67,7 +67,7 @@ jobs:
         with:
           output: '${{ runner.temp }}/results'
       - name: Upload SARIF
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}.sarif.json
           path: '${{ runner.temp }}/results/javascript.sarif'

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__local-bundle.yml
+++ b/.github/workflows/__local-bundle.yml
@@ -70,13 +70,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -104,13 +104,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
@@ -125,7 +125,7 @@ jobs:
         # We need Python 3.13 for older CLI versions because they are not compatible with Python 3.14 or newer.
         # See https://github.com/github/codeql-action/pull/3212
         if: matrix.version != 'nightly-latest' && matrix.version != 'linked'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/__overlay-init-fallback.yml
+++ b/.github/workflows/__overlay-init-fallback.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -74,18 +74,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -74,18 +74,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -74,18 +74,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -74,18 +74,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -72,13 +72,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__rust.yml
+++ b/.github/workflows/__rust.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -80,13 +80,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
@@ -62,7 +62,7 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./init
         with:
           languages: javascript

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -74,13 +74,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -72,13 +72,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -70,13 +70,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__upload-sarif.yml
+++ b/.github/workflows/__upload-sarif.yml
@@ -77,13 +77,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -71,13 +71,13 @@ jobs:
     steps:
       # This ensures we don't accidentally use the original checkout for any part of the test.
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || '>=1.21.0' }}
           cache: false
@@ -96,7 +96,7 @@ jobs:
           rm -rf ./* .github .git
       # Check out the actions repo again, but at a different location.
       # choose an arbitrary SHA so that we can later test that the commit_oid is not from main
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: 474bbf07f9247ffe1856c6a0f94aeeb10e7afee6
           path: x/y/z/some-path

--- a/.github/workflows/check-expected-release-files.yml
+++ b/.github/workflows/check-expected-release-files.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout CodeQL Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check Expected Release Files
         run: |
           bundle_version="$(cat "./src/defaults.json" | jq -r ".bundleVersion")"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
       security-events: read
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up default CodeQL bundle
       id: setup-default
       uses: ./setup-codeql
@@ -87,7 +87,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Initialize CodeQL
       uses: ./init
       id: init
@@ -124,7 +124,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Initialize CodeQL
       uses: ./init
       with:

--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -59,10 +59,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
         cache: 'npm'

--- a/.github/workflows/debug-artifacts-failure-safe.yml
+++ b/.github/workflows/debug-artifacts-failure-safe.yml
@@ -53,17 +53,17 @@ jobs:
       - name: Dump GitHub event
         run: cat "${GITHUB_EVENT_PATH}"
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
         with:
           version: ${{ matrix.version }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ^1.13.1
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '9.x'
       - name: Assert best-effort artifact scan completed
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Check expected artifacts exist
         run: |
           LANGUAGES="cpp csharp go java javascript python"

--- a/.github/workflows/debug-artifacts-safe.yml
+++ b/.github/workflows/debug-artifacts-safe.yml
@@ -49,17 +49,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Prepare test
         id: prepare-test
         uses: ./.github/actions/prepare-test
         with:
           version: ${{ matrix.version }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ^1.13.1
       - name: Install .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '9.x'
       - name: Assert best-effort artifact scan completed
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Check expected artifacts exist
         run: |
           VERSIONS="stable-v2.20.3 default linked nightly-latest"

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -44,14 +44,14 @@ jobs:
           GITHUB_CONTEXT: '${{ toJson(github) }}'
         run: echo "${GITHUB_CONTEXT}"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0  # ensure we have all tags and can push commits
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'npm'
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
@@ -134,7 +134,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Generate token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,10 +42,10 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -91,10 +91,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'npm'
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload repo size comment
         if: steps.fetch-base.outcome == 'success'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: repo-size-comment
           path: ${{ runner.temp }}/repo-size/
@@ -164,7 +164,7 @@ jobs:
       - name: 'Backport: Check out base ref'
         id: checkout-base
         if: ${{ startsWith(github.head_ref, 'backport-') }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.base_ref }}
 
@@ -203,7 +203,7 @@ jobs:
 
     steps:
       - name: Download repo size comment
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: repo-size-comment
           path: repo-size-comment

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Need full history for calculation of diffs
 

--- a/.github/workflows/publish-immutable-action.yml
+++ b/.github/workflows/publish-immutable-action.yml
@@ -20,8 +20,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Publish immutable release
         id: publish
-        uses: actions/publish-immutable-action@v0.0.4
+        uses: actions/publish-immutable-action@4bc8754ffc40f27910afb20287dbbbb675a4e978 # v0.0.4

--- a/.github/workflows/python312-windows.yml
+++ b/.github/workflows/python312-windows.yml
@@ -35,11 +35,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.12
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Prepare test
       uses: ./.github/actions/prepare-test

--- a/.github/workflows/query-filters.yml
+++ b/.github/workflows/query-filters.yml
@@ -35,10 +35,10 @@ jobs:
       contents: read # This permission is needed to allow the GitHub Actions workflow to read the contents of the repository.
     steps:
     - name: Check out repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Install Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
         cache: npm

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -24,13 +24,13 @@ jobs:
       pull-requests: write # needed to comment on the PR
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ env.HEAD_REF }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/rollback-release.yml
+++ b/.github/workflows/rollback-release.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Need full history for calculation of diffs
 
@@ -136,7 +136,7 @@ jobs:
 
       - name: Generate token
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}

--- a/.github/workflows/test-codeql-bundle-all.yml
+++ b/.github/workflows/test-codeql-bundle-all.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Prepare test
       id: prepare-test
       uses: ./.github/actions/prepare-test
@@ -51,7 +51,7 @@ jobs:
         version: ${{ matrix.version }}
         use-all-platform-bundle: true
     - name: Install .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '9.x'
     - id: init

--- a/.github/workflows/update-bundle.yml
+++ b/.github/workflows/update-bundle.yml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_CONTEXT: '${{ toJson(github) }}'
         run: echo "$GITHUB_CONTEXT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Update git config
         run: |
@@ -41,12 +41,12 @@ jobs:
           git config --global user.name "github-actions[bot]"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -38,7 +38,7 @@ jobs:
       contents: write # needed to push commits
       pull-requests: write # needed to create pull request
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0  # Need full history for calculation of diffs
     - uses: ./.github/actions/release-initialise
@@ -94,14 +94,14 @@ jobs:
       pull-requests: write # needed to create pull request
     steps:
     - name: Generate token
-      uses: actions/create-github-app-token@v3.2.0
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
         app-id: ${{ vars.AUTOMATION_APP_ID }}
         private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0  # Need full history for calculation of diffs
         token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
       - name: Checkout CodeQL Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Checkout Enterprise Releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: github/enterprise-releases
           token: ${{ secrets.ENTERPRISE_RELEASE_TOKEN }}

--- a/pr-checks/checks/analysis-kinds.yml
+++ b/pr-checks/checks/analysis-kinds.yml
@@ -46,7 +46,7 @@ steps:
       post-processed-sarif-path: "${{ runner.temp }}/post-processed"
 
   - name: Upload SARIF files
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: |
         analysis-kinds-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.analysis-kinds }}
@@ -54,7 +54,7 @@ steps:
       retention-days: 7
 
   - name: Upload post-processed SARIF
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: |
         post-processed-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.analysis-kinds }}
@@ -64,7 +64,7 @@ steps:
 
   - name: Check quality query does not appear in security SARIF
     if: contains(matrix.analysis-kinds, 'code-scanning')
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     env:
       SARIF_PATH: "${{ runner.temp }}/results/javascript.sarif"
       EXPECT_PRESENT: "false"
@@ -72,7 +72,7 @@ steps:
       script: ${{ env.CHECK_SCRIPT }}
   - name: Check quality query appears in quality SARIF
     if: contains(matrix.analysis-kinds, 'code-quality')
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     env:
       SARIF_PATH: "${{ runner.temp }}/results/javascript.quality.sarif"
       EXPECT_PRESENT: "true"

--- a/pr-checks/checks/bundle-from-toolcache.yml
+++ b/pr-checks/checks/bundle-from-toolcache.yml
@@ -7,7 +7,7 @@ steps:
     run: npm install @actions/tool-cache@3
   - name: Check toolcache contains CodeQL
     continue-on-error: true
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     with:
       script: |
         const toolcache = require('@actions/tool-cache');
@@ -20,7 +20,7 @@ steps:
     with:
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   - name: Check CodeQL is installed within the toolcache
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     with:
       script: |
         const toolcache = require('@actions/tool-cache');

--- a/pr-checks/checks/bundle-toolcache.yml
+++ b/pr-checks/checks/bundle-toolcache.yml
@@ -8,7 +8,7 @@ operatingSystems:
   - windows
 steps:
   - name: Remove CodeQL from toolcache
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     with:
       script: |
         const fs = require('fs');
@@ -18,7 +18,7 @@ steps:
   - name: Install @actions/tool-cache
     run: npm install @actions/tool-cache@3
   - name: Check toolcache does not contain CodeQL
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     with:
       script: |
         const toolcache = require('@actions/tool-cache');
@@ -37,7 +37,7 @@ steps:
       output: ${{ runner.temp }}/results
       upload-database: false
   - name: Check CodeQL is installed within the toolcache
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     with:
       script: |
         const toolcache = require('@actions/tool-cache');

--- a/pr-checks/checks/bundle-zstd.yml
+++ b/pr-checks/checks/bundle-zstd.yml
@@ -8,7 +8,7 @@ operatingSystems:
   - windows
 steps:
   - name: Remove CodeQL from toolcache
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     with:
       script: |
         const fs = require('fs');
@@ -27,13 +27,13 @@ steps:
       output: ${{ runner.temp }}/results
       upload-database: false
   - name: Upload SARIF
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: ${{ matrix.os }}-zstd-bundle.sarif
       path: ${{ runner.temp }}/results/javascript.sarif
       retention-days: 7
   - name: Check diagnostic with expected tools URL appears in SARIF
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     env:
       SARIF_PATH: ${{ runner.temp }}/results/javascript.sarif
     with:

--- a/pr-checks/checks/config-export.yml
+++ b/pr-checks/checks/config-export.yml
@@ -14,13 +14,13 @@ steps:
       output: "${{ runner.temp }}/results"
       upload-database: false
   - name: Upload SARIF
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: config-export-${{ matrix.os }}-${{ matrix.version }}.sarif.json
       path: "${{ runner.temp }}/results/javascript.sarif"
       retention-days: 7
   - name: Check config properties appear in SARIF
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     env:
       SARIF_PATH: "${{ runner.temp }}/results/javascript.sarif"
     with:

--- a/pr-checks/checks/diagnostics-export.yml
+++ b/pr-checks/checks/diagnostics-export.yml
@@ -27,13 +27,13 @@ steps:
       output: "${{ runner.temp }}/results"
       upload-database: false
   - name: Upload SARIF
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: diagnostics-export-${{ matrix.os }}-${{ matrix.version }}.sarif.json
       path: "${{ runner.temp }}/results/javascript.sarif"
       retention-days: 7
   - name: Check diagnostics appear in SARIF
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     env:
       SARIF_PATH: "${{ runner.temp }}/results/javascript.sarif"
     with:

--- a/pr-checks/checks/export-file-baseline-information.yml
+++ b/pr-checks/checks/export-file-baseline-information.yml
@@ -23,7 +23,7 @@ steps:
     with:
       output: "${{ runner.temp }}/results"
   - name: Upload SARIF
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: with-baseline-information-${{ matrix.os }}-${{ matrix.version }}.sarif.json
       path: "${{ runner.temp }}/results/javascript.sarif"

--- a/pr-checks/checks/go-indirect-tracing-workaround-diagnostic.yml
+++ b/pr-checks/checks/go-indirect-tracing-workaround-diagnostic.yml
@@ -12,7 +12,7 @@ steps:
       languages: go
       tools: ${{ steps.prepare-test.outputs.tools-url }}
   # Deliberately change Go after the `init` step
-  - uses: actions/setup-go@v6
+  - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
     with:
       go-version: "1.20"
   - name: Build code
@@ -22,7 +22,7 @@ steps:
       output: "${{ runner.temp }}/results"
       upload-database: false
   - name: Check diagnostic appears in SARIF
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     env:
       SARIF_PATH: "${{ runner.temp }}/results/go.sarif"
     with:

--- a/pr-checks/checks/go-indirect-tracing-workaround-no-file-program.yml
+++ b/pr-checks/checks/go-indirect-tracing-workaround-no-file-program.yml
@@ -23,7 +23,7 @@ steps:
       output: "${{ runner.temp }}/results"
       upload-database: false
   - name: Check diagnostic appears in SARIF
-    uses: actions/github-script@v8
+    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
     env:
       SARIF_PATH: "${{ runner.temp }}/results/go.sarif"
     with:

--- a/pr-checks/checks/job-run-uuid-sarif.yml
+++ b/pr-checks/checks/job-run-uuid-sarif.yml
@@ -12,7 +12,7 @@ steps:
     with:
       output: "${{ runner.temp }}/results"
   - name: Upload SARIF
-    uses: actions/upload-artifact@v7
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: ${{ matrix.os }}-${{ matrix.version }}.sarif.json
       path: "${{ runner.temp }}/results/javascript.sarif"

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -13,7 +13,7 @@ steps:
     # We need Python 3.13 for older CLI versions because they are not compatible with Python 3.14 or newer.
     # See https://github.com/github/codeql-action/pull/3212
     if: matrix.version != 'nightly-latest' && matrix.version != 'linked'
-    uses: actions/setup-python@v6
+    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
     with:
       python-version: "3.13"
 

--- a/pr-checks/checks/submit-sarif-failure.yml
+++ b/pr-checks/checks/submit-sarif-failure.yml
@@ -21,7 +21,7 @@ permissions:
   security-events: write # needed to upload the SARIF file
 
 steps:
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
   - uses: ./init
     with:
       languages: javascript

--- a/pr-checks/checks/with-checkout-path.yml
+++ b/pr-checks/checks/with-checkout-path.yml
@@ -14,7 +14,7 @@ steps:
       rm -rf ./* .github .git
   # Check out the actions repo again, but at a different location.
   # choose an arbitrary SHA so that we can later test that the commit_oid is not from main
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     with:
       ref: 474bbf07f9247ffe1856c6a0f94aeeb10e7afee6
       path: x/y/z/some-path

--- a/pr-checks/sync-back.test.ts
+++ b/pr-checks/sync-back.test.ts
@@ -188,6 +188,41 @@ const steps = [
     const result = updateSyncTs(syncTsPath, actionVersions);
     assert.equal(result, false);
   });
+
+  await it("updates SHA-pinned pinnedUses references", () => {
+    /** Test updating `pinnedUses(...)` references with new SHA and version */
+    const syncTsContent = `
+const steps = [
+  {
+    uses: pinnedUses(
+      "actions/setup-node",
+      "0000000000000000000000000000000000000000",
+      "v6.0.0",
+    ),
+  },
+];
+`;
+
+    fs.writeFileSync(syncTsPath, syncTsContent);
+
+    const actionVersions = {
+      "actions/setup-node": "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0",
+    };
+
+    const result = updateSyncTs(syncTsPath, actionVersions);
+    assert.equal(result, true);
+
+    const updatedContent = fs.readFileSync(syncTsPath, "utf8");
+
+    assert.ok(
+      updatedContent.includes('"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"'),
+    );
+    assert.ok(updatedContent.includes('"v6.4.0"'));
+    assert.ok(
+      !updatedContent.includes("0000000000000000000000000000000000000000"),
+    );
+    assert.ok(!updatedContent.includes('"v6.0.0"'));
+  });
 });
 
 describe("updateTemplateFiles", async () => {

--- a/pr-checks/sync-back.ts
+++ b/pr-checks/sync-back.ts
@@ -68,6 +68,10 @@ export function scanGeneratedWorkflows(
 /**
  * Update hardcoded action versions in pr-checks/sync.ts
  *
+ * Handles both inline `uses: "owner/action@ref"` strings and SHA-pinned
+ * references expressed via the `pinnedUses("owner/action", "<sha>", "version")`
+ * helper.
+ *
  * @param syncTsPath - Path to sync.ts file
  * @param actionVersions - Map of action names to versions (may include comments)
  * @returns True if the file was modified, false otherwise
@@ -87,18 +91,36 @@ export function updateSyncTs(
   for (const [actionName, versionWithComment] of Object.entries(
     actionVersions,
   )) {
-    // Extract just the version part (before any comment) for sync.ts
-    const version = versionWithComment.includes("#")
+    // Split the scanned value into the ref (e.g. a commit SHA) and the optional
+    // trailing version comment (e.g. `v6.0.3`).
+    const ref = versionWithComment.includes("#")
       ? versionWithComment.split("#")[0].trim()
       : versionWithComment.trim();
+    const versionComment = versionWithComment.includes("#")
+      ? versionWithComment.split("#")[1].trim()
+      : "";
+
+    const escaped = actionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
     // Look for patterns like uses: "actions/setup-node@v4"
     // Note that this will break if we store an Action uses reference in a
     // variable - that's a risk we're happy to take since in that case the
     // PR checks will just fail.
-    const escaped = actionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const pattern = new RegExp(`(uses:\\s*")${escaped}@(?:[^"]+)(")`, "g");
-    content = content.replace(pattern, `$1${actionName}@${version}$2`);
+    const usesPattern = new RegExp(`(uses:\\s*")${escaped}@(?:[^"]+)(")`, "g");
+    content = content.replace(usesPattern, `$1${actionName}@${ref}$2`);
+
+    // Look for SHA-pinned references expressed via the `pinnedUses` helper, e.g.
+    // `pinnedUses("actions/checkout", "<sha>", "v6.0.3")`, updating both the
+    // pinned ref and the version comment.
+    const pinnedPattern = new RegExp(
+      `(pinnedUses\\(\\s*")${escaped}("\\s*,\\s*")[^"]*("\\s*,\\s*")([^"]*)(")`,
+      "g",
+    );
+    content = content.replace(
+      pinnedPattern,
+      (_match, p1, p2, p3, oldVersion, p5) =>
+        `${p1}${actionName}${p2}${ref}${p3}${versionComment || oldVersion}${p5}`,
+    );
   }
 
   if (content !== originalContent) {

--- a/pr-checks/sync.ts
+++ b/pr-checks/sync.ts
@@ -7,6 +7,16 @@ import * as yaml from "yaml";
 
 import { BuiltInLanguage } from "../src/languages";
 
+/**
+ * Returns a `uses` value for `action` pinned to a commit SHA, with the
+ * human-readable version recorded in a trailing comment.
+ */
+function pinnedUses(action: string, sha: string, version: string): yaml.Scalar {
+  const node = new yaml.Scalar(`${action}@${sha}`);
+  node.comment = ` ${version}`;
+  return node;
+}
+
 /** Known workflow input names. */
 enum KnownInputName {
   GoVersion = "go-version",
@@ -192,7 +202,11 @@ const languageSetups: LanguageSetups = {
     steps: [
       {
         name: "Install Node.js",
-        uses: "actions/setup-node@v6",
+        uses: pinnedUses(
+          "actions/setup-node",
+          "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+          "v6.4.0",
+        ),
         with: {
           "node-version": defaultLanguageVersions.javascript,
           cache: "npm",
@@ -210,7 +224,11 @@ const languageSetups: LanguageSetups = {
     steps: [
       {
         name: "Install Go",
-        uses: "actions/setup-go@v6",
+        uses: pinnedUses(
+          "actions/setup-go",
+          "4a3601121dd01d1626a1e23e37211e3254c1c06c",
+          "v6.4.0",
+        ),
         with: {
           "go-version": `\${{ inputs.go-version || '${defaultLanguageVersions.go}' }}`,
           // to avoid potentially misleading autobuilder results where we expect it to download
@@ -226,7 +244,11 @@ const languageSetups: LanguageSetups = {
     steps: [
       {
         name: "Install Java",
-        uses: "actions/setup-java@v5",
+        uses: pinnedUses(
+          "actions/setup-java",
+          "be666c2fcd27ec809703dec50e508c2fdc7f6654",
+          "v5.2.0",
+        ),
         with: {
           "java-version": `\${{ inputs.java-version || '${defaultLanguageVersions.java}' }}`,
           distribution: "temurin",
@@ -240,7 +262,11 @@ const languageSetups: LanguageSetups = {
     steps: [
       {
         name: "Install Python",
-        uses: "actions/setup-python@v6",
+        uses: pinnedUses(
+          "actions/setup-python",
+          "a309ff8b426b58ec0e2a45f0f869d46889d02405",
+          "v6.2.0",
+        ),
         with: {
           "python-version": `\${{ inputs.python-version || '${defaultLanguageVersions.python}' }}`,
         },
@@ -253,7 +279,11 @@ const languageSetups: LanguageSetups = {
     steps: [
       {
         name: "Install .NET",
-        uses: "actions/setup-dotnet@v5",
+        uses: pinnedUses(
+          "actions/setup-dotnet",
+          "9a946fdbd5fb07b82b2f5a4466058b876ab72bb2",
+          "v5.3.0",
+        ),
         with: {
           "dotnet-version": `\${{ inputs.dotnet-version || '${defaultLanguageVersions.csharp}' }}`,
         },
@@ -456,7 +486,11 @@ function generateJob(
   const steps: Step[] = [
     {
       name: "Check out repository",
-      uses: "actions/checkout@v6",
+      uses: pinnedUses(
+        "actions/checkout",
+        "df4cb1c069e1874edd31b4311f1884172cec0e10",
+        "v6.0.3",
+      ),
     },
     ...setupInfo.steps,
     {


### PR DESCRIPTION
Pin first-party Actions from the `actions` org to commit SHAs, rather than using release tags.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

n/a

Products:

n/a

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

Monitor CI.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
