### PR TITLE
Remove `ready_for_review` triggers from workflows

### DIFF
--- a/.github/actions/prepare-mergeback-branch/action.yml
+++ b/.github/actions/prepare-mergeback-branch/action.yml
@@ -91,18 +91,15 @@ runs:
 
           Please do the following:
 
-          - [ ] Mark the PR as ready for review to trigger the full set of PR checks.
+          - [ ] Approve running the full set of PR checks.
           - [ ] Approve and merge the PR. When merging the PR, make sure "Create a merge commit" is
                 selected rather than "Squash and merge" or "Rebase and merge".
         EOF
         )
 
-        # PR checks won't be triggered on PRs created by Actions. Therefore mark the PR as draft
-        # so that a maintainer can take the PR out of draft, thereby triggering the PR checks.
         gh pr create \
           --head "${NEW_BRANCH}" \
           --base "${BASE_BRANCH}" \
           --title "${pr_title}" \
           --body "${pr_body}" \
-          --assignee "${GITHUB_ACTOR}" \
-          --draft
+          --assignee "${GITHUB_ACTOR}"

--- a/.github/update-release-branch.py
+++ b/.github/update-release-branch.py
@@ -136,7 +136,7 @@ def open_pr(
   body.append(f' - [ ] Check that there are not any unexpected commits being merged into the `{target_branch}` branch.')
   body.append(' - [ ] Ensure the docs team is aware of any documentation changes that need to be released.')
 
-  body.append(' - [ ] Mark the PR as ready for review to trigger the full set of PR checks.')
+  body.append(' - [ ] Approve running the full set of PR checks if you have not pushed any changes.')
   body.append(' - [ ] Approve and merge this PR. Make sure `Create a merge commit` is selected rather than `Squash and merge` or `Rebase and merge`.')
 
   if is_primary_release:
@@ -146,9 +146,7 @@ def open_pr(
   title = f'Merge {source_branch} into {target_branch}'
 
   # Create the pull request
-  # PR checks won't be triggered on PRs created by Actions. Therefore mark the PR as draft so that
-  # a maintainer can take the PR out of draft, thereby triggering the PR checks.
-  pr = repo.create_pull(title=title, body='\n'.join(body), head=new_branch_name, base=target_branch, draft=True)
+  pr = repo.create_pull(title=title, body='\n'.join(body), head=new_branch_name, base=target_branch)
   print(f'Created PR #{str(pr.number)}')
 
   # Assign the conductor

--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__analysis-kinds.yml
+++ b/.github/workflows/__analysis-kinds.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
+++ b/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__autobuild-working-dir.yml
+++ b/.github/workflows/__autobuild-working-dir.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__build-mode-autobuild.yml
+++ b/.github/workflows/__build-mode-autobuild.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__build-mode-none.yml
+++ b/.github/workflows/__build-mode-none.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__build-mode-rollback.yml
+++ b/.github/workflows/__build-mode-rollback.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__bundle-from-nightly.yml
+++ b/.github/workflows/__bundle-from-nightly.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__bundle-from-toolcache.yml
+++ b/.github/workflows/__bundle-from-toolcache.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__bundle-toolcache.yml
+++ b/.github/workflows/__bundle-toolcache.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__bundle-zstd.yml
+++ b/.github/workflows/__bundle-zstd.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__cleanup-db-cluster-dir.yml
+++ b/.github/workflows/__cleanup-db-cluster-dir.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__config-input.yml
+++ b/.github/workflows/__config-input.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__global-proxy.yml
+++ b/.github/workflows/__global-proxy.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__job-run-uuid-sarif.yml
+++ b/.github/workflows/__job-run-uuid-sarif.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__local-bundle.yml
+++ b/.github/workflows/__local-bundle.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__overlay-init-fallback.yml
+++ b/.github/workflows/__overlay-init-fallback.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__rust.yml
+++ b/.github/workflows/__rust.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__upload-sarif.yml
+++ b/.github/workflows/__upload-sarif.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -12,12 +12,7 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  pull_request: {}
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/check-expected-release-files.yml
+++ b/.github/workflows/check-expected-release-files.yml
@@ -5,9 +5,6 @@ on:
     paths:
       - .github/workflows/check-expected-release-files.yml
       - src/defaults.json
-    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
-    # by other workflows.
-    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main, releases/v*]
   pull_request:
-    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
-    # by other workflows.
-    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/codescanning-config-cli.yml
+++ b/.github/workflows/codescanning-config-cli.yml
@@ -13,11 +13,6 @@ on:
     - main
     - releases/v*
   pull_request:
-    types:
-    - opened
-    - synchronize
-    - reopened
-    - ready_for_review
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/debug-artifacts-failure-safe.yml
+++ b/.github/workflows/debug-artifacts-failure-safe.yml
@@ -9,11 +9,6 @@ on:
     - main
     - releases/v*
   pull_request:
-    types:
-    - opened
-    - synchronize
-    - reopened
-    - ready_for_review
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/debug-artifacts-safe.yml
+++ b/.github/workflows/debug-artifacts-safe.yml
@@ -8,11 +8,6 @@ on:
     - main
     - releases/v*
   pull_request:
-    types:
-    - opened
-    - synchronize
-    - reopened
-    - ready_for_review
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/label-pr-size.yml
+++ b/.github/workflows/label-pr-size.yml
@@ -2,6 +2,11 @@ name: Label PR with size
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 permissions:
   contents: read

--- a/.github/workflows/label-pr-size.yml
+++ b/.github/workflows/label-pr-size.yml
@@ -2,12 +2,6 @@ name: Label PR with size
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - edited
-      - ready_for_review
 
 permissions:
   contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,9 +3,6 @@ name: PR Checks
 on:
   push:
   pull_request:
-    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
-    # by other workflows.
-    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/python312-windows.yml
+++ b/.github/workflows/python312-windows.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main, releases/v*]
   pull_request:
