### PR TITLE
fix: reduce redundant git-call-failed log messages in upload-sarif

### DIFF
--- a/src/git-utils.test.ts
+++ b/src/git-utils.test.ts
@@ -252,6 +252,7 @@ test.serial(
   "determineBaseBranchHeadCommitOid not git repository",
   async (t) => {
     const infoStub = sinon.stub(core, "info");
+    const debugStub = sinon.stub(core, "debug");
 
     process.env["GITHUB_EVENT_NAME"] = "pull_request";
     process.env["GITHUB_SHA"] = "100912429fab4cb230e66ffb11e738ac5194e73a";
@@ -260,17 +261,19 @@ test.serial(
       await gitUtils.determineBaseBranchHeadCommitOid(tmpDir);
     });
 
-    t.deepEqual(1, infoStub.callCount);
-    t.deepEqual(
-      infoStub.firstCall.args[0],
-      "git call failed. Will calculate the base branch SHA on the server. Error: " +
-        "The checkout path provided to the action does not appear to be a git repository.",
+    t.deepEqual(0, infoStub.callCount);
+    t.assert(
+      debugStub.calledWithMatch(
+        "git call failed. Will calculate the base branch SHA on the server. Error: " +
+          "The checkout path provided to the action does not appear to be a git repository.",
+      ),
     );
   },
 );
 
 test.serial("determineBaseBranchHeadCommitOid other error", async (t) => {
   const infoStub = sinon.stub(core, "info");
+  const debugStub = sinon.stub(core, "debug");
 
   process.env["GITHUB_EVENT_NAME"] = "pull_request";
   process.env["GITHUB_SHA"] = "100912429fab4cb230e66ffb11e738ac5194e73a";
@@ -278,14 +281,14 @@ test.serial("determineBaseBranchHeadCommitOid other error", async (t) => {
     path.join(__dirname, "../../i-dont-exist"),
   );
   t.deepEqual(result, undefined);
-  t.deepEqual(1, infoStub.callCount);
+  t.deepEqual(0, infoStub.callCount);
   t.assert(
-    infoStub.firstCall.args[0].startsWith(
+    debugStub.calledWithMatch(
       "git call failed. Will calculate the base branch SHA on the server. Error: ",
     ),
   );
   t.assert(
-    !infoStub.firstCall.args[0].endsWith(
+    !debugStub.firstCall.args[0].endsWith(
       "The checkout path provided to the action does not appear to be a git repository.",
     ),
   );

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -92,7 +92,7 @@ export const runGitCommand = async function (
       reason =
         "The checkout path provided to the action does not appear to be a git repository.";
     }
-    core.info(`git call failed. ${customErrorMessage} Error: ${reason}`);
+    core.debug(`git call failed. ${customErrorMessage} Error: ${reason}`);
     throw error;
   }
 };
@@ -119,6 +119,9 @@ export const getCommitOid = async function (
     );
     return stdout.trim();
   } catch {
+    core.info(
+      "Could not retrieve commit SHA from git; falling back to environment.",
+    );
     return getOptionalInput("sha") || getRequiredEnvParam("GITHUB_SHA");
   }
 };


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

When `upload-sarif` runs in a directory that is not a git repository, `runGitCommand` was calling `core.info` on every git call failure. Since callers such as `getCommitOid` and `determineBaseBranchHeadCommitOid` silently swallow the exception and fall back to environment variables, the same "not a git repository" diagnostic was emitted multiple times per run, adding noise without adding value.

This PR changes the log level in `runGitCommand` from `core.info` to `core.debug` so the full diagnostic is preserved for maintainers with debug logging enabled, but does not appear in normal output. A single `core.info` fallback notice is added in `getCommitOid` so callers still see exactly one actionable message when git is unavailable.

Fixes #3383.

### Risk assessment

- **Low risk:** Changes are test-covered, only affect log output levels, and have no impact on action behavior or correctness.

#### Which use cases does this change impact?

- **Third-party analyses** - The changes affect the `upload-sarif` action.

#### How did/will you validate this change?

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files). Existing `determineBaseBranchHeadCommitOid` tests have been updated to assert `core.debug` is called instead of `core.info`. All 30 tests in `src/git-utils.test.ts` pass.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.
- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

- **Other** - Log level changes are observable; if users report missing diagnostics, debug logging can be enabled.

#### Are there any special considerations for merging or releasing this change?

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
