### PR TITLE
Always make `docker_registry` registries available

### DIFF
--- a/src/start-proxy.test.ts
+++ b/src/start-proxy.test.ts
@@ -128,6 +128,12 @@ const gitSourceCredential = {
   token: "mno",
 };
 
+const dockerRegistryCredential = {
+  type: "docker_registry",
+  host: "https://registry.example.com",
+  token: "pqr",
+};
+
 test("getCredentials prefers registriesCredentials over registrySecrets", async (t) => {
   const registryCredentials = Buffer.from(
     JSON.stringify([
@@ -633,6 +639,7 @@ test("getCredentials returns only ALWAYS_ENABLED_REGISTRY_TYPE credentials for A
   const credentialsInput = toEncodedJSON([
     ...mixedCredentials,
     gitSourceCredential,
+    dockerRegistryCredential,
   ]);
 
   const credentials = startProxyExports.getCredentials(

--- a/src/start-proxy.ts
+++ b/src/start-proxy.ts
@@ -192,7 +192,10 @@ function isPAT(value: string) {
  * enabled, because generic CodeQL workflow components may use them rather than just
  * language-specific components.
  */
-export const ALWAYS_ENABLED_REGISTRY_TYPE = ["git_source"] as const;
+export const ALWAYS_ENABLED_REGISTRY_TYPE = [
+  "git_source",
+  "docker_registry",
+] as const;
 
 type RegistryMapping = Partial<Record<BuiltInLanguage, string[]>>;
 


### PR DESCRIPTION
A similar change as in #4000, which makes `docker_registry` registries always available to the workflow. The CLI can use Docker-style registries for custom query packs.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
