### PR TITLE
Use private registry proxy for API requests when available

### DIFF
--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -92,6 +92,10 @@ jobs:
         run: exit 1
 
       - uses: ./../action/init
+        env:
+          CODEQL_PROXY_HOST: ${{ steps.proxy.outputs.proxy_host }}
+          CODEQL_PROXY_PORT: ${{ steps.proxy.outputs.proxy_port }}
+          CODEQL_PROXY_CA_CERTIFICATE: ${{ steps.proxy.outputs.proxy_ca_certificate }}
         with:
           languages: java
           tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -96,8 +96,10 @@ jobs:
           CODEQL_PROXY_HOST: ${{ steps.proxy.outputs.proxy_host }}
           CODEQL_PROXY_PORT: ${{ steps.proxy.outputs.proxy_port }}
           CODEQL_PROXY_CA_CERTIFICATE: ${{ steps.proxy.outputs.proxy_ca_certificate }}
+          CODEQL_ACTION_NEW_REMOTE_FILE_ADDRESSES: 'true'
         with:
           languages: java
           tools: ${{ steps.prepare-test.outputs.tools-url }}
+          config-file: codeql-action@main:tests/multi-language-repo/.github/codeql/custom-queries.yml
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -61,6 +61,7 @@ jobs:
         id: proxy
         uses: ./../action/start-proxy
         with:
