### PR TITLE
Create wrapper `runCliJson`

### DIFF
--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -1140,7 +1140,8 @@ async function runCliJson<T>(
   try {
     return JSON.parse(output) as T;
   } catch {
-    throw Error(`Invalid JSON output from \`${args.join(" ")}\`: ${output}`);
+    const command = [cmd, ...args].join(" ");
+    throw Error(`Invalid JSON output from \`${command}\`: ${output}`);
   }
 }
 

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -1131,6 +1131,15 @@ async function runCli(
   }
 }
 
+/**
+ * Wraps the command executor {@link runCli} and tries to parse the output as JSON.
+ * @param cmd The command to run.
+ * @param args The arguments to pass to the command.
+ * @param opts The options for running the command.
+ * @param opts.stdin Optional string to pass to the command's standard input.
+ * @param opts.noStreamStdout Optional boolean to indicate whether to stream the command's standard output.
+ * @returns The parsed JSON output from the command.
+ */
 async function runCliJson<T>(
   cmd: string,
   args: string[] = [],

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -514,16 +514,13 @@ async function getCodeQLForCmd(
     async getVersion() {
       let result = util.getCachedCodeQlVersion(cmd);
       if (result === undefined) {
-        const output = await runCli(cmd, ["version", "--format=json"], {
-          noStreamStdout: true,
-        });
-        try {
-          result = JSON.parse(output) as VersionInfo;
-        } catch {
-          throw Error(
-            `Invalid JSON output from \`version --format=json\`: ${output}`,
-          );
-        }
+        result = await runCliJson<VersionInfo>(
+          cmd,
+          ["version", "--format=json"],
+          {
+            noStreamStdout: true,
+          },
+        );
         util.cacheCodeQlVersion(cmd, result);
       }
       return result;
@@ -731,26 +728,20 @@ async function getCodeQLForCmd(
         filterToLanguagesWithQueries: boolean;
       } = { filterToLanguagesWithQueries: false },
     ) {
-      const codeqlArgs = [
+      return runCliJson<ResolveLanguagesOutput>(cmd, [
         "resolve",
         "languages",
         "--format=betterjson",
         "--extractor-options-verbosity=4",
         "--extractor-include-aliases",
+        // TODO: Unconditionally include `--filter-to-languages-with-queries`
+        //       once CODEQL_MINIMUM_VERSION is at least v2.23.0
+        //       — the first version to support this flag.
         ...(filterToLanguagesWithQueries
           ? ["--filter-to-languages-with-queries"]
           : []),
         ...getExtraOptionsFromEnv(["resolve", "languages"]),
-      ];
-      const output = await runCli(cmd, codeqlArgs);
-
-      try {
-        return JSON.parse(output) as ResolveLanguagesOutput;
-      } catch (e) {
-        throw new Error(
-          `Unexpected output from codeql resolve languages with --format=betterjson: ${e}`,
-        );
-      }
+      ]);
     },
     async resolveBuildEnvironment(
       workingDir: string | undefined,
@@ -766,15 +757,7 @@ async function getCodeQLForCmd(
       if (workingDir !== undefined) {
         codeqlArgs.push("--working-dir", workingDir);
       }
-      const output = await runCli(cmd, codeqlArgs);
-
-      try {
-        return JSON.parse(output) as ResolveBuildEnvironmentOutput;
-      } catch (e) {
-        throw new Error(
-          `Unexpected output from codeql resolve build-environment: ${e} in\n${output}`,
-        );
-      }
+      return await runCliJson<ResolveBuildEnvironmentOutput>(cmd, codeqlArgs);
     },
     async databaseRunQueries(
       databasePath: string,
@@ -976,15 +959,9 @@ async function getCodeQLForCmd(
         ...getExtraOptionsFromEnv(["resolve", "queries"]),
         ...queries,
       ];
-      const output = await runCli(cmd, codeqlArgs, { noStreamStdout: true });
-
-      try {
-        return JSON.parse(output) as string[];
-      } catch (e) {
-        throw new Error(
-          `Unexpected output from codeql resolve queries --format=startingpacks: ${e}`,
-        );
-      }
+      return await runCliJson<string[]>(cmd, codeqlArgs, {
+        noStreamStdout: true,
+      });
     },
     async resolveDatabase(
       databasePath: string,
@@ -996,15 +973,9 @@ async function getCodeQLForCmd(
         "--format=json",
         ...getExtraOptionsFromEnv(["resolve", "database"]),
       ];
-      const output = await runCli(cmd, codeqlArgs, { noStreamStdout: true });
-
-      try {
-        return JSON.parse(output) as ResolveDatabaseOutput;
-      } catch (e) {
-        throw new Error(
-          `Unexpected output from codeql resolve database --format=json: ${e}`,
-        );
-      }
+      return await runCliJson<ResolveDatabaseOutput>(cmd, codeqlArgs, {
+        noStreamStdout: true,
+      });
     },
     async mergeResults(
       sarifFiles: string[],
@@ -1157,6 +1128,19 @@ async function runCli(
       throw wrapCliConfigurationError(new CliError(e));
     }
     throw e;
+  }
+}
+
+async function runCliJson<T>(
+  cmd: string,
+  args: string[] = [],
+  opts: { stdin?: string; noStreamStdout?: boolean } = {},
+): Promise<T> {
+  const output = await runCli(cmd, args, opts);
+  try {
+    return JSON.parse(output) as T;
+  } catch {
+    throw Error(`Invalid JSON output from \`${args.join(" ")}\`: ${output}`);
   }
 }
 

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -1139,9 +1139,10 @@ async function runCliJson<T>(
   const output = await runCli(cmd, args, opts);
   try {
     return JSON.parse(output) as T;
-  } catch {
-    const command = [cmd, ...args].join(" ");
-    throw Error(`Invalid JSON output from \`${command}\`: ${output}`);
+  } catch (e) {
+    throw Error(
+      `Unexpected output from codeql ${args.join(" ")}: ${getErrorMessage(e)}`,
+    );
   }
 }
 


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

### Summary

A few of the CLI commands emit JSON. This PR creates a `runCli` wrapper function called `runCliJson` that expects JSON output from the CLI command. This change centralizes and reduces the number of JSON-parsing call sites in `codeql.ts`, making the code more readable and D.R.Y.er.

This PR is a prerequisite for #3950.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.
- **Third-party analyses** - The changes affect the `upload-sarif` action.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
