### PR TITLE
Improve global proxy tests

### DIFF
--- a/.github/workflows/__global-proxy.yml
+++ b/.github/workflows/__global-proxy.yml
@@ -55,6 +55,24 @@ jobs:
           version: ${{ matrix.version }}
           use-all-platform-bundle: 'false'
           setup-kotlin: 'false'
+      - name: Block direct internet access to force proxy usage
+        run: |
+          apt-get update -qq && apt-get install -y -qq iptables >/dev/null 2>&1
+          PROXY_IP=$(getent hosts squid-proxy | awk '{ print $1 }')
+          echo "Squid proxy IP: $PROXY_IP"
+          # Allow all traffic to the proxy container
+          iptables -A OUTPUT -d "$PROXY_IP" -j ACCEPT
+          # Allow DNS resolution
+          iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+          iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+          # Allow loopback
+          iptables -A OUTPUT -o lo -j ACCEPT
+          # Allow already-established connections (from checkout/prepare-test)
+          iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+          # Block all other outbound HTTP and HTTPS, ensuring direct access fails
+          iptables -A OUTPUT -p tcp --dport 80 -j REJECT --reject-with tcp-reset
+          iptables -A OUTPUT -p tcp --dport 443 -j REJECT --reject-with tcp-reset
+          echo "Direct HTTP/HTTPS access is now blocked - all traffic must go through the proxy"
       - uses: ./../action/init
         with:
           languages: javascript
@@ -66,6 +84,7 @@ jobs:
       CODEQL_ACTION_TEST_MODE: true
     container:
       image: ubuntu:22.04
+      options: --cap-add=NET_ADMIN
     services:
       squid-proxy:
         image: ubuntu/squid:latest

--- a/.github/workflows/__global-proxy.yml
+++ b/.github/workflows/__global-proxy.yml
@@ -73,13 +73,22 @@ jobs:
           iptables -A OUTPUT -p tcp --dport 80 -j REJECT --reject-with tcp-reset
           iptables -A OUTPUT -p tcp --dport 443 -j REJECT --reject-with tcp-reset
           echo "Direct HTTP/HTTPS access is now blocked - all traffic must go through the proxy"
+
+      - name: Set proxy environment variables
+        shell: bash
+        run: |
+          echo "http_proxy=http://squid-proxy:3128" >> $GITHUB_ENV
+          echo "HTTP_PROXY=http://squid-proxy:3128" >> $GITHUB_ENV
+          echo "https_proxy=http://squid-proxy:3128" >> $GITHUB_ENV
+          echo "HTTPS_PROXY=http://squid-proxy:3128" >> $GITHUB_ENV
+
       - uses: ./../action/init
         with:
           languages: javascript
           tools: ${{ steps.prepare-test.outputs.tools-url }}
+
       - uses: ./../action/analyze
     env:
-      https_proxy: http://squid-proxy:3128
       CODEQL_ACTION_TOLERATE_MISSING_GIT_VERSION: true
       CODEQL_ACTION_TEST_MODE: true
     container:

--- a/pr-checks/checks/global-proxy.yml
+++ b/pr-checks/checks/global-proxy.yml
@@ -5,6 +5,7 @@ versions:
   - nightly-latest
 container:
   image: ubuntu:22.04
+  options: --cap-add=NET_ADMIN
 services:
   squid-proxy:
     image: ubuntu/squid:latest
@@ -14,6 +15,24 @@ env:
   https_proxy: http://squid-proxy:3128
   CODEQL_ACTION_TOLERATE_MISSING_GIT_VERSION: true
 steps:
+  - name: Block direct internet access to force proxy usage
+    run: |
+      apt-get update -qq && apt-get install -y -qq iptables >/dev/null 2>&1
+      PROXY_IP=$(getent hosts squid-proxy | awk '{ print $1 }')
+      echo "Squid proxy IP: $PROXY_IP"
+      # Allow all traffic to the proxy container
+      iptables -A OUTPUT -d "$PROXY_IP" -j ACCEPT
+      # Allow DNS resolution
+      iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+      iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+      # Allow loopback
+      iptables -A OUTPUT -o lo -j ACCEPT
+      # Allow already-established connections (from checkout/prepare-test)
+      iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+      # Block all other outbound HTTP and HTTPS, ensuring direct access fails
+      iptables -A OUTPUT -p tcp --dport 80 -j REJECT --reject-with tcp-reset
+      iptables -A OUTPUT -p tcp --dport 443 -j REJECT --reject-with tcp-reset
+      echo "Direct HTTP/HTTPS access is now blocked - all traffic must go through the proxy"
   - uses: ./../action/init
     with:
       languages: javascript

--- a/pr-checks/checks/global-proxy.yml
+++ b/pr-checks/checks/global-proxy.yml
@@ -12,7 +12,6 @@ services:
     ports:
       - 3128:3128
 env:
