### PR TITLE
Fix `XCode16` no longer being available on `latest` runners

### DIFF
--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -129,10 +129,6 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Use Xcode 16
-        if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
-        run: sudo xcode-select -s "/Applications/Xcode_16.app"
-
       - uses: ./../action/init
         id: init
         with:

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -91,9 +91,6 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - name: Use Xcode 16
-        if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
-        run: sudo xcode-select -s "/Applications/Xcode_16.app"
       - uses: ./../action/init
         id: init
         with:

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -17,10 +17,6 @@ steps:
     with:
       python-version: "3.13"
 
-  - name: Use Xcode 16
-    if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
-    run: sudo xcode-select -s "/Applications/Xcode_16.app"
-
   - uses: ./../action/init
     id: init
     with:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -11,9 +11,6 @@ installDotNet: true
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
-  - name: Use Xcode 16
-    if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
-    run: sudo xcode-select -s "/Applications/Xcode_16.app"
   - uses: ./../action/init
     id: init
     with:


### PR DESCRIPTION
Xcode 16 is no longer available by default on `macos-latest` runners and trying to `xcode-select` it fails as a result. However, we still require Xcode 16 for CodeQL `v2.19.4` and `v2.20.7`.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

- **Other** - Please provide details.

CI.

#### Are there any special considerations for merging or releasing this change?

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
