### PR TITLE
Pin Swift macOS PR checks to macOS 15 for Xcode 16

### DIFF
--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -81,19 +81,19 @@ jobs:
             version: stable-v2.23.9
           - os: ubuntu-latest
             version: stable-v2.24.3
-          - os: macos-15-xlarge
+          - os: macos-latest-xlarge
             version: stable-v2.24.3
           - os: ubuntu-latest
             version: default
-          - os: macos-15-xlarge
+          - os: macos-latest-xlarge
             version: default
           - os: ubuntu-latest
             version: linked
-          - os: macos-15-xlarge
+          - os: macos-latest-xlarge
             version: linked
           - os: ubuntu-latest
             version: nightly-latest
-          - os: macos-15-xlarge
+          - os: macos-latest-xlarge
             version: nightly-latest
     name: Multi-language repository
     if: github.triggering_actor != 'dependabot[bot]'
@@ -130,7 +130,8 @@ jobs:
           python-version: '3.13'
 
       - name: Use Xcode 16
-        if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
+        # Only the older CodeQL CLI versions need Xcode 16, and these run on macOS 15.
+        if: matrix.os == 'macos-15-xlarge'
         run: sudo xcode-select -s "/Applications/Xcode_16.app"
 
       - uses: ./../action/init

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -61,39 +61,39 @@ jobs:
         include:
           - os: ubuntu-latest
             version: stable-v2.19.4
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: stable-v2.19.4
           - os: ubuntu-latest
             version: stable-v2.20.7
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: stable-v2.20.7
           - os: ubuntu-latest
             version: stable-v2.21.4
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: stable-v2.21.4
           - os: ubuntu-latest
             version: stable-v2.22.4
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: stable-v2.22.4
           - os: ubuntu-latest
             version: stable-v2.23.9
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: stable-v2.23.9
           - os: ubuntu-latest
             version: stable-v2.24.3
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: stable-v2.24.3
           - os: ubuntu-latest
             version: default
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: default
           - os: ubuntu-latest
             version: linked
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: linked
           - os: ubuntu-latest
             version: nightly-latest
-          - os: macos-latest-xlarge
+          - os: macos-15-xlarge
             version: nightly-latest
     name: Multi-language repository
     if: github.triggering_actor != 'dependabot[bot]'

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -77,7 +77,7 @@ jobs:
             version: stable-v2.22.4
           - os: ubuntu-latest
             version: stable-v2.23.9
-          - os: macos-15-xlarge
+          - os: macos-latest-xlarge
             version: stable-v2.23.9
           - os: ubuntu-latest
             version: stable-v2.24.3

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,11 +59,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             version: linked
-          - os: macos-latest
+          - os: macos-15
             version: default
-          - os: macos-latest
+          - os: macos-15
             version: nightly-latest
     name: Swift analysis using a custom build command
     if: github.triggering_actor != 'dependabot[bot]'

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -59,11 +59,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15
+          - os: macos-latest
             version: linked
-          - os: macos-15
+          - os: macos-latest
             version: default
-          - os: macos-15
+          - os: macos-latest
             version: nightly-latest
     name: Swift analysis using a custom build command
     if: github.triggering_actor != 'dependabot[bot]'
@@ -91,9 +91,6 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - name: Use Xcode 16
-        if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
-        run: sudo xcode-select -s "/Applications/Xcode_16.app"
       - uses: ./../action/init
         id: init
         with:

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -2,16 +2,8 @@ name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
 operatingSystems:
   - ubuntu
-  # Newer CodeQL CLI versions support Swift 6.2, so analyse Swift on the latest macOS runner
-  # (currently macOS 26) with its default Xcode. This exercises the common combination of a
-  # recent CLI on a recent runner.
   - os: macos
     runner-image: macos-latest-xlarge
-    codeql-versions:
-      - stable-v2.24.3
-      - default
-      - linked
-      - nightly-latest
   # Older CodeQL CLI versions only support Swift up to 6.1, which requires Xcode 16. That is
   # not available on macOS 26, so run these versions on macOS 15 where we select Xcode 16
   # below. See https://github.com/actions/runner-images/issues/14167.
@@ -22,7 +14,6 @@ operatingSystems:
       - stable-v2.20.7
       - stable-v2.21.4
       - stable-v2.22.4
-      - stable-v2.23.9
 env:
   CODEQL_ACTION_RESOLVE_SUPPORTED_LANGUAGES_USING_CLI: true
 installGo: true

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -2,11 +2,27 @@ name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
 operatingSystems:
   - ubuntu
