### PR TITLE
Add FF for configuration file repository property

### DIFF
--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -82,3 +82,23 @@ test("getConfigFileInput ignores empty repository property value", async (t) => 
   );
   t.is(result, undefined);
 });
+
+test("getConfigFileInput ignores repository property value when FF is off", async (t) => {
+  const logger = new RecordingLogger();
+  const actionsEnv = getTestActionsEnv();
+
+  // Since the FF is off, we should ignore the repository property value.
+  const result = getConfigFileInput(
+    logger,
+    actionsEnv,
+    repositoryProperties,
+    false,
+  );
+  t.is(result, undefined);
+
+  t.false(
+    logger.hasMessage(
+      "Using configuration file input from repository property",
+    ),
+  );
+});

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -101,4 +101,9 @@ test("getConfigFileInput ignores repository property value when FF is off", asyn
       "Using configuration file input from repository property",
     ),
   );
+  t.true(
+    logger.hasMessage(
+      "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled.",
+    ),
+  );
 });

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -15,7 +15,7 @@ setupTests(test);
 test("getConfigFileInput returns undefined by default", async (t) => {
   const logger = new RecordingLogger();
   const actionsEnv = getTestActionsEnv();
-  const result = getConfigFileInput(logger, actionsEnv, {});
+  const result = getConfigFileInput(logger, actionsEnv, {}, true);
   t.is(result, undefined);
 });
 
@@ -34,7 +34,12 @@ test("getConfigFileInput returns input value", async (t) => {
 
   // Even though both an input and repository property are configured,
   // we prefer the direct input to the Action.
-  const result = getConfigFileInput(logger, actionsEnv, repositoryProperties);
+  const result = getConfigFileInput(
+    logger,
+    actionsEnv,
+    repositoryProperties,
+    true,
+  );
   t.is(result, testInput);
 
   // Check for the expected log message.
@@ -46,7 +51,12 @@ test("getConfigFileInput returns repository property value", async (t) => {
   const actionsEnv = getTestActionsEnv();
 
   // Since there is no direct input, we should use the repository property.
-  const result = getConfigFileInput(logger, actionsEnv, repositoryProperties);
+  const result = getConfigFileInput(
+    logger,
+    actionsEnv,
+    repositoryProperties,
+    true,
+  );
   t.is(result, repositoryProperties[RepositoryPropertyName.CONFIG_FILE]);
 
   // Check for the expected log message.
@@ -62,8 +72,13 @@ test("getConfigFileInput ignores empty repository property value", async (t) => 
   const actionsEnv = getTestActionsEnv();
 
   // Since the repository property value is an empty/whitespace string, we should ignore it.
-  const result = getConfigFileInput(logger, actionsEnv, {
-    [RepositoryPropertyName.CONFIG_FILE]: "   ",
-  });
+  const result = getConfigFileInput(
+    logger,
+    actionsEnv,
+    {
+      [RepositoryPropertyName.CONFIG_FILE]: "   ",
+    },
+    true,
+  );
   t.is(result, undefined);
 });

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -21,19 +21,21 @@ export function getConfigFileInput(
     return input;
   }
 
-  // Don't take the repository property into consideration if the FF is not enabled.
-  if (!useRepositoryProperty) {
-    return undefined;
-  }
-
   const propertyValue =
     repositoryProperties[RepositoryPropertyName.CONFIG_FILE];
 
   if (propertyValue !== undefined && propertyValue.trim().length > 0) {
-    logger.info(
-      `Using configuration file input from repository property: ${propertyValue}`,
-    );
-    return propertyValue;
+    // Only use the repository property value if the FF is enabled.
+    if (useRepositoryProperty) {
+      logger.info(
+        `Using configuration file input from repository property: ${propertyValue}`,
+      );
+      return propertyValue;
+    } else {
+      logger.info(
+        "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled.",
+      );
+    }
   }
 
   return undefined;

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -12,12 +12,18 @@ export function getConfigFileInput(
   logger: Logger,
   actions: ActionsEnv,
   repositoryProperties: Partial<RepositoryProperties>,
+  useRepositoryProperty: boolean,
 ): string | undefined {
   const input = actions.getOptionalInput("config-file");
 
   if (input !== undefined) {
     logger.info(`Using configuration file input from workflow: ${input}`);
     return input;
+  }
+
+  // Don't take the repository property into consideration if the FF is not enabled.
+  if (!useRepositoryProperty) {
+    return undefined;
   }
 
   const propertyValue =

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -74,6 +74,8 @@ export enum Feature {
   AllowMultipleAnalysisKinds = "allow_multiple_analysis_kinds",
   AllowToolcacheInput = "allow_toolcache_input",
   CleanupTrapCaches = "cleanup_trap_caches",
+  /** Whether to allow the `config-file` input to be specified via a repository property. */
+  ConfigFileRepositoryProperty = "config_file_repository_property",
   CppDependencyInstallation = "cpp_dependency_installation_enabled",
   CsharpCacheBuildModeNone = "csharp_cache_bmn",
   CsharpNewCacheKey = "csharp_new_cache_key",
@@ -182,6 +184,11 @@ export const featureConfig = {
   [Feature.CleanupTrapCaches]: {
     defaultValue: false,
     envVar: "CODEQL_ACTION_CLEANUP_TRAP_CACHES",
+    minimumVersion: undefined,
+  },
+  [Feature.ConfigFileRepositoryProperty]: {
+    defaultValue: false,
+    envVar: "CODEQL_ACTION_CONFIG_FILE_REPOSITORY_PROPERTY",
     minimumVersion: undefined,
   },
   [Feature.CppDependencyInstallation]: {

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -263,7 +263,15 @@ async function run(startedAt: Date) {
 
     core.exportVariable(EnvVar.INIT_ACTION_HAS_RUN, "true");
 
-    configFile = getConfigFileInput(logger, actionsEnv, repositoryProperties);
+    const useConfigFileProperty = await features.getValue(
+      Feature.ConfigFileRepositoryProperty,
+    );
+    configFile = getConfigFileInput(
+      logger,
+      actionsEnv,
+      repositoryProperties,
+      useConfigFileProperty,
+    );
 
     // path.resolve() respects the intended semantics of source-root. If
     // source-root is relative, it is relative to the GITHUB_WORKSPACE. If


### PR DESCRIPTION
Follow-up to #3963 which adds a FF to control whether that functionality is enabled or not.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Feature flags** - All new or changed code paths can be fully disabled with corresponding feature flags.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