-    # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
-    # by other workflows.
-    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/query-filters.yml
+++ b/.github/workflows/query-filters.yml
@@ -6,11 +6,6 @@ on:
     - main
     - releases/v*
   pull_request:
-    types:
-    - opened
-    - synchronize
-    - reopened
-    - ready_for_review
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -143,6 +143,5 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "Pushed a commit to rebuild the Action." \
-            "Please mark the PR as ready for review to trigger PR checks." |
+            "Please approve running the PR checks." |
             gh pr comment --body-file - --repo github/codeql-action "$PR_NUMBER"
-          gh pr ready --undo --repo github/codeql-action "$PR_NUMBER"

--- a/.github/workflows/test-codeql-bundle-all.yml
+++ b/.github/workflows/test-codeql-bundle-all.yml
@@ -8,11 +8,6 @@ on:
     - main
     - releases/v*
   pull_request:
-    types:
-    - opened
-    - synchronize
-    - reopened
-    - ready_for_review
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/update-bundle.yml
+++ b/.github/workflows/update-bundle.yml
@@ -114,7 +114,6 @@ jobs:
             --title "Update default bundle to $cli_version" \
             --body "$pr_body" \
             --assignee "$GITHUB_ACTOR" \
-            --draft \
           )
           echo "CLI_VERSION=$cli_version" | tee -a "$GITHUB_ENV"
           echo "PR_URL=$pr_url" | tee -a "$GITHUB_ENV"

--- a/pr-checks/sync.ts
+++ b/pr-checks/sync.ts
@@ -724,9 +724,7 @@ function main(): void {
         push: {
           branches: ["main", "releases/v*"],
         },
-        pull_request: {
-          types: ["opened", "synchronize", "reopened", "ready_for_review"],
-        },
+        pull_request: {},
         merge_group: {
           types: ["checks_requested"],
         },


### PR DESCRIPTION
For CI-generated commits, we have used the workaround of creating draft PRs and marking them as "Ready for review" to trigger workflows using the `ready_for_review` type for `pull_request` events. This appears to no longer be necessary, because we can now click on the "Approve workflow runs" button in the UI instead.

This PR removes the `ready_for_review` triggers we had specifically for this purpose (allowing us to revert to not specifying the event types at all, because the remaining list matches the default list). It also updates the automation where we create PRs to no longer create or mark them as drafts.

Removing the `ready_for_review` triggers has the additional benefit that, for regular PRs, we no longer end up running the workflows twice if they have already run while the PR was a draft.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Other** - Please provide details.

Validated this approach in a different repository which has the same scenario.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Other** - Please provide details.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