-  # Pin to macOS 15 rather than `macos-latest`: the older CodeQL CLI versions in the
-  # matrix only support Swift up to 6.1 (Xcode 16), which is not available on macOS 26
-  # (ships Xcode 26 / Swift 6.2). See https://github.com/actions/runner-images/issues/14167.
+  # Newer CodeQL CLI versions support Swift 6.2, so analyse Swift on the latest macOS runner
+  # (currently macOS 26) with its default Xcode. This exercises the common combination of a
+  # recent CLI on a recent runner.
+  - os: macos
+    runner-image: macos-latest-xlarge
+    codeql-versions:
+      - stable-v2.24.3
+      - default
+      - linked
+      - nightly-latest
+  # Older CodeQL CLI versions only support Swift up to 6.1, which requires Xcode 16. That is
+  # not available on macOS 26, so run these versions on macOS 15 where we select Xcode 16
+  # below. See https://github.com/actions/runner-images/issues/14167.
   - os: macos
     runner-image: macos-15-xlarge
+    codeql-versions:
+      - stable-v2.19.4
+      - stable-v2.20.7
+      - stable-v2.21.4
+      - stable-v2.22.4
+      - stable-v2.23.9
 env:
   CODEQL_ACTION_RESOLVE_SUPPORTED_LANGUAGES_USING_CLI: true
 installGo: true
@@ -21,7 +37,8 @@ steps:
       python-version: "3.13"
 
   - name: Use Xcode 16
-    if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
+    # Only the older CodeQL CLI versions need Xcode 16, and these run on macOS 15.
+    if: matrix.os == 'macos-15-xlarge'
     run: sudo xcode-select -s "/Applications/Xcode_16.app"
 
   - uses: ./../action/init

--- a/pr-checks/checks/multi-language-autodetect.yml
+++ b/pr-checks/checks/multi-language-autodetect.yml
@@ -2,8 +2,11 @@ name: "Multi-language repository"
 description: "An end-to-end integration test of a multi-language repository using automatic language detection"
 operatingSystems:
   - ubuntu
+  # Pin to macOS 15 rather than `macos-latest`: the older CodeQL CLI versions in the
+  # matrix only support Swift up to 6.1 (Xcode 16), which is not available on macOS 26
+  # (ships Xcode 26 / Swift 6.2). See https://github.com/actions/runner-images/issues/14167.
   - os: macos
-    runner-image: macos-latest-xlarge
+    runner-image: macos-15-xlarge
 env:
   CODEQL_ACTION_RESOLVE_SUPPORTED_LANGUAGES_USING_CLI: true
 installGo: true

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -5,7 +5,11 @@ versions:
   - default
   - nightly-latest
 operatingSystems:
-  - macos
+  # Pin to macOS 15 rather than `macos-latest`: the `linked`/`default` CodeQL CLI versions
+  # are analysed with Xcode 16, which is not available on macOS 26 (ships Xcode 26 / Swift
+  # 6.2). See https://github.com/actions/runner-images/issues/14167.
+  - os: macos
+    runner-image: macos-15
 installGo: true
 installDotNet: true
 env:

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -5,19 +5,12 @@ versions:
   - default
   - nightly-latest
 operatingSystems:
-  # Pin to macOS 15 rather than `macos-latest`: the `linked`/`default` CodeQL CLI versions
-  # are analysed with Xcode 16, which is not available on macOS 26 (ships Xcode 26 / Swift
-  # 6.2). See https://github.com/actions/runner-images/issues/14167.
-  - os: macos
-    runner-image: macos-15
+  - macos
 installGo: true
 installDotNet: true
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
 steps:
-  - name: Use Xcode 16
-    if: runner.os == 'macOS' && matrix.version != 'nightly-latest'
-    run: sudo xcode-select -s "/Applications/Xcode_16.app"
   - uses: ./../action/init
     id: init
     with:

--- a/pr-checks/sync.ts
+++ b/pr-checks/sync.ts
@@ -55,9 +55,10 @@ type OperatingSystem =
       /** Optional runner image label. */
       "runner-image"?: string;
       /**
-       * Optional CodeQL versions to run on this entry. If specified, only these versions are
-       * tested on this runner image. This allows running different runner images for different
-       * CodeQL versions of the same OS.
+       * Optional CodeQL versions to run on this entry. If specified, this entry runs only these
+       * versions. A sibling entry for the same OS that omits `codeql-versions` runs all versions
+       * not claimed by any sibling entry. This allows pinning specific CodeQL versions to a
+       * particular runner image while letting the remaining versions default to another.
        */
       "codeql-versions"?: string[];
     };
