### PR TITLE
Categorize Code Quality "not enabled" upload failure as user-error

### DIFF
--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -181,6 +181,7 @@ test.serial(
       "Code Security must be enabled for this repository to use code scanning",
       "Advanced Security must be enabled for this repository to use code scanning",
       "Code Scanning is not enabled for this repository. Please enable code scanning in the repository settings.",
+      "Code quality is not enabled for this repository. Please enable code quality in the repository settings.",
     ];
     const transforms = [
       (msg: string) => msg,

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -311,6 +311,7 @@ function isEnablementError(msg: string) {
     /Code Security must be enabled/i,
     /Advanced Security must be enabled/i,
     /Code Scanning is not enabled/i,
+    /Code Quality is not enabled/i,
   ].some((pattern) => pattern.test(msg));
 }
 


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.
-->

When a repository requests Code Quality analysis but it is not enabled, the analyze/`finish` job fails and is reported with `status=failure`, when it should be `user-error`: this is a customer configuration problem, not a CodeQL Action bug. We saw a burst of ~290 such failures from a single org, all surfacing this miscategorization.

The root cause is the code-quality SARIF upload (`PUT /repos/:owner/:repo/code-quality/analysis`). On a 403 it returns the message `Code quality is not enabled for this repository. Please enable code quality in the repository settings.`. `wrapApiConfigurationError` only converts a 403 into a `ConfigurationError` when `isEnablementError` matches a known pattern, and none of the existing patterns covered the Code Quality wording. So the error stayed a plain `Error`, and `getActionsStatus` mapped it to `failure`.

This change adds a `/Code Quality is not enabled/i` pattern to `isEnablementError`, mirroring the existing `/Code Scanning is not enabled/i` entry. The error now becomes a `ConfigurationError` and is correctly categorized as `user-error`. The case-insensitive flag tolerates the observed lowercase wording. The existing enablement-error unit test in `src/api-client.test.ts` is extended with the Code Quality message. The change is intentionally surgical, with no broader error-handling refactor.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Documentation/test-only and telemetry categorization only; no change to upload behavior or control flow beyond how an already-failing case is labelled.

#### Which use cases does this change impact?

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files). The existing enablement-error test is extended with the Code Quality message.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix. The blast radius is limited to how an already-failing upload is categorized in telemetry.

#### How will you know if something goes wrong after this change is released?

- **Telemetry** - The status report `report_status.status` for these Code Quality enablement failures should move from `failure` to `user-error`.

#### Are there any special considerations for merging or releasing this change?

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.