+          language: java
           registry_secrets: |
             [
               {
@@ -92,7 +93,7 @@ jobs:
 
       - uses: ./../action/init
         with:
-          languages: csharp
+          languages: java
           tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -57,11 +57,6 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'true'
-      - uses: ./../action/init
-        with:
-          languages: csharp
-          tools: ${{ steps.prepare-test.outputs.tools-url }}
-
       - name: Setup proxy for registries
         id: proxy
         uses: ./../action/start-proxy
@@ -94,5 +89,10 @@ jobs:
           || !contains(steps.proxy.outputs.proxy_urls, 'https://repo.maven.apache.org/maven2/')
           || !contains(steps.proxy.outputs.proxy_urls, 'https://repo1.maven.org/maven2')
         run: exit 1
+
+      - uses: ./../action/init
+        with:
+          languages: csharp
+          tools: ${{ steps.prepare-test.outputs.tools-url }}
     env:
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -102,4 +102,5 @@ jobs:
           tools: ${{ steps.prepare-test.outputs.tools-url }}
           config-file: codeql-action@main:tests/multi-language-repo/.github/codeql/custom-queries.yml
     env:
+      CODEQL_ACTION_PROXY_API_REQUESTS: 'true'
       CODEQL_ACTION_TEST_MODE: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "long": "^5.3.2",
         "node-forge": "^1.4.0",
         "semver": "^7.8.5",
+        "undici": "^6.24.0",
         "uuid": "^14.0.1"
       },
       "devDependencies": {
@@ -9363,7 +9364,6 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
       "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "long": "^5.3.2",
     "node-forge": "^1.4.0",
     "semver": "^7.8.5",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "undici": "^6.24.0"
   },
   "devDependencies": {
     "@ava/typescript": "6.0.0",

--- a/pr-checks/checks/start-proxy.yml
+++ b/pr-checks/checks/start-proxy.yml
@@ -46,6 +46,8 @@ steps:
       CODEQL_PROXY_HOST: ${{ steps.proxy.outputs.proxy_host }}
       CODEQL_PROXY_PORT: ${{ steps.proxy.outputs.proxy_port }}
       CODEQL_PROXY_CA_CERTIFICATE: ${{ steps.proxy.outputs.proxy_ca_certificate }}
+      CODEQL_ACTION_NEW_REMOTE_FILE_ADDRESSES: "true"
     with:
       languages: java
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+      config-file: codeql-action@main:tests/multi-language-repo/.github/codeql/custom-queries.yml

--- a/pr-checks/checks/start-proxy.yml
+++ b/pr-checks/checks/start-proxy.yml
@@ -42,6 +42,10 @@ steps:
     run: exit 1
 
   - uses: ./../action/init
+    env:
+      CODEQL_PROXY_HOST: ${{ steps.proxy.outputs.proxy_host }}
+      CODEQL_PROXY_PORT: ${{ steps.proxy.outputs.proxy_port }}
+      CODEQL_PROXY_CA_CERTIFICATE: ${{ steps.proxy.outputs.proxy_ca_certificate }}
     with:
       languages: java
       tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/pr-checks/checks/start-proxy.yml
+++ b/pr-checks/checks/start-proxy.yml
@@ -11,6 +11,7 @@ steps:
     id: proxy
     uses: ./../action/start-proxy
     with:
+      language: java
       registry_secrets: |
         [
           {
@@ -42,5 +43,5 @@ steps:
 
   - uses: ./../action/init
     with:
-      languages: csharp
+      languages: java
       tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/pr-checks/checks/start-proxy.yml
+++ b/pr-checks/checks/start-proxy.yml
@@ -7,11 +7,6 @@ operatingSystems:
 versions:
   - linked
 steps:
-  - uses: ./../action/init
-    with:
-      languages: csharp
-      tools: ${{ steps.prepare-test.outputs.tools-url }}
-
   - name: Setup proxy for registries
     id: proxy
     uses: ./../action/start-proxy
@@ -44,3 +39,8 @@ steps:
       || !contains(steps.proxy.outputs.proxy_urls, 'https://repo.maven.apache.org/maven2/')
       || !contains(steps.proxy.outputs.proxy_urls, 'https://repo1.maven.org/maven2')
     run: exit 1
+
+  - uses: ./../action/init
+    with:
+      languages: csharp
+      tools: ${{ steps.prepare-test.outputs.tools-url }}

--- a/pr-checks/checks/start-proxy.yml
+++ b/pr-checks/checks/start-proxy.yml
@@ -6,6 +6,8 @@ operatingSystems:
   - windows
 versions:
   - linked
+env:
+  CODEQL_ACTION_PROXY_API_REQUESTS: "true"
 steps:
   - name: Setup proxy for registries
     id: proxy

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -6,7 +6,7 @@ import * as sinon from "sinon";
 import * as actionsUtil from "./actions-util";
 import * as api from "./api-client";
 import { DO_NOT_RETRY_STATUSES } from "./api-client";
-import { ActionsEnvVars } from "./environment";
+import { ActionsEnvVars, RegistryProxyVars } from "./environment";
 import { getTestEnv, setupTests } from "./testing-utils";
 import * as util from "./util";
 
@@ -27,14 +27,17 @@ test.serial("getApiClient", async (t) => {
 
   sinon.stub(actionsUtil, "getRequiredInput").withArgs("token").returns("xyz");
 
-  api.getApiClient(env);
+  const apiClient = api.getApiClient(env);
+  t.truthy(apiClient);
 
+  t.true(githubStub.calledOnce);
   t.assert(
     githubStub.calledOnceWithExactly({
       auth: "token xyz",
       baseUrl: "http://api.github.localhost",
       log: sinon.match.any,
       userAgent: `CodeQL-Action/${actionsUtil.getActionVersion()}`,
+      request: sinon.match.any,
       retry: {
         doNotRetry: DO_NOT_RETRY_STATUSES,
       },
@@ -204,3 +207,32 @@ test.serial(
     }
   },
 );
+
+test("getRegistryProxy - returns undefined if the proxy is not configured", async (t) => {
+  // Empty environment.
+  t.is(api.getRegistryProxy(getTestEnv()), undefined);
+  // Only the host.
+  t.is(
+    api.getRegistryProxy(
+      getTestEnv({ [RegistryProxyVars.PROXY_HOST]: "localhost" }),
+    ),
+    undefined,
+  );
+  // Only the port.
+  t.is(
+    api.getRegistryProxy(
+      getTestEnv({ [RegistryProxyVars.PROXY_PORT]: "1234" }),
+    ),
+    undefined,
+  );
+});
+
+test("getRegistryProxy - returns value when both vars are set", async (t) => {
+  const proxy = api.getRegistryProxy(
+    getTestEnv({
+      [RegistryProxyVars.PROXY_HOST]: "localhost",
+      [RegistryProxyVars.PROXY_PORT]: "1234",
+    }),
+  );
+  t.truthy(proxy);
+});

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -234,3 +234,20 @@ test("getRegistryProxy - returns value when both vars are set", async (t) => {
     )
     .passes(t.truthy);
 });
+
+test("getRegistryProxyConfig - gets the configuration from the env vars", async (t) => {
+  const host = "localhost";
+  const port = "1234";
+  const ca = "cert";
+
+  await callee(api.getRegistryProxyConfig)
+    .withArgs()
+    .withEnv(
+      getTestEnv({
+        [RegistryProxyVars.PROXY_HOST]: host,
+        [RegistryProxyVars.PROXY_PORT]: port,
+        [RegistryProxyVars.PROXY_CA_CERTIFICATE]: ca,
+      }),
+    )
+    .passes(t.like, { host, port, ca });
+});

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -7,7 +7,7 @@ import * as actionsUtil from "./actions-util";
 import * as api from "./api-client";
 import { DO_NOT_RETRY_STATUSES } from "./api-client";
 import { ActionsEnvVars, RegistryProxyVars } from "./environment";
-import { getTestEnv, setupTests } from "./testing-utils";
+import { callee, getTestEnv, setupTests } from "./testing-utils";
 import * as util from "./util";
 
 setupTests(test);
@@ -209,30 +209,28 @@ test.serial(
 );
 
 test("getRegistryProxy - returns undefined if the proxy is not configured", async (t) => {
+  const target = callee(api.getRegistryProxy).withArgs();
+
   // Empty environment.
-  t.is(api.getRegistryProxy(getTestEnv()), undefined);
+  await target.passes(t.is, undefined);
   // Only the host.
-  t.is(
-    api.getRegistryProxy(
-      getTestEnv({ [RegistryProxyVars.PROXY_HOST]: "localhost" }),
-    ),
-    undefined,
-  );
+  await target
+    .withEnv(getTestEnv({ [RegistryProxyVars.PROXY_HOST]: "localhost" }))
+    .passes(t.is, undefined);
   // Only the port.
-  t.is(
-    api.getRegistryProxy(
-      getTestEnv({ [RegistryProxyVars.PROXY_PORT]: "1234" }),
-    ),
-    undefined,
-  );
+  await target
+    .withEnv(getTestEnv({ [RegistryProxyVars.PROXY_PORT]: "1234" }))
+    .passes(t.is, undefined);
 });
 
 test("getRegistryProxy - returns value when both vars are set", async (t) => {
-  const proxy = api.getRegistryProxy(
-    getTestEnv({
-      [RegistryProxyVars.PROXY_HOST]: "localhost",
-      [RegistryProxyVars.PROXY_PORT]: "1234",
-    }),
-  );
-  t.truthy(proxy);
+  await callee(api.getRegistryProxy)
+    .withArgs()
+    .withEnv(
+      getTestEnv({
+        [RegistryProxyVars.PROXY_HOST]: "localhost",
+        [RegistryProxyVars.PROXY_PORT]: "1234",
+      }),
+    )
+    .passes(t.truthy);
 });

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as githubUtils from "@actions/github/lib/utils";
 import * as retry from "@octokit/plugin-retry";
+import { RequestRequestOptions } from "@octokit/types";
 import {
   ProxyAgent,
   RequestInfo,
@@ -81,6 +82,22 @@ export function getRegistryProxy(env: ReadOnlyEnv): ProxyAgent | undefined {
 }
 
 /**
+ * Constructs a `RequestRequestOptions` with a custom `fetch` implementation
+ * that uses `dispatcher` as a proxy for requests.
+ *
+ * @param dispatcher The proxy to use.
+ */
+export function makeProxyRequestOptions(
+  dispatcher: ProxyAgent,
+): RequestRequestOptions {
+  return {
+    fetch: (req: RequestInfo, init?: RequestInit) => {
+      return undiciFetch(req, { ...init, dispatcher });
+    },
+  };
+}
+
+/**
  * Returns an implementation of `fetch` to use for API requests.
  * This will run API requests through the private registry authentication proxy
  * if it is configured.
@@ -96,13 +113,20 @@ export function getApiFetch(env: ReadOnlyEnv): typeof undiciFetch {
   return proxiedFetch;
 }
 
+interface CreateApiClientOptions {
+  allowExternal?: boolean;
+  proxy?: ProxyAgent;
+}
+
 function createApiClientWithDetails(
   apiDetails: GitHubApiCombinedDetails,
-  { allowExternal = false } = {},
+  { allowExternal = false, proxy = undefined }: CreateApiClientOptions = {},
 ) {
   const auth =
     (allowExternal && apiDetails.externalRepoAuth) || apiDetails.auth;
   const retryingOctokit = githubUtils.GitHub.plugin(retry.retry);
+  const requestOptions =
+    proxy === undefined ? undefined : makeProxyRequestOptions(proxy);
   return new retryingOctokit(
     githubUtils.getOctokitOptions(auth, {
       baseUrl: apiDetails.apiURL,
@@ -113,7 +137,7 @@ function createApiClientWithDetails(
         warn: core.warning,
         error: core.error,
       },
-      request: { fetch: getApiFetch(getEnv()) },
+      request: requestOptions,
       retry: {
         doNotRetry: DO_NOT_RETRY_STATUSES,
       },
@@ -135,8 +159,9 @@ export function getApiClient(env: ReadOnlyEnv = getEnv()) {
 
 export function getApiClientWithExternalAuth(
   apiDetails: GitHubApiCombinedDetails,
+  proxy?: ProxyAgent,
 ) {
-  return createApiClientWithDetails(apiDetails, { allowExternal: true });
+  return createApiClientWithDetails(apiDetails, { allowExternal: true, proxy });
 }
 
 /**

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -66,15 +66,19 @@ export interface GitHubApiExternalRepoDetails {
  *          or `undefined` if we couldn't retrieve the host and port.
  */
 export function getRegistryProxy(
-  action: ActionState<["Env"]>,
+  action: ActionState<["Logger", "Env"]>,
 ): ProxyAgent | undefined {
   const host = action.env.getOptional(RegistryProxyVars.PROXY_HOST);
   const port = action.env.getOptional(RegistryProxyVars.PROXY_PORT);
   const cert = action.env.getOptional(RegistryProxyVars.PROXY_CA_CERTIFICATE);
 
   if (host && port) {
+    const uri = `http://${host}:${port}`;
+    action.logger.debug(
+      `Using private registry proxy at '${uri}' for API client.`,
+    );
     return new ProxyAgent({
-      uri: `http://${host}:${port}`,
+      uri,
       keepAliveTimeout: 10,
       keepAliveMaxTimeout: 10,
       requestTls: cert ? { ca: cert } : undefined,
@@ -107,7 +111,9 @@ export function makeProxyRequestOptions(
  *
  * @param action The required Action state.
  */
-export function getApiFetch(action: ActionState<["Env"]>): typeof undiciFetch {
+export function getApiFetch(
+  action: ActionState<["Logger", "Env"]>,
+): typeof undiciFetch {
   const dispatcher = getRegistryProxy(action);
 
   const proxiedFetch = (req: RequestInfo, init?: RequestInit) => {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -9,6 +9,7 @@ import {
   fetch as undiciFetch,
 } from "undici";
 
+import type { ActionState } from "./action-common";
 import { getActionVersion, getRequiredInput } from "./actions-util";
 import {
   ActionsEnvVars,
@@ -60,14 +61,16 @@ export interface GitHubApiExternalRepoDetails {
  * Gets the configuration for the private registry authentication proxy,
  * if it is available in the environment.
  *
- * @param env The environment to query for the proxy host and port.
+ * @param action The required Action state.
  * @returns A `ProxyAgent` corresponding to the private registry proxy,
  *          or `undefined` if we couldn't retrieve the host and port.
  */
-export function getRegistryProxy(env: ReadOnlyEnv): ProxyAgent | undefined {
-  const host = env.getOptional(RegistryProxyVars.PROXY_HOST);
-  const port = env.getOptional(RegistryProxyVars.PROXY_PORT);
-  const cert = env.getOptional(RegistryProxyVars.PROXY_CA_CERTIFICATE);
+export function getRegistryProxy(
+  action: ActionState<["Env"]>,
+): ProxyAgent | undefined {
+  const host = action.env.getOptional(RegistryProxyVars.PROXY_HOST);
+  const port = action.env.getOptional(RegistryProxyVars.PROXY_PORT);
+  const cert = action.env.getOptional(RegistryProxyVars.PROXY_CA_CERTIFICATE);
 
   if (host && port) {
     return new ProxyAgent({
@@ -102,10 +105,10 @@ export function makeProxyRequestOptions(
  * This will run API requests through the private registry authentication proxy
  * if it is configured.
  *
- * @param env The environment to query for the proxy host and port.
+ * @param action The required Action state.
  */
-export function getApiFetch(env: ReadOnlyEnv): typeof undiciFetch {
-  const dispatcher = getRegistryProxy(env);
+export function getApiFetch(action: ActionState<["Env"]>): typeof undiciFetch {
+  const dispatcher = getRegistryProxy(action);
 
   const proxiedFetch = (req: RequestInfo, init?: RequestInit) => {
     return undiciFetch(req, { ...init, dispatcher });

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -65,15 +65,28 @@ export interface GitHubApiExternalRepoDetails {
  * if it is available in the environment.
  *
  * @param action The required Action state.
+ * @returns The hostname, port, and CA retrieved from the corresponding environment variables.
+ */
+export function getRegistryProxyConfig(action: ActionState<["ReadOnlyEnv"]>) {
+  return {
+    host: action.env.getOptional(RegistryProxyVars.PROXY_HOST),
+    port: action.env.getOptional(RegistryProxyVars.PROXY_PORT),
+    ca: action.env.getOptional(RegistryProxyVars.PROXY_CA_CERTIFICATE),
+  };
+}
+
+/**
+ * Gets the configuration for the private registry authentication proxy,
+ * and uses it to initialise a corresponding `ProxyAgent`.
+ *
+ * @param action The required Action state.
  * @returns A `ProxyAgent` corresponding to the private registry proxy,
  *          or `undefined` if we couldn't retrieve the host and port.
  */
 export function getRegistryProxy(
-  action: ActionState<["Logger", "Env"]>,
+  action: ActionState<["Logger", "ReadOnlyEnv"]>,
 ): ProxyAgent | undefined {
-  const host = action.env.getOptional(RegistryProxyVars.PROXY_HOST);
-  const port = action.env.getOptional(RegistryProxyVars.PROXY_PORT);
-  const cert = action.env.getOptional(RegistryProxyVars.PROXY_CA_CERTIFICATE);
+  const { host, port, ca } = getRegistryProxyConfig(action);
 
   if (host && port) {
     const uri = `http://${host}:${port}`;
@@ -84,7 +97,7 @@ export function getRegistryProxy(
       uri,
       keepAliveTimeout: 10,
       keepAliveMaxTimeout: 10,
-      requestTls: cert ? { ca: cert } : undefined,
+      requestTls: ca ? { ca } : undefined,
     });
   }
 

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -107,24 +107,6 @@ export function makeProxyRequestOptions(
   };
 }
 
-/**
- * Returns an implementation of `fetch` to use for API requests.
- * This will run API requests through the private registry authentication proxy
- * if it is configured.
- *
- * @param action The required Action state.
- */
-export function getApiFetch(
-  action: ActionState<["Logger", "Env"]>,
-): typeof undiciFetch {
-  const dispatcher = getRegistryProxy(action);
-
-  const proxiedFetch = (req: RequestInfo, init?: RequestInit) => {
-    return undiciFetch(req, { ...init, dispatcher });
-  };
-  return proxiedFetch;
-}
-
 /** The type of GitHub API client we use. */
 export type ApiClient = Octokit & Api & { paginate: PaginateInterface };
 

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,9 +1,21 @@
 import * as core from "@actions/core";
 import * as githubUtils from "@actions/github/lib/utils";
 import * as retry from "@octokit/plugin-retry";
+import {
+  ProxyAgent,
+  RequestInfo,
+  RequestInit,
+  fetch as undiciFetch,
+} from "undici";
 
 import { getActionVersion, getRequiredInput } from "./actions-util";
-import { EnvVar, ReadOnlyEnv, ActionsEnvVars, getEnv } from "./environment";
+import {
+  ActionsEnvVars,
+  EnvVar,
+  ReadOnlyEnv,
+  RegistryProxyVars,
+  getEnv,
+} from "./environment";
 import { Logger } from "./logging";
 import { getRepositoryNwo, RepositoryNwo } from "./repository";
 import {
@@ -43,6 +55,47 @@ export interface GitHubApiExternalRepoDetails {
   apiURL: string | undefined;
 }
 
+/**
+ * Gets the configuration for the private registry authentication proxy,
+ * if it is available in the environment.
+ *
+ * @param env The environment to query for the proxy host and port.
+ * @returns A `ProxyAgent` corresponding to the private registry proxy,
+ *          or `undefined` if we couldn't retrieve the host and port.
+ */
+export function getRegistryProxy(env: ReadOnlyEnv): ProxyAgent | undefined {
+  const host = env.getOptional(RegistryProxyVars.PROXY_HOST);
+  const port = env.getOptional(RegistryProxyVars.PROXY_PORT);
+  const cert = env.getOptional(RegistryProxyVars.PROXY_CA_CERTIFICATE);
+
+  if (host && port) {
+    return new ProxyAgent({
+      uri: `http://${host}:${port}`,
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10,
+      requestTls: cert ? { ca: cert } : undefined,
+    });
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns an implementation of `fetch` to use for API requests.
+ * This will run API requests through the private registry authentication proxy
+ * if it is configured.
+ *
+ * @param env The environment to query for the proxy host and port.
+ */
+export function getApiFetch(env: ReadOnlyEnv): typeof undiciFetch {
+  const dispatcher = getRegistryProxy(env);
+
+  const proxiedFetch = (req: RequestInfo, init?: RequestInit) => {
+    return undiciFetch(req, { ...init, dispatcher });
+  };
+  return proxiedFetch;
+}
+
 function createApiClientWithDetails(
   apiDetails: GitHubApiCombinedDetails,
   { allowExternal = false } = {},
@@ -60,6 +113,7 @@ function createApiClientWithDetails(
         warn: core.warning,
         error: core.error,
       },
+      request: { fetch: getApiFetch(getEnv()) },
       retry: {
         doNotRetry: DO_NOT_RETRY_STATUSES,
       },

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -1,11 +1,18 @@
+import * as github from "@actions/github";
 import test from "ava";
 import sinon from "sinon";
 
+import * as api from "../api-client";
+import { RegistryProxyVars } from "../environment";
 import { Feature } from "../feature-flags";
 import { RepositoryPropertyName } from "../feature-flags/properties";
-import { callee, setupTests } from "../testing-utils";
+import {
+  callee,
+  SAMPLE_DOTCOM_API_DETAILS,
+  setupTests,
+} from "../testing-utils";
 
-import { getConfigFileInput } from "./file";
+import { getConfigFileInput, getRemoteConfig } from "./file";
 
 setupTests(test);
 
@@ -66,4 +73,48 @@ test("getConfigFileInput ignores repository property value when FF is off", asyn
       "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled.",
     )
     .passes(t.is, undefined);
+});
+
+test.serial("getRemoteConfig uses proxy when it is supposed to", async (t) => {
+  const client = github.getOctokit("123");
+  const response = {
+    data: {
+      content: Buffer.from("disable-default-queries: false").toString("base64"),
+    },
+  };
+  sinon
+    .stub(client.rest.repos, "getContent")
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    .resolves(response as any);
+  sinon.stub(api, "getApiClientWithExternalAuth").value(() => client);
+
+  const target = callee(getRemoteConfig)
+    .withDefaultActionsEnv()
+    .withArgs("file.yml", SAMPLE_DOTCOM_API_DETAILS);
+
+  // Should use it when the FF is enabled and the environment variables are set.
+  await target
+    .withFeatures([Feature.ProxyApiRequests, Feature.NewRemoteFileAddresses])
+    .withEnv((env) => {
+      env.set(RegistryProxyVars.PROXY_HOST, "localhost");
+      env.set(RegistryProxyVars.PROXY_PORT, "1234");
+    })
+    .logs(t, "Using private registry proxy at 'http://localhost:1234'")
+    .passes(t.truthy);
+
+  // But not when the FF is not enabled.
+  await target
+    .withFeatures([Feature.NewRemoteFileAddresses])
+    .withEnv((env) => {
+      env.set(RegistryProxyVars.PROXY_HOST, "localhost");
+      env.set(RegistryProxyVars.PROXY_PORT, "1234");
+    })
+    .notLogs(t, "Using private registry proxy at 'http://localhost:1234'")
+    .passes(t.truthy);
+
+  // And not when the environment variables aren't set.
+  await target
+    .withFeatures([Feature.ProxyApiRequests, Feature.NewRemoteFileAddresses])
+    .notLogs(t, "Using private registry proxy at 'http://localhost:1234'")
+    .passes(t.truthy);
 });

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -99,8 +99,7 @@ test.serial("getRemoteConfig uses proxy when it is supposed to", async (t) => {
         throw new Error(errorMessage);
       }
       // Otherwise return the client object.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return client as unknown as any;
+      return client;
     });
 
   const target = callee(getRemoteConfig)

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -86,7 +86,22 @@ test.serial("getRemoteConfig uses proxy when it is supposed to", async (t) => {
     .stub(client.rest.repos, "getContent")
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     .resolves(response as any);
-  sinon.stub(api, "getApiClientWithExternalAuth").value(() => client);
+
+  // We stub `getApiClientWithExternalAuth` so that it throws if no
+  // proxy is provided and returns the client otherwise. This allows us
+  // to verify the result in the following test cases.
+  const errorMessage = "No `proxy` was provided by the caller.";
+  sinon
+    .stub(api, "getApiClientWithExternalAuth")
+    .callsFake((_details, proxy) => {
+      // Throw if proxy isn't defined.
+      if (proxy === undefined) {
+        throw new Error(errorMessage);
+      }
+      // Otherwise return the client object.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return client as unknown as any;
+    });
 
   const target = callee(getRemoteConfig)
     .withDefaultActionsEnv()
@@ -110,11 +125,11 @@ test.serial("getRemoteConfig uses proxy when it is supposed to", async (t) => {
       env.set(RegistryProxyVars.PROXY_PORT, "1234");
     })
     .notLogs(t, "Using private registry proxy at 'http://localhost:1234'")
-    .passes(t.truthy);
+    .throws(t, { message: errorMessage });
 
   // And not when the environment variables aren't set.
   await target
     .withFeatures([Feature.ProxyApiRequests, Feature.NewRemoteFileAddresses])
     .notLogs(t, "Using private registry proxy at 'http://localhost:1234'")
-    .passes(t.truthy);
+    .throws(t, { message: errorMessage });
 });

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -68,7 +68,13 @@ export async function getRemoteConfig(
   apiDetails: api.GitHubApiCombinedDetails,
 ): Promise<UserConfig> {
   const address = await parseRemoteFileAddress(actionState, configFile);
-  const proxy = api.getRegistryProxy(actionState.env);
+
+  const shouldProxyRequest = await actionState.features.getValue(
+    Feature.ProxyApiRequests,
+  );
+  const proxy = shouldProxyRequest
+    ? api.getRegistryProxy(actionState.env)
+    : undefined;
 
   const response = await api
     .getApiClientWithExternalAuth(apiDetails, proxy)

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -68,9 +68,10 @@ export async function getRemoteConfig(
   apiDetails: api.GitHubApiCombinedDetails,
 ): Promise<UserConfig> {
   const address = await parseRemoteFileAddress(actionState, configFile);
+  const proxy = api.getRegistryProxy(actionState.env);
 
   const response = await api
-    .getApiClientWithExternalAuth(apiDetails)
+    .getApiClientWithExternalAuth(apiDetails, proxy)
     .rest.repos.getContent({
       owner: address.owner,
       repo: address.repo,

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -73,7 +73,7 @@ export async function getRemoteConfig(
     Feature.ProxyApiRequests,
   );
   const proxy = shouldProxyRequest
-    ? api.getRegistryProxy(actionState.env)
+    ? api.getRegistryProxy(actionState)
     : undefined;
 
   const response = await api

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -265,6 +265,11 @@ export function getOptionalEnvVar(paramName: string): string | undefined {
 export class ReadOnlyEnv<T extends string | undefined = string | undefined> {
   constructor(protected readonly vars: Record<string, T>) {}
 
+  /** Clones the object while detaching the underlying environment from the original. */
+  public clone(): this {
+    return Object.create(this, { vars: { value: { ...this.vars } } }) as this;
+  }
+
   /** Tries to get the value for `name` and throws if there isn't one. */
   public getRequired(name: string): string {
     return getRequiredEnvVar(this.vars, name);

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,4 +1,14 @@
 /**
+ * Environment variables used by Default Setup to communicate the private registry proxy configuration.
+ */
+export enum RegistryProxyVars {
+  PROXY_HOST = "CODEQL_PROXY_HOST",
+  PROXY_PORT = "CODEQL_PROXY_PORT",
+  PROXY_CA_CERTIFICATE = "CODEQL_PROXY_CA_CERTIFICATE",
+  PROXY_URLS = "CODEQL_PROXY_URLS",
+}
+
+/**
  * Environment variables used by the CodeQL Action.
  *
  * We recommend prefixing environment variables with `CODEQL_ACTION_`
@@ -202,7 +212,7 @@ export enum ActionsEnvVars {
 }
 
 /** A type representing all known environment variables. */
-export type KnownEnvVar = EnvVar | ActionsEnvVars;
+export type KnownEnvVar = EnvVar | ActionsEnvVars | RegistryProxyVars;
 
 /**
  * Gets an environment variable, but throws an error if it is not set.

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -136,6 +136,8 @@ export enum Feature {
   /** Controls whether overlay build failures on the default branch are stored in the Actions cache. */
   OverlayAnalysisStatusSave = "overlay_analysis_status_save",
   QaTelemetryEnabled = "qa_telemetry_enabled",
+  /** Routes (some) API requests through the registry proxy. */
+  ProxyApiRequests = "proxy_api_requests",
   /** Note that this currently only disables baseline file coverage information. */
   SkipFileCoverageOnPrs = "skip_file_coverage_on_prs",
   StartProxyUseFeaturesRelease = "start_proxy_use_features_release",
@@ -380,6 +382,11 @@ export const featureConfig = {
     defaultValue: false,
     envVar: "CODEQL_ACTION_QA_TELEMETRY",
     legacyApi: true,
+    minimumVersion: undefined,
+  },
+  [Feature.ProxyApiRequests]: {
+    defaultValue: false,
+    envVar: "CODEQL_ACTION_PROXY_API_REQUESTS",
     minimumVersion: undefined,
   },
   [Feature.SkipFileCoverageOnPrs]: {

--- a/src/testing-utils.ts
+++ b/src/testing-utils.ts
@@ -178,8 +178,7 @@ export function makeMacro<Args extends unknown[]>(
   return wrapper;
 }
 
-export function getTestEnv(): Env {
-  const testEnv: NodeJS.ProcessEnv = {};
+export function getTestEnv(testEnv: NodeJS.ProcessEnv = {}): Env {
   return getEnv(testEnv);
 }
 

--- a/src/testing-utils.ts
+++ b/src/testing-utils.ts
@@ -240,7 +240,7 @@ abstract class BaseEnvBuilder<
       cloneFrom !== undefined
         ? ({
             ...cloneFrom.state,
-            env: Object.create(cloneFrom.state.env),
+            env: cloneFrom.state.env.clone(),
             actions: Object.create(cloneFrom.state.actions),
             logger: this.logger,
           } satisfies ActionState<AllState>)


### PR DESCRIPTION
This PR allows the CodeQL Action to use the private registry authentication proxy when fetching remote configuration files. The authentication proxy is available in Default Setup workflows. Doing so allows configuration files to be retrieved from private repositories, provided that a suitable `git_source` registry is set up for the organisation.

#4000 has laid the groundwork for this, by always enabling `git_source` registries when they are available. 

The change is behind a new FF. 

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Test repository** - This change will be tested on a test repository before merging.
- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Feature flags** - All new or changed code paths can be fully disabled with corresponding feature flags.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
