### PR TITLE
Use `ComputedInput` for configuration file input

### DIFF
--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -148426,9 +148426,8 @@ function parseUserConfig(logger, pathInput, contents, validateConfig) {
 // src/config/inputs.ts
 async function getComputedInput(action, repositoryProperties, name, options) {
   const input = action.actions.getOptionalInput(name);
-  const allowRepositoryProperty = options.repositoryPropertyName !== void 0;
-  const propertyValue = options.repositoryPropertyName !== void 0 ? repositoryProperties[options.repositoryPropertyName] : void 0;
-  if (allowRepositoryProperty && options.allowForcedRepositoryPropertyValue && propertyValue?.startsWith("!")) {
+  const propertyValue = repositoryProperties[options.repositoryPropertyName];
+  if (options.repositoryPropertyFeatureEnabled && options.allowForcedRepositoryPropertyValue && propertyValue?.startsWith("!")) {
     action.logger.info(
       `Using ${name} input from repository property (enforced): ${propertyValue}`
     );
@@ -148442,7 +148441,7 @@ async function getComputedInput(action, repositoryProperties, name, options) {
     action.logger.info(`Using ${name} input from workflow: ${input}`);
     return { value: input, source: "workflow" /* Workflow */ };
   }
-  if (allowRepositoryProperty && propertyValue !== void 0) {
+  if (options.repositoryPropertyFeatureEnabled && propertyValue !== void 0) {
     action.logger.info(
       `Using ${name} input from repository property: ${propertyValue}`
     );
@@ -148450,6 +148449,10 @@ async function getComputedInput(action, repositoryProperties, name, options) {
       value: propertyValue,
       source: "repository-property" /* RepositoryProperty */
     };
+  } else if (propertyValue !== void 0) {
+    action.logger.info(
+      `Ignoring ${name} input from repository property, because the corresponding feature flag is disabled.`
+    );
   }
   return void 0;
 }
@@ -148458,8 +148461,9 @@ async function getToolsInput(action, repositoryProperties) {
     "tools_repository_property" /* ToolsRepositoryProperty */
   );
   return getComputedInput(action, repositoryProperties, "tools" /* Tools */, {
+    repositoryPropertyFeatureEnabled: allowRepositoryProperty,
     allowForcedRepositoryPropertyValue: true,
-    repositoryPropertyName: allowRepositoryProperty ? "github-codeql-tools" /* TOOLS */ : void 0
+    repositoryPropertyName: "github-codeql-tools" /* TOOLS */
   });
 }
 

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -148550,33 +148550,15 @@ async function parseRemoteFileAddress(actionState, configFile) {
 // src/config/file.ts
 var LOCAL_PATH_PREFIX = "./";
 var REMOTE_PATH_PREFIX = "remote=";
-async function getConfigFileInput({
-  logger,
-  actions,
-  features
-}, repositoryProperties) {
-  const input = actions.getOptionalInput("config-file");
-  if (input !== void 0) {
-    logger.info(`Using configuration file input from workflow: ${input}`);
-    return { value: input, source: "workflow" /* Workflow */ };
-  }
-  const propertyValue = repositoryProperties["github-codeql-config-file" /* CONFIG_FILE */];
-  if (propertyValue !== void 0 && propertyValue.trim().length > 0) {
-    const useRepositoryProperty = await features.getValue(
-      "config_file_repository_property" /* ConfigFileRepositoryProperty */
-    );
-    if (useRepositoryProperty) {
-      logger.info(
-        `Using configuration file input from repository property: ${propertyValue}`
-      );
-      return { value: propertyValue, source: "repository-property" /* RepositoryProperty */ };
-    } else {
-      logger.info(
-        "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled."
-      );
-    }
-  }
-  return void 0;
+async function getConfigFileInput(action, repositoryProperties) {
+  const useRepositoryProperty = await action.features.getValue(
+    "config_file_repository_property" /* ConfigFileRepositoryProperty */
+  );
+  return getComputedInput(action, repositoryProperties, "config-file" /* ConfigFile */, {
+    repositoryPropertyFeatureEnabled: useRepositoryProperty,
+    allowForcedRepositoryPropertyValue: false,
+    repositoryPropertyName: "github-codeql-config-file" /* CONFIG_FILE */
+  });
 }
 async function getRemoteConfig(actionState, configFile, apiDetails) {
   const address = await parseRemoteFileAddress(actionState, configFile);

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -148424,13 +148424,10 @@ function parseUserConfig(logger, pathInput, contents, validateConfig) {
 }
 
 // src/config/inputs.ts
-async function getToolsInput(action, repositoryProperties) {
-  const name = "tools" /* Tools */;
+async function getComputedInput(action, repositoryProperties, name, options) {
   const input = action.actions.getOptionalInput(name);
-  const propertyValue = repositoryProperties["github-codeql-tools" /* TOOLS */];
-  const allowRepositoryProperty = await action.features.getValue(
-    "tools_repository_property" /* ToolsRepositoryProperty */
-  );
+  const allowRepositoryProperty = options.repositoryPropertyName !== void 0;
+  const propertyValue = options.repositoryPropertyName !== void 0 ? repositoryProperties[options.repositoryPropertyName] : void 0;
   if (allowRepositoryProperty && propertyValue?.startsWith("!")) {
     action.logger.info(
       `Using ${name} input from repository property (enforced): ${propertyValue}`
@@ -148455,6 +148452,14 @@ async function getToolsInput(action, repositoryProperties) {
     };
   }
   return void 0;
+}
+async function getToolsInput(action, repositoryProperties) {
+  const allowRepositoryProperty = await action.features.getValue(
+    "tools_repository_property" /* ToolsRepositoryProperty */
+  );
+  return getComputedInput(action, repositoryProperties, "tools" /* Tools */, {
+    repositoryPropertyName: allowRepositoryProperty ? "github-codeql-tools" /* TOOLS */ : void 0
+  });
 }
 
 // src/config/remote-file.ts

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -148428,7 +148428,7 @@ async function getComputedInput(action, repositoryProperties, name, options) {
   const input = action.actions.getOptionalInput(name);
   const allowRepositoryProperty = options.repositoryPropertyName !== void 0;
   const propertyValue = options.repositoryPropertyName !== void 0 ? repositoryProperties[options.repositoryPropertyName] : void 0;
-  if (allowRepositoryProperty && propertyValue?.startsWith("!")) {
+  if (allowRepositoryProperty && options.allowForcedRepositoryPropertyValue && propertyValue?.startsWith("!")) {
     action.logger.info(
       `Using ${name} input from repository property (enforced): ${propertyValue}`
     );
@@ -148458,6 +148458,7 @@ async function getToolsInput(action, repositoryProperties) {
     "tools_repository_property" /* ToolsRepositoryProperty */
   );
   return getComputedInput(action, repositoryProperties, "tools" /* Tools */, {
+    allowForcedRepositoryPropertyValue: true,
     repositoryPropertyName: allowRepositoryProperty ? "github-codeql-tools" /* TOOLS */ : void 0
   });
 }

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146550,7 +146550,7 @@ async function sendStatusReport(statusReport) {
     );
   }
 }
-async function createInitWithConfigStatusReport(config, initStatusReport, configFile, totalCacheSize, overlayBaseDatabaseStats, dependencyCachingResults) {
+async function createInitWithConfigStatusReport(config, initStatusReport, configFileInput, totalCacheSize, overlayBaseDatabaseStats, dependencyCachingResults) {
   const languages = config.languages.join(",");
   const paths = (config.originalUserInput.paths || []).join(",");
   const pathsIgnore = (config.originalUserInput["paths-ignore"] || []).join(
@@ -146576,7 +146576,7 @@ async function createInitWithConfigStatusReport(config, initStatusReport, config
   }
   return {
     ...initStatusReport,
-    config_file: configFile ?? "",
+    config_file: configFileInput?.value ?? "",
     disable_default_queries: disableDefaultQueries,
     paths,
     paths_ignore: pathsIgnore,
@@ -148423,6 +148423,40 @@ function parseUserConfig(logger, pathInput, contents, validateConfig) {
   }
 }
 
+// src/config/inputs.ts
+async function getToolsInput(action, repositoryProperties) {
+  const name = "tools" /* Tools */;
+  const input = action.actions.getOptionalInput(name);
+  const propertyValue = repositoryProperties["github-codeql-tools" /* TOOLS */];
+  const allowRepositoryProperty = await action.features.getValue(
+    "tools_repository_property" /* ToolsRepositoryProperty */
+  );
+  if (allowRepositoryProperty && propertyValue?.startsWith("!")) {
+    action.logger.info(
+      `Using ${name} input from repository property (enforced): ${propertyValue}`
+    );
+    return {
+      // Drop the '!' from the value.
+      value: propertyValue.substring(1),
+      source: "repository-property" /* RepositoryProperty */
+    };
+  }
+  if (input !== void 0) {
+    action.logger.info(`Using ${name} input from workflow: ${input}`);
+    return { value: input, source: "workflow" /* Workflow */ };
+  }
+  if (allowRepositoryProperty && propertyValue !== void 0) {
+    action.logger.info(
+      `Using ${name} input from repository property: ${propertyValue}`
+    );
+    return {
+      value: propertyValue,
+      source: "repository-property" /* RepositoryProperty */
+    };
+  }
+  return void 0;
+}
+
 // src/config/remote-file.ts
 var DEFAULT_CONFIG_FILE_NAME = ".github/codeql-action.yaml";
 var DEFAULT_CONFIG_FILE_REF = "main";
@@ -148504,7 +148538,7 @@ async function getConfigFileInput({
   const input = actions.getOptionalInput("config-file");
   if (input !== void 0) {
     logger.info(`Using configuration file input from workflow: ${input}`);
-    return input;
+    return { value: input, source: "workflow" /* Workflow */ };
   }
   const propertyValue = repositoryProperties["github-codeql-config-file" /* CONFIG_FILE */];
   if (propertyValue !== void 0 && propertyValue.trim().length > 0) {
@@ -148515,7 +148549,7 @@ async function getConfigFileInput({
       logger.info(
         `Using configuration file input from repository property: ${propertyValue}`
       );
-      return propertyValue;
+      return { value: propertyValue, source: "repository-property" /* RepositoryProperty */ };
     } else {
       logger.info(
         "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled."
@@ -160347,40 +160381,6 @@ var core21 = __toESM(require_core());
 var io7 = __toESM(require_io());
 var semver10 = __toESM(require_semver2());
 
-// src/config/inputs.ts
-async function getToolsInput(action, repositoryProperties) {
-  const name = "tools" /* Tools */;
-  const input = action.actions.getOptionalInput(name);
-  const propertyValue = repositoryProperties["github-codeql-tools" /* TOOLS */];
-  const allowRepositoryProperty = await action.features.getValue(
-    "tools_repository_property" /* ToolsRepositoryProperty */
-  );
-  if (allowRepositoryProperty && propertyValue?.startsWith("!")) {
-    action.logger.info(
-      `Using ${name} input from repository property (enforced): ${propertyValue}`
-    );
-    return {
-      // Drop the '!' from the value.
-      value: propertyValue.substring(1),
-      source: "repository-property" /* RepositoryProperty */
-    };
-  }
-  if (input !== void 0) {
-    action.logger.info(`Using ${name} input from workflow: ${input}`);
-    return { value: input, source: "workflow" /* Workflow */ };
-  }
-  if (allowRepositoryProperty && propertyValue !== void 0) {
-    action.logger.info(
-      `Using ${name} input from repository property: ${propertyValue}`
-    );
-    return {
-      value: propertyValue,
-      source: "repository-property" /* RepositoryProperty */
-    };
-  }
-  return void 0;
-}
-
 // src/workflow.ts
 var fs27 = __toESM(require("fs"));
 var path23 = __toESM(require("path"));
@@ -160671,7 +160671,7 @@ async function sendStartingStatusReport(startedAt, config, logger) {
     await sendStatusReport(statusReportBase);
   }
 }
-async function sendCompletedStatusReport2(startedAt, config, configFile, toolsInput, toolsDownloadStatusReport, toolsFeatureFlagsValid, toolsSource, toolsVersion, overlayBaseDatabaseStats, dependencyCachingResults, logger, error3) {
+async function sendCompletedStatusReport2(startedAt, config, configFileInput, toolsInput, toolsDownloadStatusReport, toolsFeatureFlagsValid, toolsSource, toolsVersion, overlayBaseDatabaseStats, dependencyCachingResults, logger, error3) {
   const statusReportBase = await createStatusReportBase(
     "init" /* Init */,
     getActionsStatus(error3),
@@ -160696,6 +160696,9 @@ async function sendCompletedStatusReport2(startedAt, config, configFile, toolsIn
   if (toolsInput !== void 0) {
     initStatusReport.computed_inputs.tools = toolsInput;
   }
+  if (configFileInput !== void 0) {
+    initStatusReport.computed_inputs["config-file"] = configFileInput;
+  }
   const initToolsDownloadFields = {};
   if (toolsDownloadStatusReport?.downloadDurationMs !== void 0) {
     initToolsDownloadFields.tools_download_duration_ms = toolsDownloadStatusReport.downloadDurationMs;
@@ -160707,7 +160710,7 @@ async function sendCompletedStatusReport2(startedAt, config, configFile, toolsIn
     const initWithConfigStatusReport = await createInitWithConfigStatusReport(
       config,
       initStatusReport,
-      configFile,
+      configFileInput,
       Math.round(
         await getTotalCacheSize(Object.values(config.trapCaches), logger)
       ),
@@ -160727,7 +160730,7 @@ async function run3(actionState) {
   const logger = actionState.logger;
   let apiDetails;
   let config;
-  let configFile;
+  let configFileInput;
   let codeql;
   let features;
   let sourceRoot;
@@ -160765,7 +160768,7 @@ async function run3(actionState) {
     core21.exportVariable("JOB_RUN_UUID" /* JOB_RUN_UUID */, jobRunUuid);
     core21.exportVariable("CODEQL_ACTION_INIT_HAS_RUN" /* INIT_ACTION_HAS_RUN */, "true");
     const actionStateWithFeatures = { ...actionState, features };
-    configFile = await getConfigFileInput(
+    configFileInput = await getConfigFileInput(
       actionStateWithFeatures,
       repositoryProperties
     );
@@ -160846,7 +160849,7 @@ async function run3(actionState) {
       packsInput: getOptionalInput("packs"),
       buildModeInput: getOptionalInput("build-mode"),
       ramInput: getOptionalInput("ram"),
-      configFile,
+      configFile: configFileInput?.value,
       dbLocation: getOptionalInput("db-location"),
       configInput: getOptionalInput("config"),
       dependencyCachingEnabled: getDependencyCachingEnabled(),
@@ -161133,7 +161136,7 @@ exec ${goBinaryPath} "$@"`
   await sendCompletedStatusReport2(
     startedAt,
     config,
-    configFile,
+    configFileInput,
     toolsInput,
     toolsDownloadStatusReport,
     toolsFeatureFlagsValid,

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -147996,13 +147996,17 @@ var stringProperty = {
   validate: isString2,
   parse: parseStringRepositoryProperty
 };
+var nonEmptyStringProperty = {
+  ...stringProperty,
+  parse: parseNonEmptyStringRepositoryProperty
+};
 var booleanProperty = {
   // The value from the API should come as a string, which we then parse into a boolean.
   validate: isString2,
   parse: parseBooleanRepositoryProperty
 };
 var repositoryPropertyParsers = {
-  ["github-codeql-config-file" /* CONFIG_FILE */]: stringProperty,
+  ["github-codeql-config-file" /* CONFIG_FILE */]: nonEmptyStringProperty,
   ["github-codeql-disable-overlay" /* DISABLE_OVERLAY */]: booleanProperty,
   ["github-codeql-extra-queries" /* EXTRA_QUERIES */]: stringProperty,
   ["github-codeql-file-coverage-on-prs" /* FILE_COVERAGE_ON_PRS */]: booleanProperty,
@@ -148078,6 +148082,12 @@ function parseBooleanRepositoryProperty(name, value, logger) {
   return value === "true";
 }
 function parseStringRepositoryProperty(_name, value) {
+  return value;
+}
+function parseNonEmptyStringRepositoryProperty(_name, value) {
+  if (value.trim().length === 0) {
+    return void 0;
+  }
   return value;
 }
 var KNOWN_REPOSITORY_PROPERTY_NAMES = new Set(

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -42,7 +42,7 @@ test("getConfigFileInput returns input value", async (t) => {
         .returns(testInput);
     })
     .withArgs(repositoryProperties)
-    .logs(t, "Using configuration file input from workflow")
+    .logs(t, "Using config-file input from workflow")
     .passes(t.deepEqual, { value: testInput, source: InputSource.Workflow });
 });
 
@@ -51,19 +51,11 @@ test("getConfigFileInput returns repository property value", async (t) => {
   await callee(getConfigFileInput)
     .withFeatures([Feature.ConfigFileRepositoryProperty])
     .withArgs(repositoryProperties)
-    .logs(t, "Using configuration file input from repository property")
+    .logs(t, "Using config-file input from repository property")
     .passes(t.deepEqual, {
       value: repositoryProperties[RepositoryPropertyName.CONFIG_FILE],
       source: InputSource.RepositoryProperty,
     });
-});
-
-test("getConfigFileInput ignores empty repository property value", async (t) => {
-  // Since the repository property value is an empty/whitespace string, we should ignore it.
-  await callee(getConfigFileInput)
-    .withFeatures([Feature.ConfigFileRepositoryProperty])
-    .withArgs({ [RepositoryPropertyName.CONFIG_FILE]: "   " })
-    .passes(t.is, undefined);
 });
 
 test("getConfigFileInput ignores repository property value when FF is off", async (t) => {
@@ -71,10 +63,10 @@ test("getConfigFileInput ignores repository property value when FF is off", asyn
   await callee(getConfigFileInput)
     .withFeatures([])
     .withArgs(repositoryProperties)
-    .notLogs(t, "Using configuration file input from repository property")
+    .notLogs(t, "Using config-file input from repository property")
     .logs(
       t,
-      "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled.",
+      "Ignoring config-file input from repository property, because the corresponding feature flag is disabled.",
     )
     .passes(t.is, undefined);
 });

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../testing-utils";
 
 import { getConfigFileInput, getRemoteConfig } from "./file";
+import { InputSource } from "./inputs";
 
 setupTests(test);
 
@@ -42,7 +43,7 @@ test("getConfigFileInput returns input value", async (t) => {
     })
     .withArgs(repositoryProperties)
     .logs(t, "Using configuration file input from workflow")
-    .passes(t.is, testInput);
+    .passes(t.deepEqual, { value: testInput, source: InputSource.Workflow });
 });
 
 test("getConfigFileInput returns repository property value", async (t) => {
@@ -51,7 +52,10 @@ test("getConfigFileInput returns repository property value", async (t) => {
     .withFeatures([Feature.ConfigFileRepositoryProperty])
     .withArgs(repositoryProperties)
     .logs(t, "Using configuration file input from repository property")
-    .passes(t.is, repositoryProperties[RepositoryPropertyName.CONFIG_FILE]);
+    .passes(t.deepEqual, {
+      value: repositoryProperties[RepositoryPropertyName.CONFIG_FILE],
+      source: InputSource.RepositoryProperty,
+    });
 });
 
 test("getConfigFileInput ignores empty repository property value", async (t) => {

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -9,7 +9,7 @@ import {
 import { ConfigurationError } from "../util";
 
 import { parseUserConfig, UserConfig } from "./db-config";
-import { InputSource, type ComputedInput } from "./inputs";
+import { getComputedInput, InputName, type ComputedInput } from "./inputs";
 import { parseRemoteFileAddress } from "./remote-file";
 
 /**
@@ -29,42 +29,19 @@ export const REMOTE_PATH_PREFIX = "remote=";
  * Gets the value that is configured for the configuration file, if any.
  */
 export async function getConfigFileInput(
-  {
-    logger,
-    actions,
-    features,
-  }: ActionState<["Logger", "Actions", "FeatureFlags"]>,
+  action: ActionState<["Logger", "Actions", "FeatureFlags"]>,
   repositoryProperties: Partial<RepositoryProperties>,
 ): Promise<ComputedInput | undefined> {
-  const input = actions.getOptionalInput("config-file");
+  // Only use the repository property value if the FF is enabled.
+  const useRepositoryProperty = await action.features.getValue(
+    Feature.ConfigFileRepositoryProperty,
+  );
 
-  if (input !== undefined) {
-    logger.info(`Using configuration file input from workflow: ${input}`);
-    return { value: input, source: InputSource.Workflow };
-  }
-
-  const propertyValue =
-    repositoryProperties[RepositoryPropertyName.CONFIG_FILE];
-
-  if (propertyValue !== undefined && propertyValue.trim().length > 0) {
-    // Only use the repository property value if the FF is enabled.
-    const useRepositoryProperty = await features.getValue(
-      Feature.ConfigFileRepositoryProperty,
-    );
-
-    if (useRepositoryProperty) {
-      logger.info(
-        `Using configuration file input from repository property: ${propertyValue}`,
-      );
-      return { value: propertyValue, source: InputSource.RepositoryProperty };
-    } else {
-      logger.info(
-        "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled.",
-      );
-    }
-  }
-
-  return undefined;
+  return getComputedInput(action, repositoryProperties, InputName.ConfigFile, {
+    repositoryPropertyFeatureEnabled: useRepositoryProperty,
+    allowForcedRepositoryPropertyValue: false,
+    repositoryPropertyName: RepositoryPropertyName.CONFIG_FILE,
+  });
 }
 
 /**

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -9,6 +9,7 @@ import {
 import { ConfigurationError } from "../util";
 
 import { parseUserConfig, UserConfig } from "./db-config";
+import { InputSource, type ComputedInput } from "./inputs";
 import { parseRemoteFileAddress } from "./remote-file";
 
 /**
@@ -34,12 +35,12 @@ export async function getConfigFileInput(
     features,
   }: ActionState<["Logger", "Actions", "FeatureFlags"]>,
   repositoryProperties: Partial<RepositoryProperties>,
-): Promise<string | undefined> {
+): Promise<ComputedInput | undefined> {
   const input = actions.getOptionalInput("config-file");
 
   if (input !== undefined) {
     logger.info(`Using configuration file input from workflow: ${input}`);
-    return input;
+    return { value: input, source: InputSource.Workflow };
   }
 
   const propertyValue =
@@ -55,7 +56,7 @@ export async function getConfigFileInput(
       logger.info(
         `Using configuration file input from repository property: ${propertyValue}`,
       );
-      return propertyValue;
+      return { value: propertyValue, source: InputSource.RepositoryProperty };
     } else {
       logger.info(
         "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled.",

--- a/src/config/inputs.ts
+++ b/src/config/inputs.ts
@@ -33,7 +33,16 @@ export type ComputedInput = {
  * Represents options for how to compute an input.
  */
 export interface ComputedInputOptions {
+  /**
+   * The name of the repository property to try and get the input value from.
+   * Repository properties are ignored if this is `undefined`.
+   */
   repositoryPropertyName?: StringRepositoryPropertyNames;
+  /**
+   * Whether the repository property value may start with `!` to take precedence
+   * over any input value provided in the workflow file.
+   */
+  allowForcedRepositoryPropertyValue?: boolean;
 }
 
 /**
@@ -61,7 +70,11 @@ export async function getComputedInput(
       : undefined;
 
   // The repository property takes precedence if it starts with an '!'.
-  if (allowRepositoryProperty && propertyValue?.startsWith("!")) {
+  if (
+    allowRepositoryProperty &&
+    options.allowForcedRepositoryPropertyValue &&
+    propertyValue?.startsWith("!")
+  ) {
     action.logger.info(
       `Using ${name} input from repository property (enforced): ${propertyValue}`,
     );
@@ -109,6 +122,7 @@ export async function getToolsInput(
     Feature.ToolsRepositoryProperty,
   );
   return getComputedInput(action, repositoryProperties, InputName.Tools, {
+    allowForcedRepositoryPropertyValue: true,
     repositoryPropertyName: allowRepositoryProperty
       ? RepositoryPropertyName.TOOLS
       : undefined,

--- a/src/config/inputs.ts
+++ b/src/config/inputs.ts
@@ -7,6 +7,7 @@ import {
 
 /** Enumerates input names. */
 export enum InputName {
+  ConfigFile = "config-file",
   Tools = "tools",
 }
 

--- a/src/config/inputs.ts
+++ b/src/config/inputs.ts
@@ -3,6 +3,7 @@ import { Feature } from "../feature-flags";
 import {
   RepositoryProperties,
   RepositoryPropertyName,
+  StringRepositoryPropertyNames,
 } from "../feature-flags/properties";
 
 /** Enumerates input names. */
@@ -29,23 +30,35 @@ export type ComputedInput = {
 };
 
 /**
- * Gets the computed `tools` input. This comes from either the workflow or
+ * Represents options for how to compute an input.
+ */
+export interface ComputedInputOptions {
+  repositoryPropertyName?: StringRepositoryPropertyNames;
+}
+
+/**
+ * Gets the computed input for `name`. This comes from either the workflow or
  * the repository property.
  *
  * @param action The Action state.
  * @param repositoryProperties The values of known repository properties.
+ * @param name The name of the input to compute.
+ * @param options Options for how to compute the input value.
+ *
  * @returns The computed input or `undefined` if there is no input.
  */
-export async function getToolsInput(
+export async function getComputedInput(
   action: ActionState<["Logger", "Actions", "FeatureFlags"]>,
-  repositoryProperties: Partial<RepositoryProperties>,
+  repositoryProperties: RepositoryProperties,
+  name: InputName,
+  options: ComputedInputOptions,
 ): Promise<ComputedInput | undefined> {
-  const name = InputName.Tools;
   const input = action.actions.getOptionalInput(name);
-  const propertyValue = repositoryProperties[RepositoryPropertyName.TOOLS];
-  const allowRepositoryProperty = await action.features.getValue(
-    Feature.ToolsRepositoryProperty,
-  );
+  const allowRepositoryProperty = options.repositoryPropertyName !== undefined;
+  const propertyValue =
+    options.repositoryPropertyName !== undefined
+      ? repositoryProperties[options.repositoryPropertyName]
+      : undefined;
 
   // The repository property takes precedence if it starts with an '!'.
   if (allowRepositoryProperty && propertyValue?.startsWith("!")) {
@@ -78,4 +91,26 @@ export async function getToolsInput(
 
   // There's no input.
   return undefined;
+}
+
+/**
+ * Gets the computed `tools` input. This comes from either the workflow or
+ * the repository property.
+ *
+ * @param action The Action state.
+ * @param repositoryProperties The values of known repository properties.
+ * @returns The computed input or `undefined` if there is no input.
+ */
+export async function getToolsInput(
+  action: ActionState<["Logger", "Actions", "FeatureFlags"]>,
+  repositoryProperties: Partial<RepositoryProperties>,
+): Promise<ComputedInput | undefined> {
+  const allowRepositoryProperty = await action.features.getValue(
+    Feature.ToolsRepositoryProperty,
+  );
+  return getComputedInput(action, repositoryProperties, InputName.Tools, {
+    repositoryPropertyName: allowRepositoryProperty
+      ? RepositoryPropertyName.TOOLS
+      : undefined,
+  });
 }

--- a/src/config/inputs.ts
+++ b/src/config/inputs.ts
@@ -34,15 +34,18 @@ export type ComputedInput = {
  */
 export interface ComputedInputOptions {
   /**
-   * The name of the repository property to try and get the input value from.
-   * Repository properties are ignored if this is `undefined`.
+   * Whether the FF for the repository property (if any) is enabled.
    */
-  repositoryPropertyName?: StringRepositoryPropertyNames;
+  repositoryPropertyFeatureEnabled: boolean;
+  /**
+   * The name of the repository property to try and get the input value from.
+   */
+  repositoryPropertyName: StringRepositoryPropertyNames;
   /**
    * Whether the repository property value may start with `!` to take precedence
    * over any input value provided in the workflow file.
    */
-  allowForcedRepositoryPropertyValue?: boolean;
+  allowForcedRepositoryPropertyValue: boolean;
 }
 
 /**
@@ -63,15 +66,11 @@ export async function getComputedInput(
   options: ComputedInputOptions,
 ): Promise<ComputedInput | undefined> {
   const input = action.actions.getOptionalInput(name);
-  const allowRepositoryProperty = options.repositoryPropertyName !== undefined;
-  const propertyValue =
-    options.repositoryPropertyName !== undefined
-      ? repositoryProperties[options.repositoryPropertyName]
-      : undefined;
+  const propertyValue = repositoryProperties[options.repositoryPropertyName];
 
   // The repository property takes precedence if it starts with an '!'.
   if (
-    allowRepositoryProperty &&
+    options.repositoryPropertyFeatureEnabled &&
     options.allowForcedRepositoryPropertyValue &&
     propertyValue?.startsWith("!")
   ) {
@@ -92,7 +91,7 @@ export async function getComputedInput(
   }
 
   // Use the repository property if there's no workflow input.
-  if (allowRepositoryProperty && propertyValue !== undefined) {
+  if (options.repositoryPropertyFeatureEnabled && propertyValue !== undefined) {
     action.logger.info(
       `Using ${name} input from repository property: ${propertyValue}`,
     );
@@ -100,6 +99,10 @@ export async function getComputedInput(
       value: propertyValue,
       source: InputSource.RepositoryProperty,
     };
+  } else if (propertyValue !== undefined) {
+    action.logger.info(
+      `Ignoring ${name} input from repository property, because the corresponding feature flag is disabled.`,
+    );
   }
 
   // There's no input.
@@ -122,9 +125,8 @@ export async function getToolsInput(
     Feature.ToolsRepositoryProperty,
   );
   return getComputedInput(action, repositoryProperties, InputName.Tools, {
+    repositoryPropertyFeatureEnabled: allowRepositoryProperty,
     allowForcedRepositoryPropertyValue: true,
-    repositoryPropertyName: allowRepositoryProperty
-      ? RepositoryPropertyName.TOOLS
-      : undefined,
+    repositoryPropertyName: RepositoryPropertyName.TOOLS,
   });
 }

--- a/src/feature-flags/properties.test.ts
+++ b/src/feature-flags/properties.test.ts
@@ -177,6 +177,30 @@ test.serial(
 );
 
 test.serial(
+  "loadPropertiesFromApi returns undefined if non-empty string property is empty",
+  async (t) => {
+    sinon.stub(api, "getRepositoryProperties").resolves({
+      headers: {},
+      status: 200,
+      url: "",
+      data: [{ property_name: "github-codeql-config-file", value: "" }],
+    });
+    const logger = getRunnerLogger(true);
+    const mockRepositoryNwo = parseRepositoryNwo("owner/repo");
+
+    // `github-codeql-config-file` is a `nonEmptyStringProperty`, so we expect to
+    // get `undefined` instead of the empty string
+    const response = await properties.loadPropertiesFromApi(
+      logger,
+      mockRepositoryNwo,
+    );
+    t.deepEqual(response, {
+      "github-codeql-config-file": undefined,
+    });
+  },
+);
+
+test.serial(
   "loadPropertiesFromApi warns if boolean property has unexpected value",
   async (t) => {
     sinon.stub(api, "getRepositoryProperties").resolves({

--- a/src/feature-flags/properties.ts
+++ b/src/feature-flags/properties.ts
@@ -29,6 +29,13 @@ export type AllRepositoryProperties = {
   [RepositoryPropertyName.TOOLS]: string;
 };
 
+/** The subset of known repository properties which are of type `string`. */
+export type StringRepositoryPropertyNames = keyof {
+  [K in keyof AllRepositoryProperties as AllRepositoryProperties[K] extends string
+    ? K
+    : never]: AllRepositoryProperties[K];
+};
+
 /** Parsed repository properties. */
 export type RepositoryProperties = Partial<AllRepositoryProperties>;
 

--- a/src/feature-flags/properties.ts
+++ b/src/feature-flags/properties.ts
@@ -22,16 +22,21 @@ export enum RepositoryPropertyName {
 
 /** Parsed types of the known repository properties. */
 export type AllRepositoryProperties = {
-  [RepositoryPropertyName.CONFIG_FILE]: string;
+  [RepositoryPropertyName.CONFIG_FILE]: string | undefined;
   [RepositoryPropertyName.DISABLE_OVERLAY]: boolean;
   [RepositoryPropertyName.EXTRA_QUERIES]: string;
   [RepositoryPropertyName.FILE_COVERAGE_ON_PRS]: boolean;
   [RepositoryPropertyName.TOOLS]: string;
 };
 
-/** The subset of known repository properties which are of type `string`. */
+/**
+ * The subset of known repository properties which are of type `string`.
+ * We tolerate `undefined` for `string`-typed properties that are empty.
+ */
 export type StringRepositoryPropertyNames = keyof {
-  [K in keyof AllRepositoryProperties as AllRepositoryProperties[K] extends string
+  [K in keyof AllRepositoryProperties as AllRepositoryProperties[K] extends
+    | string
+    | undefined
     ? K
     : never]: AllRepositoryProperties[K];
 };
@@ -79,6 +84,12 @@ const stringProperty = {
   parse: parseStringRepositoryProperty,
 };
 
+/** A repository property that we expect to contain a non-empty string value. */
+const nonEmptyStringProperty = {
+  ...stringProperty,
+  parse: parseNonEmptyStringRepositoryProperty,
+};
+
 /** A repository property that we expect to contain a boolean value. */
 const booleanProperty = {
   // The value from the API should come as a string, which we then parse into a boolean.
@@ -90,7 +101,7 @@ const booleanProperty = {
 const repositoryPropertyParsers: {
   [K in RepositoryPropertyName]: PropertyInfo<K>;
 } = {
-  [RepositoryPropertyName.CONFIG_FILE]: stringProperty,
+  [RepositoryPropertyName.CONFIG_FILE]: nonEmptyStringProperty,
   [RepositoryPropertyName.DISABLE_OVERLAY]: booleanProperty,
   [RepositoryPropertyName.EXTRA_QUERIES]: stringProperty,
   [RepositoryPropertyName.FILE_COVERAGE_ON_PRS]: booleanProperty,
@@ -232,6 +243,17 @@ function parseBooleanRepositoryProperty(
 
 /** Parse a string repository property. */
 function parseStringRepositoryProperty(_name: string, value: string): string {
+  return value;
+}
+
+/** Parse a non-empty string repository property. */
+function parseNonEmptyStringRepositoryProperty(
+  _name: string,
+  value: string,
+): string | undefined {
+  if (value.trim().length === 0) {
+    return undefined;
+  }
   return value;
 }
 

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -129,7 +129,7 @@ async function sendStartingStatusReport(
 async function sendCompletedStatusReport(
   startedAt: Date,
   config: configUtils.Config | undefined,
-  configFile: string | undefined,
+  configFileInput: ComputedInput | undefined,
   toolsInput: ComputedInput | undefined,
   toolsDownloadStatusReport: ToolsDownloadStatusReport | undefined,
   toolsFeatureFlagsValid: boolean | undefined,
@@ -168,6 +168,9 @@ async function sendCompletedStatusReport(
   if (toolsInput !== undefined) {
     initStatusReport.computed_inputs.tools = toolsInput;
   }
+  if (configFileInput !== undefined) {
+    initStatusReport.computed_inputs["config-file"] = configFileInput;
+  }
 
   const initToolsDownloadFields: InitToolsDownloadFields = {};
 
@@ -185,7 +188,7 @@ async function sendCompletedStatusReport(
       await createInitWithConfigStatusReport(
         config,
         initStatusReport,
-        configFile,
+        configFileInput,
         Math.round(
           await getTotalCacheSize(Object.values(config.trapCaches), logger),
         ),
@@ -212,7 +215,7 @@ async function run(
 
   let apiDetails: GitHubApiCombinedDetails;
   let config: configUtils.Config | undefined;
-  let configFile: string | undefined;
+  let configFileInput: ComputedInput | undefined;
   let codeql: CodeQL;
   let features: FeatureEnablement;
   let sourceRoot: string;
@@ -263,7 +266,7 @@ async function run(
     core.exportVariable(EnvVar.INIT_ACTION_HAS_RUN, "true");
 
     const actionStateWithFeatures = { ...actionState, features };
-    configFile = await getConfigFileInput(
+    configFileInput = await getConfigFileInput(
       actionStateWithFeatures,
       repositoryProperties,
     );
@@ -376,7 +379,7 @@ async function run(
       packsInput: getOptionalInput("packs"),
       buildModeInput: getOptionalInput("build-mode"),
       ramInput: getOptionalInput("ram"),
-      configFile,
+      configFile: configFileInput?.value,
       dbLocation: getOptionalInput("db-location"),
       configInput: getOptionalInput("config"),
       dependencyCachingEnabled: getDependencyCachingEnabled(),
@@ -782,7 +785,7 @@ async function run(
   await sendCompletedStatusReport(
     startedAt,
     config,
-    configFile,
+    configFileInput,
     toolsInput,
     toolsDownloadStatusReport,
     toolsFeatureFlagsValid,

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -554,7 +554,7 @@ export interface InitToolsDownloadFields {
  *
  * @param config The CodeQL Action configuration whose values should be added to the base status report.
  * @param initStatusReport The base status report.
- * @param configFile Optionally, the filename of the configuration file that was read.
+ * @param configFileInput Optionally, the filename of the configuration file that was read.
  * @param totalCacheSize The computed total TRAP cache size.
  * @param overlayBaseDatabaseStats Statistics about the overlay database, if any.
  * @returns
@@ -562,7 +562,7 @@ export interface InitToolsDownloadFields {
 export async function createInitWithConfigStatusReport(
   config: Config,
   initStatusReport: InitStatusReport,
-  configFile: string | undefined,
+  configFileInput: ComputedInput | undefined,
   totalCacheSize: number,
   overlayBaseDatabaseStats: OverlayBaseDatabaseDownloadStats | undefined,
   dependencyCachingResults: DependencyCacheRestoreStatusReport | undefined,
@@ -601,7 +601,7 @@ export async function createInitWithConfigStatusReport(
 
   return {
     ...initStatusReport,
-    config_file: configFile ?? "",
+    config_file: configFileInput?.value ?? "",
     disable_default_queries: disableDefaultQueries,
     paths,
     paths_ignore: pathsIgnore,


### PR DESCRIPTION
Modifies `getConfigFileInput` to:

1. Return a `ComputedInput` value that we can report in telemetry, rather than just the computed value itself.
2. Use a generalised `getComputedInput` function extracted from `getToolsInput`.

A secondary change is the introduction of a `nonEmptyStringProperty` so that we can make this explicit in `repositoryPropertyParsers` rather than dealing with empty strings everywhere downstream.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Feature flags** - All new or changed code paths can be fully disabled with corresponding feature flags.
- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
