### PR TITLE
Always enable `git_source` registries

### DIFF
--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -120,8 +120,13 @@ const mixedCredentials = [
   { type: "maven_repository", host: "maven.pkg.github.com", token: "def" },
   { type: "nuget_feed", host: "nuget.pkg.github.com", token: "ghi" },
   { type: "goproxy_server", host: "goproxy.example.com", token: "jkl" },
-  { type: "git_source", host: "github.com/github", token: "mno" },
 ];
+
+const gitSourceCredential = {
+  type: "git_source",
+  host: "github.com/github",
+  token: "mno",
+};
 
 test("getCredentials prefers registriesCredentials over registrySecrets", async (t) => {
   const registryCredentials = Buffer.from(
@@ -241,7 +246,7 @@ test("getCredentials returns all for a language when specified", async (t) => {
   const credentials = startProxyExports.getCredentials(
     getRunnerLogger(true),
     undefined,
-    toEncodedJSON(mixedCredentials),
+    toEncodedJSON([...mixedCredentials, gitSourceCredential]),
     BuiltInLanguage.go,
   );
   t.is(credentials.length, 2);
@@ -284,7 +289,7 @@ test("getCredentials returns all maven_repositories for Java when specified", as
       host: "maven2.pkg.github.com",
       token: "token2",
     },
-    { type: "git_source", host: "github.com/github", token: "mno" },
+    { type: "goproxy_server", host: "github.com/github", token: "mno" },
   ];
 
   const credentials = startProxyExports.getCredentials(
@@ -624,8 +629,11 @@ test("getCredentials validates 'replaces-base' correctly", async (t) => {
   );
 });
 
-test("getCredentials returns no credentials for Actions", async (t) => {
-  const credentialsInput = toEncodedJSON(mixedCredentials);
+test("getCredentials returns only ALWAYS_ENABLED_REGISTRY_TYPE credentials for Actions", async (t) => {
+  const credentialsInput = toEncodedJSON([
+    ...mixedCredentials,
+    gitSourceCredential,
+  ]);
 
   const credentials = startProxyExports.getCredentials(
     getRunnerLogger(true),
@@ -633,7 +641,41 @@ test("getCredentials returns no credentials for Actions", async (t) => {
     credentialsInput,
     BuiltInLanguage.actions,
   );
-  t.deepEqual(credentials, []);
+
+  for (const credential of credentials) {
+    t.true(
+      startProxyExports.ALWAYS_ENABLED_REGISTRY_TYPE.some(
+        (ty) => ty === credential.type,
+      ),
+    );
+  }
+});
+
+test("getCredentials always returns ALWAYS_ENABLED_REGISTRY_TYPE credentials for all languages", async (t) => {
+  const alwaysEnabledCredentials: startProxyExports.Credential[] = [];
+
+  for (const alwaysEnabled of startProxyExports.ALWAYS_ENABLED_REGISTRY_TYPE) {
+    alwaysEnabledCredentials.push({
+      type: alwaysEnabled,
+      host: `host-${alwaysEnabled}`,
+      token: `bar-${alwaysEnabled}`,
+      url: `url-${alwaysEnabled}`,
+    });
+  }
+
+  const credentialsInput = toEncodedJSON(alwaysEnabledCredentials);
+
+  // Test all languages.
+  for (const language of Object.values(BuiltInLanguage)) {
+    const credentials = startProxyExports.getCredentials(
+      getRunnerLogger(true),
+      undefined,
+      credentialsInput,
+      language,
+    );
+
+    t.deepEqual(credentials, alwaysEnabledCredentials);
+  }
 });
 
 function mockGetApiClient(endpoints: any) {

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -192,7 +192,7 @@ function isPAT(value: string) {
  * enabled, because generic CodeQL workflow components may use them rather than just
  * language-specific components.
  */
-export const ALWAYS_ENABLED_REGISTRY_TYPE = ["git_source"];
+export const ALWAYS_ENABLED_REGISTRY_TYPE = ["git_source"] as const;
 
 type RegistryMapping = Partial<Record<BuiltInLanguage, string[]>>;
 

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -187,9 +187,16 @@ function isPAT(value: string) {
   ]);
 }
 
+/**
+ * A list of always-enabled registry types. The registry types in this list are always
+ * enabled, because generic CodeQL workflow components may use them rather than just
+ * language-specific components.
+ */
+export const ALWAYS_ENABLED_REGISTRY_TYPE = ["git_source"];
+
 type RegistryMapping = Partial<Record<BuiltInLanguage, string[]>>;
 
-const LANGUAGE_TO_REGISTRY_TYPE: Required<RegistryMapping> = {
+export const LANGUAGE_TO_REGISTRY_TYPE: Required<RegistryMapping> = {
   actions: [],
   cpp: [],
   java: ["maven_repository"],
@@ -233,9 +240,11 @@ function getRegistryAddress(
   }
 }
 
-// getCredentials returns registry credentials from action inputs.
-// It prefers `registries_credentials` over `registry_secrets`.
-// If neither is set, it returns an empty array.
+/**
+ * Returns registry credentials from action inputs.
+ * It prefers `registriesCredentials` over `registrySecrets`.
+ * If neither is set, it returns an empty array.
+ */
 export function getCredentials(
   logger: Logger,
   registrySecrets: string | undefined,
@@ -292,7 +301,10 @@ export function getCredentials(
 
     // Filter credentials based on language if specified. `type` is the registry type.
     // E.g., "maven_feed" for Java/Kotlin, "nuget_repository" for C#.
+    // We always allow types in `ALWAYS_ENABLED_REGISTRY_TYPE` since they can be used by
+    // other parts of the workflow.
     if (
+      !ALWAYS_ENABLED_REGISTRY_TYPE.some((t) => t === e.type) &&
       registryTypeForLanguage &&
       !registryTypeForLanguage.some((t) => t === e.type)
     ) {

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -300,7 +300,7 @@ export function getCredentials(
     const address = getRegistryAddress(e);
 
     // Filter credentials based on language if specified. `type` is the registry type.
-    // E.g., "maven_feed" for Java/Kotlin, "nuget_repository" for C#.
+    // E.g., "maven_repository" for Java/Kotlin, "nuget_feed" for C#.
     // We always allow types in `ALWAYS_ENABLED_REGISTRY_TYPE` since they can be used by
     // other parts of the workflow.
     if (


### PR DESCRIPTION
This PR changes the language-based registry configuration filtering logic in the `start-proxy` action to always enable `git_source` registries since `git_source` registries are useful outside of language-specific contexts.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **High risk:** Changes are not fully under feature flags, have limited visibility and/or cannot be tested outside of production.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