@@ -358,6 +359,28 @@ function generateJobMatrix(
 ): Array<Record<string, any>> {
   let matrix: Array<Record<string, any>> = [];
 
+  const operatingSystems = checkSpecification.operatingSystems ?? ["ubuntu"];
+
+  // For each OS, collect the CodeQL versions explicitly claimed by entries that specify
+  // `codeql-versions`. A sibling entry for the same OS that omits `codeql-versions` runs all
+  // versions not in this set.
+  const claimedVersionsByOs = new Map<string, Set<string>>();
+  for (const operatingSystemConfig of operatingSystems) {
+    if (typeof operatingSystemConfig === "string") {
+      continue;
+    }
+    const entryVersions = operatingSystemConfig["codeql-versions"];
+    if (!entryVersions) {
+      continue;
+    }
+    const claimed =
+      claimedVersionsByOs.get(operatingSystemConfig.os) ?? new Set<string>();
+    for (const entryVersion of entryVersions) {
+      claimed.add(entryVersion);
+    }
+    claimedVersionsByOs.set(operatingSystemConfig.os, claimed);
+  }
+
   for (const version of checkSpecification.versions ?? defaultTestVersions) {
     if (version === "latest") {
       throw new Error(
@@ -370,7 +393,6 @@ function generateJobMatrix(
       "macos-latest",
       "windows-latest",
     ];
-    const operatingSystems = checkSpecification.operatingSystems ?? ["ubuntu"];
 
     for (const operatingSystemConfig of operatingSystems) {
       const operatingSystem =
@@ -385,12 +407,16 @@ function generateJobMatrix(
         continue;
       }
 
-      // If this OS entry restricts itself to specific CodeQL versions, skip other versions.
+      // An entry that specifies `codeql-versions` runs only those versions. A sibling entry for
+      // the same OS that omits `codeql-versions` runs all versions not claimed by its siblings.
       const entryVersions =
         typeof operatingSystemConfig === "string"
           ? undefined
           : operatingSystemConfig["codeql-versions"];
-      if (entryVersions && !entryVersions.includes(version)) {
+      const runsThisVersion = entryVersions
+        ? entryVersions.includes(version)
+        : !claimedVersionsByOs.get(operatingSystem)?.has(version);
+      if (!runsThisVersion) {
         continue;
       }
 

--- a/pr-checks/sync.ts
+++ b/pr-checks/sync.ts
@@ -54,6 +54,12 @@ type OperatingSystem =
       os: OperatingSystemIdentifier;
       /** Optional runner image label. */
       "runner-image"?: string;
+      /**
+       * Optional CodeQL versions to run on this entry. If specified, only these versions are
+       * tested on this runner image. This allows running different runner images for different
+       * CodeQL versions of the same OS.
+       */
+      "codeql-versions"?: string[];
     };
 
 /**
@@ -376,6 +382,15 @@ function generateJobMatrix(
       const allowedVersions =
         checkSpecification.osCodeQlVersions?.[operatingSystem];
       if (allowedVersions && !allowedVersions.includes(version)) {
+        continue;
+      }
+
+      // If this OS entry restricts itself to specific CodeQL versions, skip other versions.
+      const entryVersions =
+        typeof operatingSystemConfig === "string"
+          ? undefined
+          : operatingSystemConfig["codeql-versions"];
+      if (entryVersions && !entryVersions.includes(version)) {
         continue;
       }
 


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.
-->

The `macos-latest-xlarge` label has started resolving to **macOS 26**, which ships only Xcode 26 (Swift 6.2) and no longer includes Xcode 16. Our Swift-analysing PR checks explicitly select Xcode 16 (`xcode-select -s /Applications/Xcode_16.app`) because CodeQL CLI versions before 2.24.0 only support Swift up to 6.1. That step now fails on macOS 26, which is why the *Multi-language repository* check is red.

We still want to exercise the full matrix of supported CodeQL versions (back to 2.19.4) against Swift, so we can't simply move to Xcode 26. Instead, this pins the affected checks to macOS 15, where Xcode 16 is still available:

- `multi-language-autodetect`: `macos-latest-xlarge` -> `macos-15-xlarge`

This restores the runner that `macos-latest-xlarge` pointed at before the migration, so it is a known-good configuration. The generated `__*.yml` workflows were regenerated via `npm run update-pr-checks`. Once the minimum supported CodeQL version reaches 2.24.0, these checks can drop the Xcode 16 pin and move back to `macos-latest`.

The nightly-only Swift checks (`swift-autobuild`, `export-file-baseline-information`) are intentionally left on macOS 26, since nightly CodeQL supports Swift 6.2 with the default Xcode.

See https://github.com/actions/runner-images/issues/14167.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

- **Other** - The affected PR checks will fail in CI.

#### Are there any special considerations for merging or releasing this change?

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change. N/A - CI/test-only change with no user-facing impact.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary. N/A