### PR TITLE
Promote `AllowToolcacheInput` feature

### DIFF
--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -74,7 +74,6 @@ export enum Feature {
   AllowMergeConfigFiles = "allow_merge_config_files",
   /** Controls whether we allow multiple values for the `analysis-kinds` input. */
   AllowMultipleAnalysisKinds = "allow_multiple_analysis_kinds",
-  AllowToolcacheInput = "allow_toolcache_input",
   CleanupTrapCaches = "cleanup_trap_caches",
   /** Whether to allow the `config-file` input to be specified via a repository property. */
   ConfigFileRepositoryProperty = "config_file_repository_property",
@@ -183,11 +182,6 @@ export const featureConfig = {
   [Feature.AllowMultipleAnalysisKinds]: {
     defaultValue: false,
     envVar: "CODEQL_ACTION_ALLOW_MULTIPLE_ANALYSIS_KINDS",
-    minimumVersion: undefined,
-  },
-  [Feature.AllowToolcacheInput]: {
-    defaultValue: false,
-    envVar: "CODEQL_ACTION_ALLOW_TOOLCACHE_INPUT",
     minimumVersion: undefined,
   },
   [Feature.CleanupTrapCaches]: {

--- a/src/setup-codeql.test.ts
+++ b/src/setup-codeql.test.ts
@@ -451,7 +451,7 @@ test.serial(
   async (t) => {
     const loggedMessages: LoggedMessage[] = [];
     const logger = getRecordingLogger(loggedMessages);
-    const features = createFeatures([Feature.AllowToolcacheInput]);
+    const features = createFeatures([]);
 
     const latestToolcacheVersion = "3.2.1";
     const latestVersionPath = "/path/to/latest";
@@ -580,7 +580,7 @@ const toolcacheInputFallbackMacro = makeMacro({
 
 toolcacheInputFallbackMacro.serial(
   "the toolcache doesn't have a CodeQL CLI when tools == toolcache",
-  [Feature.AllowToolcacheInput],
+  [],
   { GITHUB_EVENT_NAME: "dynamic" },
   [],
   [
@@ -591,20 +591,12 @@ toolcacheInputFallbackMacro.serial(
 
 toolcacheInputFallbackMacro.serial(
   "the workflow trigger is not `dynamic`",
-  [Feature.AllowToolcacheInput],
+  [],
   { GITHUB_EVENT_NAME: "pull_request" },
   [],
   [
     `Ignoring 'tools: toolcache' because the workflow was not triggered dynamically.`,
   ],
-);
-
-toolcacheInputFallbackMacro.serial(
-  "the feature flag is not enabled",
-  [],
-  { GITHUB_EVENT_NAME: "dynamic" },
-  [],
-  [`Ignoring 'tools: toolcache' because the feature is not enabled.`],
 );
 
 test.serial(

--- a/src/setup-codeql.ts
+++ b/src/setup-codeql.ts
@@ -533,11 +533,7 @@ export async function getCodeQLSource(
     // We only allow `toolsInput === "toolcache"` for `dynamic` events. In general, using `toolsInput === "toolcache"`
     // can lead to alert wobble and so it shouldn't be used for an analysis where results are intended to be uploaded.
     // We also allow this in test mode.
-    const allowToolcacheValueFF = await features.getValue(
-      Feature.AllowToolcacheInput,
-    );
-    const allowToolcacheValue =
-      allowToolcacheValueFF && (isDynamicWorkflow() || util.isInTestMode());
+    const allowToolcacheValue = isDynamicWorkflow() || util.isInTestMode();
     if (allowToolcacheValue) {
       // If `toolsInput === "toolcache"`, try to find the latest version of the CLI that's available in the toolcache
       // and use that. We perform this check here since we can set `cliVersion` directly and don't want to default to
@@ -558,15 +554,9 @@ export async function getCodeQLSource(
           `Found no CodeQL CLI in the toolcache, ignoring 'tools: ${toolsInput}'...`,
         );
       } else {
-        if (allowToolcacheValueFF) {
-          logger.warning(
-            `Ignoring 'tools: ${toolsInput}' because the workflow was not triggered dynamically.`,
-          );
-        } else {
-          logger.info(
-            `Ignoring 'tools: ${toolsInput}' because the feature is not enabled.`,
-          );
-        }
+        logger.warning(
+          `Ignoring 'tools: ${toolsInput}' because the workflow was not triggered dynamically.`,
+        );
       }
 
       const version = await resolveDefaultCliVersion(


### PR DESCRIPTION
This feature has been rolled out for some time now. This PR removes the FF and makes the behaviour that was guarded by it the default.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
