### PR TITLE
Fix broken log grouping due to nested log group

### DIFF
--- a/src/diff-informed-analysis-utils.ts
+++ b/src/diff-informed-analysis-utils.ts
@@ -5,7 +5,7 @@ import type { PullRequestBranches } from "./actions-util";
 import { getApiClient, getGitHubVersion } from "./api-client";
 import type { CodeQL } from "./codeql";
 import { Feature, FeatureEnablement } from "./feature-flags";
-import { Logger, withGroupAsync } from "./logging";
+import { Logger } from "./logging";
 import { getRepositoryNwoFromEnv } from "./repository";
 import { getErrorMessage, GitHubVariant, satisfiesGHESVersion } from "./util";
 
@@ -83,16 +83,14 @@ export async function prepareDiffInformedAnalysis(
     return false;
   }
 
-  return await withGroupAsync("Computing PR diff ranges", async () => {
-    try {
-      return await computeAndPersistDiffRanges(branches, logger);
-    } catch (e) {
-      logger.warning(
-        `Failed to compute diff-informed analysis ranges: ${getErrorMessage(e)}`,
-      );
-      return false;
-    }
-  });
+  try {
+    return await computeAndPersistDiffRanges(branches, logger);
+  } catch (e) {
+    logger.warning(
+      `Failed to compute diff-informed analysis ranges: ${getErrorMessage(e)}`,
+    );
+    return false;
+  }
 }
 
 export interface DiffThunkRange {
@@ -192,6 +190,7 @@ export async function computeAndPersistDiffRanges(
   branches: PullRequestBranches,
   logger: Logger,
 ): Promise<boolean> {
+  logger.info("Computing PR diff ranges...");
   const ranges = await getPullRequestEditedDiffRanges(branches, logger);
   if (ranges === undefined) {
     return false;


### PR DESCRIPTION
The "Computing PR diff ranges" log group was nested within the "Load language configuration" log group.  Since Actions doesn't support nested log groups this was creating some noise in the logs where the last part of "Load language configuration" spilled out into the top-level logs.

This PR simply removes the "Computing PR diff ranges" log group in favour of a log message instead.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
