### PR TITLE
Add repository property for configuration files

### DIFF
--- a/src/actions-util.ts
+++ b/src/actions-util.ts
@@ -22,6 +22,21 @@ import {
 declare const __CODEQL_ACTION_VERSION__: string;
 
 /**
+ * Abstracts over GitHub Actions functions so that we do not have to stub
+ * global functions in tests.
+ */
+export interface ActionsEnv {
+  getOptionalInput: (name: string) => string | undefined;
+}
+
+/**
+ * Gets the real `ActionsEnv` used by production code.
+ */
+export function getActionsEnv(): ActionsEnv {
+  return { getOptionalInput };
+}
+
+/**
  * Wrapper around core.getInput for inputs that always have a value.
  * Also see getOptionalInput.
  *

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -1,0 +1,26 @@
+import test from "ava";
+import sinon from "sinon";
+
+import { getTestActionsEnv, setupTests } from "../testing-utils";
+
+import { getConfigFileInput } from "./file";
+
+setupTests(test);
+
+test("getConfigFileInput returns undefined by default", async (t) => {
+  const actionsEnv = getTestActionsEnv();
+  const result = getConfigFileInput(actionsEnv);
+  t.is(result, undefined);
+});
+
+test("getConfigFileInput returns input value", async (t) => {
+  const actionsEnv = getTestActionsEnv();
+  const testInput = "/some/path";
+  sinon
+    .stub(actionsEnv, "getOptionalInput")
+    .withArgs("config-file")
+    .returns(testInput);
+
+  const result = getConfigFileInput(actionsEnv);
+  t.is(result, testInput);
+});

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -2,15 +2,20 @@ import test from "ava";
 import sinon from "sinon";
 
 import { RepositoryPropertyName } from "../feature-flags/properties";
-import { getTestActionsEnv, setupTests } from "../testing-utils";
+import {
+  getTestActionsEnv,
+  RecordingLogger,
+  setupTests,
+} from "../testing-utils";
 
 import { getConfigFileInput } from "./file";
 
 setupTests(test);
 
 test("getConfigFileInput returns undefined by default", async (t) => {
+  const logger = new RecordingLogger();
   const actionsEnv = getTestActionsEnv();
-  const result = getConfigFileInput(actionsEnv, {});
+  const result = getConfigFileInput(logger, actionsEnv, {});
   t.is(result, undefined);
 });
 
@@ -19,6 +24,7 @@ const repositoryProperties = {
 };
 
 test("getConfigFileInput returns input value", async (t) => {
+  const logger = new RecordingLogger();
   const actionsEnv = getTestActionsEnv();
   const testInput = "/some/path";
   sinon
@@ -28,14 +34,25 @@ test("getConfigFileInput returns input value", async (t) => {
 
   // Even though both an input and repository property are configured,
   // we prefer the direct input to the Action.
-  const result = getConfigFileInput(actionsEnv, repositoryProperties);
+  const result = getConfigFileInput(logger, actionsEnv, repositoryProperties);
   t.is(result, testInput);
+
+  // Check for the expected log message.
+  t.true(logger.hasMessage("Using configuration file input from workflow"));
 });
 
 test("getConfigFileInput returns repository property value", async (t) => {
+  const logger = new RecordingLogger();
   const actionsEnv = getTestActionsEnv();
 
   // Since there is no direct input, we should use the repository property.
-  const result = getConfigFileInput(actionsEnv, repositoryProperties);
+  const result = getConfigFileInput(logger, actionsEnv, repositoryProperties);
   t.is(result, repositoryProperties[RepositoryPropertyName.CONFIG_FILE]);
+
+  // Check for the expected log message.
+  t.true(
+    logger.hasMessage(
+      "Using configuration file input from repository property",
+    ),
+  );
 });

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -56,3 +56,14 @@ test("getConfigFileInput returns repository property value", async (t) => {
     ),
   );
 });
+
+test("getConfigFileInput ignores empty repository property value", async (t) => {
+  const logger = new RecordingLogger();
+  const actionsEnv = getTestActionsEnv();
+
+  // Since the repository property value is an empty/whitespace string, we should ignore it.
+  const result = getConfigFileInput(logger, actionsEnv, {
+    [RepositoryPropertyName.CONFIG_FILE]: "   ",
+  });
+  t.is(result, undefined);
+});

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -1,6 +1,7 @@
 import test from "ava";
 import sinon from "sinon";
 
+import { RepositoryPropertyName } from "../feature-flags/properties";
 import { getTestActionsEnv, setupTests } from "../testing-utils";
 
 import { getConfigFileInput } from "./file";
@@ -9,9 +10,13 @@ setupTests(test);
 
 test("getConfigFileInput returns undefined by default", async (t) => {
   const actionsEnv = getTestActionsEnv();
-  const result = getConfigFileInput(actionsEnv);
+  const result = getConfigFileInput(actionsEnv, {});
   t.is(result, undefined);
 });
+
+const repositoryProperties = {
+  [RepositoryPropertyName.CONFIG_FILE]: "/path/from/property",
+};
 
 test("getConfigFileInput returns input value", async (t) => {
   const actionsEnv = getTestActionsEnv();
@@ -21,6 +26,16 @@ test("getConfigFileInput returns input value", async (t) => {
     .withArgs("config-file")
     .returns(testInput);
 
-  const result = getConfigFileInput(actionsEnv);
+  // Even though both an input and repository property are configured,
+  // we prefer the direct input to the Action.
+  const result = getConfigFileInput(actionsEnv, repositoryProperties);
   t.is(result, testInput);
+});
+
+test("getConfigFileInput returns repository property value", async (t) => {
+  const actionsEnv = getTestActionsEnv();
+
+  // Since there is no direct input, we should use the repository property.
+  const result = getConfigFileInput(actionsEnv, repositoryProperties);
+  t.is(result, repositoryProperties[RepositoryPropertyName.CONFIG_FILE]);
 });

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -3,16 +3,32 @@ import {
   RepositoryProperties,
   RepositoryPropertyName,
 } from "../feature-flags/properties";
+import { Logger } from "../logging";
 
 /**
  * Gets the value that is configured for the configuration file, if any.
  */
 export function getConfigFileInput(
+  logger: Logger,
   actions: ActionsEnv,
   repositoryProperties: Partial<RepositoryProperties>,
 ): string | undefined {
-  return (
-    actions.getOptionalInput("config-file") ||
-    repositoryProperties[RepositoryPropertyName.CONFIG_FILE]
-  );
+  const input = actions.getOptionalInput("config-file");
+
+  if (input !== undefined) {
+    logger.info(`Using configuration file input from workflow: ${input}`);
+    return input;
+  }
+
+  const propertyValue =
+    repositoryProperties[RepositoryPropertyName.CONFIG_FILE];
+
+  if (propertyValue !== undefined) {
+    logger.info(
+      `Using configuration file input from repository property: ${propertyValue}`,
+    );
+    return propertyValue;
+  }
+
+  return undefined;
 }

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -23,7 +23,7 @@ export function getConfigFileInput(
   const propertyValue =
     repositoryProperties[RepositoryPropertyName.CONFIG_FILE];
 
-  if (propertyValue !== undefined) {
+  if (propertyValue !== undefined && propertyValue.trim().length > 0) {
     logger.info(
       `Using configuration file input from repository property: ${propertyValue}`,
     );

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -1,0 +1,8 @@
+import { ActionsEnv } from "../actions-util";
+
+/**
+ * Gets the value that is configured for the configuration file, if any.
+ */
+export function getConfigFileInput(actions: ActionsEnv): string | undefined {
+  return actions.getOptionalInput("config-file");
+}

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -1,8 +1,18 @@
 import { ActionsEnv } from "../actions-util";
+import {
+  RepositoryProperties,
+  RepositoryPropertyName,
+} from "../feature-flags/properties";
 
 /**
  * Gets the value that is configured for the configuration file, if any.
  */
-export function getConfigFileInput(actions: ActionsEnv): string | undefined {
-  return actions.getOptionalInput("config-file");
+export function getConfigFileInput(
+  actions: ActionsEnv,
+  repositoryProperties: Partial<RepositoryProperties>,
+): string | undefined {
+  return (
+    actions.getOptionalInput("config-file") ||
+    repositoryProperties[RepositoryPropertyName.CONFIG_FILE]
+  );
 }

--- a/src/feature-flags/properties.test.ts
+++ b/src/feature-flags/properties.test.ts
@@ -77,6 +77,7 @@ test.serial("loadPropertiesFromApi loads known properties", async (t) => {
     status: 200,
     url: "",
     data: [
+      { property_name: "github-codeql-config-file", value: "owner/repo" },
       { property_name: "github-codeql-extra-queries", value: "+queries" },
       { property_name: "unknown-property", value: "something" },
     ] satisfies properties.GitHubPropertiesResponse,
@@ -87,7 +88,10 @@ test.serial("loadPropertiesFromApi loads known properties", async (t) => {
     logger,
     mockRepositoryNwo,
   );
-  t.deepEqual(response, { "github-codeql-extra-queries": "+queries" });
+  t.deepEqual(response, {
+    "github-codeql-config-file": "owner/repo",
+    "github-codeql-extra-queries": "+queries",
+  });
 });
 
 test.serial("loadPropertiesFromApi parses true boolean property", async (t) => {

--- a/src/feature-flags/properties.ts
+++ b/src/feature-flags/properties.ts
@@ -10,6 +10,7 @@ export const GITHUB_CODEQL_PROPERTY_PREFIX = "github-codeql-";
  * Enumerates repository property names that have some meaning to us.
  */
 export enum RepositoryPropertyName {
+  CONFIG_FILE = "github-codeql-config-file",
   DISABLE_OVERLAY = "github-codeql-disable-overlay",
   EXTRA_QUERIES = "github-codeql-extra-queries",
   FILE_COVERAGE_ON_PRS = "github-codeql-file-coverage-on-prs",
@@ -17,6 +18,7 @@ export enum RepositoryPropertyName {
 
 /** Parsed types of the known repository properties. */
 export type AllRepositoryProperties = {
+  [RepositoryPropertyName.CONFIG_FILE]: string;
   [RepositoryPropertyName.DISABLE_OVERLAY]: boolean;
   [RepositoryPropertyName.EXTRA_QUERIES]: string;
   [RepositoryPropertyName.FILE_COVERAGE_ON_PRS]: boolean;
@@ -27,6 +29,7 @@ export type RepositoryProperties = Partial<AllRepositoryProperties>;
 
 /** Maps known repository properties to the type we expect to get from the API. */
 export type RepositoryPropertyApiType = {
+  [RepositoryPropertyName.CONFIG_FILE]: string;
   [RepositoryPropertyName.DISABLE_OVERLAY]: string;
   [RepositoryPropertyName.EXTRA_QUERIES]: string;
   [RepositoryPropertyName.FILE_COVERAGE_ON_PRS]: string;
@@ -74,6 +77,7 @@ const booleanProperty = {
 const repositoryPropertyParsers: {
   [K in RepositoryPropertyName]: PropertyInfo<K>;
 } = {
+  [RepositoryPropertyName.CONFIG_FILE]: stringProperty,
   [RepositoryPropertyName.DISABLE_OVERLAY]: booleanProperty,
   [RepositoryPropertyName.EXTRA_QUERIES]: stringProperty,
   [RepositoryPropertyName.FILE_COVERAGE_ON_PRS]: booleanProperty,

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -263,7 +263,7 @@ async function run(startedAt: Date) {
 
     core.exportVariable(EnvVar.INIT_ACTION_HAS_RUN, "true");
 
-    configFile = getConfigFileInput(actionsEnv, repositoryProperties);
+    configFile = getConfigFileInput(logger, actionsEnv, repositoryProperties);
 
     // path.resolve() respects the intended semantics of source-root. If
     // source-root is relative, it is relative to the GITHUB_WORKSPACE. If

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -254,6 +254,7 @@ async function run(startedAt: Date) {
       repositoryNwo,
       logger,
     );
+    const repositoryProperties = repositoryPropertiesResult.orElse({});
 
     // Create a unique identifier for this run.
     const jobRunUuid = uuidV4();
@@ -262,7 +263,7 @@ async function run(startedAt: Date) {
 
     core.exportVariable(EnvVar.INIT_ACTION_HAS_RUN, "true");
 
-    configFile = getConfigFileInput(actionsEnv);
+    configFile = getConfigFileInput(actionsEnv, repositoryProperties);
 
     // path.resolve() respects the intended semantics of source-root. If
     // source-root is relative, it is relative to the GITHUB_WORKSPACE. If
@@ -353,7 +354,6 @@ async function run(startedAt: Date) {
 
     analysisKinds = await getAnalysisKinds(logger, features);
     const debugMode = getOptionalInput("debug") === "true" || core.isDebug();
-    const repositoryProperties = repositoryPropertiesResult.orElse({});
     const fileCoverageResult = await getFileCoverageInformationEnabled(
       debugMode,
       codeql,

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -9,6 +9,7 @@ import { v4 as uuidV4 } from "uuid";
 
 import {
   FileCmdNotFoundError,
+  getActionsEnv,
   getActionVersion,
   getFileType,
   getOptionalInput,
@@ -24,6 +25,7 @@ import {
   shouldRestoreCache,
 } from "./caching-utils";
 import { CodeQL } from "./codeql";
+import { getConfigFileInput } from "./config/file";
 import * as configUtils from "./config-utils";
 import {
   DependencyCacheRestoreStatusReport,
@@ -207,6 +209,7 @@ async function run(startedAt: Date) {
   // possible, and only use safe functions outside.
 
   const logger = getActionsLogger();
+  const actionsEnv = getActionsEnv();
 
   let apiDetails: GitHubApiCombinedDetails;
   let config: configUtils.Config | undefined;
@@ -259,7 +262,7 @@ async function run(startedAt: Date) {
 
     core.exportVariable(EnvVar.INIT_ACTION_HAS_RUN, "true");
 
-    configFile = getOptionalInput("config-file");
+    configFile = getConfigFileInput(actionsEnv);
 
     // path.resolve() respects the intended semantics of source-root. If
     // source-root is relative, it is relative to the GITHUB_WORKSPACE. If

--- a/src/testing-utils.ts
+++ b/src/testing-utils.ts
@@ -10,7 +10,7 @@ import test, {
 import nock from "nock";
 import * as sinon from "sinon";
 
-import { getActionVersion } from "./actions-util";
+import { ActionsEnv, getActionVersion } from "./actions-util";
 import { AnalysisKind } from "./analyses";
 import * as apiClient from "./api-client";
 import { GitHubApiDetails } from "./api-client";
@@ -170,6 +170,15 @@ export function makeMacro<Args extends unknown[]>(
   wrapper.fn = decl.exec;
 
   return wrapper;
+}
+
+/**
+ * Gets an `ActionsEnv` instance for use in tests.
+ */
+export function getTestActionsEnv(): ActionsEnv {
+  return {
+    getOptionalInput: () => undefined,
+  };
 }
 
 /**


### PR DESCRIPTION
This PR is the first in a series of changes which will add the ability to point the CodeQL Action at a configuration file using a repository property.

This PR adds the new repository property and uses its value, if provided and no explicit `config-file` input is provided for the CodeQL Action in the workflow. In other words, the `config-file` input has priority over the value of the repository property.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
