### PR TITLE
Support `undefined`, `number` in JSON module

### DIFF
--- a/src/json/index.test.ts
+++ b/src/json/index.test.ts
@@ -10,8 +10,8 @@ const testSchema = {
   requiredKey: json.string,
 };
 
-const optionalSchema = {
-  optionalKey: json.optional(json.string),
+const optionalOrNullSchema = {
+  optionalKey: json.optionalOrNull(json.string),
 };
 
 test("validateSchema - required properties are required", async (t) => {
@@ -30,11 +30,34 @@ test("validateSchema - required properties are required", async (t) => {
 
 test("validateSchema - optional properties are optional", async (t) => {
   // Optional fields may be absent
-  t.true(json.validateSchema(optionalSchema, {}));
-  t.true(json.validateSchema(optionalSchema, { optionalKey: undefined }));
-  t.true(json.validateSchema(optionalSchema, { optionalKey: null }));
+  t.true(json.validateSchema(optionalOrNullSchema, {}));
+  t.true(json.validateSchema(optionalOrNullSchema, { optionalKey: undefined }));
+  t.true(json.validateSchema(optionalOrNullSchema, { optionalKey: null }));
 
   // But, if present, should have the expected type
+  t.false(json.validateSchema(optionalOrNullSchema, { optionalKey: 0 }));
+  t.false(json.validateSchema(optionalOrNullSchema, { optionalKey: 123 }));
+  t.false(json.validateSchema(optionalOrNullSchema, { optionalKey: false }));
+  t.false(json.validateSchema(optionalOrNullSchema, { optionalKey: true }));
+  t.false(json.validateSchema(optionalOrNullSchema, { optionalKey: [] }));
+  t.false(json.validateSchema(optionalOrNullSchema, { optionalKey: {} }));
+  t.true(json.validateSchema(optionalOrNullSchema, { optionalKey: "" }));
+  t.true(json.validateSchema(optionalOrNullSchema, { optionalKey: "foo" }));
+});
+
+const optionalSchema = {
+  optionalKey: json.optional(json.string),
+};
+
+test("validateSchema - optional properties may be absent or undefined, but reject null", async (t) => {
+  // Optional fields may be absent or explicitly undefined
+  t.true(json.validateSchema(optionalSchema, {}));
+  t.true(json.validateSchema(optionalSchema, { optionalKey: undefined }));
+
+  // But should reject null
+  t.false(json.validateSchema(optionalSchema, { optionalKey: null }));
+
+  // And, if present, should have the expected type
   t.false(json.validateSchema(optionalSchema, { optionalKey: 0 }));
   t.false(json.validateSchema(optionalSchema, { optionalKey: 123 }));
   t.false(json.validateSchema(optionalSchema, { optionalKey: false }));

--- a/src/json/index.test.ts
+++ b/src/json/index.test.ts
@@ -28,7 +28,7 @@ test("validateSchema - required properties are required", async (t) => {
   t.true(json.validateSchema(testSchema, { requiredKey: "foo" }));
 });
 
-test("validateSchema - optional properties are optional", async (t) => {
+test("validateSchema - optionalOrNullSchema properties are optional or null", async (t) => {
   // Optional fields may be absent
   t.true(json.validateSchema(optionalOrNullSchema, {}));
   t.true(json.validateSchema(optionalOrNullSchema, { optionalKey: undefined }));
@@ -49,7 +49,7 @@ const optionalSchema = {
   optionalKey: json.optional(json.string),
 };
 
-test("validateSchema - optional properties may be absent or undefined, but reject null", async (t) => {
+test("validateSchema - optional properties are optional", async (t) => {
   // Optional fields may be absent or explicitly undefined
   t.true(json.validateSchema(optionalSchema, {}));
   t.true(json.validateSchema(optionalSchema, { optionalKey: undefined }));

--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -66,14 +66,30 @@ export const number = {
   required: true,
 } as const satisfies Validator<number>;
 
-/** Transforms a validator to be optional. */
-export function optional<T>(validator: Validator<T>) {
+/**
+ * Transforms a validator to be optional, accepting `undefined` or `null` for an
+ * absent value.
+ */
+export function optionalOrNull<T>(validator: Validator<T>) {
   return {
     validate: (val: unknown) => {
       return val === undefined || val === null || validator.validate(val);
     },
     required: false,
   } as const satisfies Validator<T | undefined | null>;
+}
+
+/**
+ * Transforms a validator to be optional, accepting `undefined` for an absent
+ * value but, unlike `optionalOrNull`, rejecting `null`.
+ */
+export function optional<T>(validator: Validator<T>) {
+  return {
+    validate: (val: unknown): val is T | undefined => {
+      return val === undefined || validator.validate(val);
+    },
+    required: false,
+  } as const satisfies Validator<T | undefined>;
 }
 
 /** Represents an arbitrary object schema. */

--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -30,6 +30,11 @@ export function isString(value: unknown): value is string {
   return typeof value === "string";
 }
 
+/** Asserts that `value` is a number. */
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
 /** Asserts that `value` is either a string or undefined. */
 export function isStringOrUndefined(
   value: unknown,
@@ -54,6 +59,12 @@ export const string = {
   validate: isString,
   required: true,
 } as const satisfies Validator<string>;
+
+/** A validator for number fields in schemas. */
+export const number = {
+  validate: isNumber,
+  required: true,
+} as const satisfies Validator<number>;
 
 /** Transforms a validator to be optional. */
 export function optional<T>(validator: Validator<T>) {

--- a/src/start-proxy/types.ts
+++ b/src/start-proxy/types.ts
@@ -12,7 +12,7 @@ export type RawCredential = UnvalidatedObject<Credential>;
 /** A schema for credential objects with a username. */
 export const usernameSchema = {
   /** The username needed to authenticate to the package registry, if any. */
-  username: json.optional(json.string),
+  username: json.optionalOrNull(json.string),
 } as const satisfies json.Schema;
 
 /** Usernames may be present for both authentication with tokens or passwords. */
@@ -29,7 +29,7 @@ export function hasUsername(config: AuthConfig): config is Username {
 /** A schema for credential objects with a username and password. */
 export const usernamePasswordSchema = {
   /** The password needed to authenticate to the package registry, if any. */
-  password: json.optional(json.string),
+  password: json.optionalOrNull(json.string),
   ...usernameSchema,
 } as const satisfies json.Schema;
 
@@ -52,7 +52,7 @@ export function hasUsernameAndPassword(
 /** A schema for credential objects for token-based authentication. */
 export const tokenSchema = {
   /** The token needed to authenticate to the package registry, if any. */
-  token: json.optional(json.string),
+  token: json.optionalOrNull(json.string),
   ...usernameSchema,
 } as const satisfies json.Schema;
 
@@ -100,7 +100,7 @@ export const awsConfigSchema = {
   "role-name": json.string,
   domain: json.string,
   "domain-owner": json.string,
-  audience: json.optional(json.string),
+  audience: json.optionalOrNull(json.string),
 } as const satisfies json.Schema;
 
 /** Configuration for AWS OIDC. */
@@ -116,8 +116,8 @@ export function isAWSConfig(
 /** A schema for JFrog OIDC configurations. */
 export const jfrogConfigSchema = {
   "jfrog-oidc-provider-name": json.string,
-  audience: json.optional(json.string),
-  "identity-mapping-name": json.optional(json.string),
+  audience: json.optionalOrNull(json.string),
+  "identity-mapping-name": json.optionalOrNull(json.string),
 } as const satisfies json.Schema;
 
 /** Configuration for JFrog OIDC. */
@@ -150,8 +150,8 @@ export function isCloudsmithConfig(
 /** A schema for GCP OIDC configurations. */
 export const gcpConfigSchema = {
   "workload-identity-provider": json.string,
-  "service-account": json.optional(json.string),
-  audience: json.optional(json.string),
+  "service-account": json.optionalOrNull(json.string),
+  audience: json.optionalOrNull(json.string),
 } as const satisfies json.Schema;
 
 /** Configuration for GCP OIDC. */


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

### Summary

This pull request introduces several additions to the JSON schema-validation utilities:

* Renamed the `optional` validator to `optionalOrNull` to clarify that schema fields may be optional and accept `null` as a valid value, in addition to `undefined`.
* Redefined the `optional` validator so that it only accepts `undefined` (not `null`), making its behavior more precise and distinct from `optionalOrNull`.
* Added new built-in validators for `number`.
* Added an `isNumber` type guard function for type checking.

This PR is a prerequisite for #3950.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- [x] Confirm this change is backwards compatible with existing workflows.
- [x] Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- [x] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