-  https_proxy: http://squid-proxy:3128
   CODEQL_ACTION_TOLERATE_MISSING_GIT_VERSION: true
 steps:
   - name: Block direct internet access to force proxy usage
@@ -33,8 +32,18 @@ steps:
       iptables -A OUTPUT -p tcp --dport 80 -j REJECT --reject-with tcp-reset
       iptables -A OUTPUT -p tcp --dport 443 -j REJECT --reject-with tcp-reset
       echo "Direct HTTP/HTTPS access is now blocked - all traffic must go through the proxy"
+
+  - name: Set proxy environment variables
+    shell: bash
+    run: |
+      echo "http_proxy=http://squid-proxy:3128" >> $GITHUB_ENV
+      echo "HTTP_PROXY=http://squid-proxy:3128" >> $GITHUB_ENV
+      echo "https_proxy=http://squid-proxy:3128" >> $GITHUB_ENV
+      echo "HTTPS_PROXY=http://squid-proxy:3128" >> $GITHUB_ENV
+
   - uses: ./../action/init
     with:
       languages: javascript
       tools: ${{ steps.prepare-test.outputs.tools-url }}
+
   - uses: ./../action/analyze

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -2,6 +2,7 @@ import * as github from "@actions/github";
 import * as githubUtils from "@actions/github/lib/utils";
 import test from "ava";
 import * as sinon from "sinon";
+import { ProxyAgent } from "undici";
 
 import * as actionsUtil from "./actions-util";
 import * as api from "./api-client";
@@ -250,4 +251,24 @@ test("getRegistryProxyConfig - gets the configuration from the env vars", async 
       }),
     )
     .passes(t.like, { host, port, ca });
+});
+
+test("makeProxyRequestOptions - returns defaults without custom proxy", async (t) => {
+  t.deepEqual(
+    api.makeProxyRequestOptions(undefined),
+    githubUtils.defaults.request,
+  );
+});
+
+test("makeProxyRequestOptions - returns fetch with custom proxy", async (t) => {
+  const opts = api.makeProxyRequestOptions(
+    new ProxyAgent("http://localhost:1080"),
+  );
+  // Fetch should be different from the defaults.
+  t.notDeepEqual(opts?.fetch, githubUtils.defaults.request?.fetch);
+  // The options should be the same aside from that.
+  t.deepEqual(
+    { ...opts, fetch: githubUtils.defaults.request?.fetch },
+    githubUtils.defaults.request,
+  );
 });

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -108,12 +108,19 @@ export function getRegistryProxy(
  * Constructs a `RequestRequestOptions` with a custom `fetch` implementation
  * that uses `dispatcher` as a proxy for requests.
  *
- * @param dispatcher The proxy to use.
+ * @param dispatcher The proxy to use, if any.
  */
 export function makeProxyRequestOptions(
-  dispatcher: ProxyAgent,
-): RequestRequestOptions {
+  dispatcher: ProxyAgent | undefined,
+): RequestRequestOptions | undefined {
+  // If we don't have a custom `ProxyAgent`, return the defaults.
+  if (dispatcher === undefined) {
+    return githubUtils.defaults.request;
+  }
+
+  // Otherwise, construct the custom `fetch` and add it onto the defaults.
   return {
+    ...githubUtils.defaults.request,
     fetch: (req: RequestInfo, init?: RequestInit) => {
       return undiciFetch(req, { ...init, dispatcher });
     },
@@ -136,10 +143,7 @@ function createApiClientWithDetails(
   const auth =
     (allowExternal && apiDetails.externalRepoAuth) || apiDetails.auth;
   const retryingOctokit = githubUtils.GitHub.plugin(retry.retry);
-  const requestOptions =
-    proxy === undefined
-      ? githubUtils.defaults.request
-      : makeProxyRequestOptions(proxy);
+  const requestOptions = makeProxyRequestOptions(proxy);
   return new retryingOctokit(
     githubUtils.getOctokitOptions(auth, {
       baseUrl: apiDetails.apiURL,


### PR DESCRIPTION
Improves our `global-proxy` e2e test. The existing test setup didn't actually verify that the proxy was used or force its usage. This PR improves the test by blocking HTTP(S) connections (for the standard ports). I have verified that this [fails without the changes](https://github.com/github/codeql-action/actions/runs/29897030568) to `api-client.ts` from #4030 / this PR and [succeeds with them](https://github.com/github/codeql-action/actions/runs/29897141859).

Additionally, this PR slightly modifies `makeProxyRequestOptions` to always base the result on `githubUtils.defaults.request` and only overrides `fetch`. This should make it more robust if `githubUtils.defaults.request` includes other properties in the future or `agent` becomes more critical. I have also added two test cases there to check that the result either matches the default if no custom `dispatcher` is given, or matches the defaults with a different `fetch` otherwise. The actual proxy functionality is tested elsewhere.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.
- **Third-party analyses** - The changes affect the `upload-sarif` action.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
