### PR TITLE
Ignore configuration file repo property for unsupported analysis kinds

### DIFF
--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -160750,11 +160750,6 @@ async function run3(actionState) {
     logger.info(`Job run UUID is ${jobRunUuid}.`);
     core21.exportVariable("JOB_RUN_UUID" /* JOB_RUN_UUID */, jobRunUuid);
     core21.exportVariable("CODEQL_ACTION_INIT_HAS_RUN" /* INIT_ACTION_HAS_RUN */, "true");
-    const actionStateWithFeatures = { ...actionState, features };
-    configFile = await getConfigFileInput(
-      actionStateWithFeatures,
-      repositoryProperties
-    );
     sourceRoot = path24.resolve(
       getRequiredEnvParam("GITHUB_WORKSPACE"),
       getOptionalInput("source-root") || ""
@@ -160767,6 +160762,11 @@ async function run3(actionState) {
         `Failed to parse analysis kinds for 'starting' status report: ${getErrorMessage(err)}`
       );
     }
+    const actionStateWithFeatures = { ...actionState, features };
+    configFile = await getConfigFileInput(
+      actionStateWithFeatures,
+      repositoryProperties
+    );
     await sendStartingStatusReport(startedAt, { analysisKinds }, logger);
     if (process.env["CODEQL_ACTION_SETUP_CODEQL_HAS_RUN" /* SETUP_CODEQL_ACTION_HAS_RUN */] === "true") {
       throw new ConfigurationError(

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -148503,15 +148503,19 @@ async function getConfigFileInput({
   }
   const propertyValue = repositoryProperties["github-codeql-config-file" /* CONFIG_FILE */];
   const analysisKindSupported = analysisKinds === void 0 || analysisKinds.includes("code-scanning" /* CodeScanning */) && analysisKinds.length === 1;
-  if (analysisKindSupported && propertyValue !== void 0 && propertyValue.trim().length > 0) {
+  if (propertyValue !== void 0 && propertyValue.trim().length > 0) {
     const useRepositoryProperty = await features.getValue(
       "config_file_repository_property" /* ConfigFileRepositoryProperty */
     );
-    if (useRepositoryProperty) {
+    if (analysisKindSupported && useRepositoryProperty) {
       logger.info(
         `Using configuration file input from repository property: ${propertyValue}`
       );
       return propertyValue;
+    } else if (!analysisKindSupported) {
+      logger.info(
+        "Ignoring configuration file input from repository property, because it is unsupported for the current analysis kind."
+      );
     } else {
       logger.info(
         "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled."

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -148495,14 +148495,15 @@ async function getConfigFileInput({
   logger,
   actions,
   features
-}, repositoryProperties) {
+}, repositoryProperties, analysisKinds) {
   const input = actions.getOptionalInput("config-file");
   if (input !== void 0) {
     logger.info(`Using configuration file input from workflow: ${input}`);
     return input;
   }
   const propertyValue = repositoryProperties["github-codeql-config-file" /* CONFIG_FILE */];
-  if (propertyValue !== void 0 && propertyValue.trim().length > 0) {
+  const analysisKindSupported = analysisKinds === void 0 || analysisKinds.includes("code-scanning" /* CodeScanning */) && analysisKinds.length === 1;
+  if (analysisKindSupported && propertyValue !== void 0 && propertyValue.trim().length > 0) {
     const useRepositoryProperty = await features.getValue(
       "config_file_repository_property" /* ConfigFileRepositoryProperty */
     );
@@ -160765,7 +160766,8 @@ async function run3(actionState) {
     const actionStateWithFeatures = { ...actionState, features };
     configFile = await getConfigFileInput(
       actionStateWithFeatures,
-      repositoryProperties
+      repositoryProperties,
+      analysisKinds
     );
     await sendStartingStatusReport(startedAt, { analysisKinds }, logger);
     if (process.env["CODEQL_ACTION_SETUP_CODEQL_HAS_RUN" /* SETUP_CODEQL_ACTION_HAS_RUN */] === "true") {

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -79,6 +79,10 @@ test("getConfigFileInput ignores repository property for other analysis kinds", 
     // Since the analysis kind is unsupported, we should ignore the repository property.
     await target
       .withArgs(repositoryProperties, unsupportedCase)
+      .logs(
+        t,
+        "Ignoring configuration file input from repository property, because it is unsupported for the current analysis kind.",
+      )
       .passes(t.is, undefined);
   }
 });

--- a/src/config/file.test.ts
+++ b/src/config/file.test.ts
@@ -2,6 +2,7 @@ import * as github from "@actions/github";
 import test from "ava";
 import sinon from "sinon";
 
+import { AnalysisKind } from "../analyses";
 import * as api from "../api-client";
 import { RegistryProxyVars } from "../environment";
 import { Feature } from "../feature-flags";
@@ -18,7 +19,7 @@ setupTests(test);
 
 test("getConfigFileInput returns undefined by default", async (t) => {
   await callee(getConfigFileInput)
-    .withArgs({})
+    .withArgs({}, undefined)
     .withFeatures([Feature.ConfigFileRepositoryProperty])
     .passes(t.is, undefined);
 });
@@ -40,7 +41,7 @@ test("getConfigFileInput returns input value", async (t) => {
         .withArgs("config-file")
         .returns(testInput);
     })
-    .withArgs(repositoryProperties)
+    .withArgs(repositoryProperties, undefined)
     .logs(t, "Using configuration file input from workflow")
     .passes(t.is, testInput);
 });
@@ -49,16 +50,44 @@ test("getConfigFileInput returns repository property value", async (t) => {
   // Since there is no direct input, we should use the repository property.
   await callee(getConfigFileInput)
     .withFeatures([Feature.ConfigFileRepositoryProperty])
-    .withArgs(repositoryProperties)
+    .withArgs(repositoryProperties, undefined)
     .logs(t, "Using configuration file input from repository property")
     .passes(t.is, repositoryProperties[RepositoryPropertyName.CONFIG_FILE]);
+});
+
+test("getConfigFileInput returns repository property value for Code Scanning", async (t) => {
+  // Since there is no direct input, we should use the repository property.
+  await callee(getConfigFileInput)
+    .withFeatures([Feature.ConfigFileRepositoryProperty])
+    .withArgs(repositoryProperties, [AnalysisKind.CodeScanning])
+    .logs(t, "Using configuration file input from repository property")
+    .passes(t.is, repositoryProperties[RepositoryPropertyName.CONFIG_FILE]);
+});
+
+test("getConfigFileInput ignores repository property for other analysis kinds", async (t) => {
+  const unsupportedCases = [
+    [AnalysisKind.CodeQuality],
+    [AnalysisKind.RiskAssessment],
+    [AnalysisKind.CodeScanning, AnalysisKind.CodeQuality],
+  ];
+
+  const target = callee(getConfigFileInput).withFeatures([
+    Feature.ConfigFileRepositoryProperty,
+  ]);
+
+  for (const unsupportedCase of unsupportedCases) {
+    // Since the analysis kind is unsupported, we should ignore the repository property.
+    await target
+      .withArgs(repositoryProperties, unsupportedCase)
+      .passes(t.is, undefined);
+  }
 });
 
 test("getConfigFileInput ignores empty repository property value", async (t) => {
   // Since the repository property value is an empty/whitespace string, we should ignore it.
   await callee(getConfigFileInput)
     .withFeatures([Feature.ConfigFileRepositoryProperty])
-    .withArgs({ [RepositoryPropertyName.CONFIG_FILE]: "   " })
+    .withArgs({ [RepositoryPropertyName.CONFIG_FILE]: "   " }, undefined)
     .passes(t.is, undefined);
 });
 
@@ -66,7 +95,7 @@ test("getConfigFileInput ignores repository property value when FF is off", asyn
   // Since the FF is off, we should ignore the repository property value.
   await callee(getConfigFileInput)
     .withFeatures([])
-    .withArgs(repositoryProperties)
+    .withArgs(repositoryProperties, undefined)
     .notLogs(t, "Using configuration file input from repository property")
     .logs(
       t,

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -1,4 +1,5 @@
 import { ActionState } from "../action-common";
+import { AnalysisKind } from "../analyses";
 import * as api from "../api-client";
 import * as errorMessages from "../error-messages";
 import { Feature } from "../feature-flags";
@@ -34,6 +35,7 @@ export async function getConfigFileInput(
     features,
   }: ActionState<["Logger", "Actions", "FeatureFlags"]>,
   repositoryProperties: Partial<RepositoryProperties>,
+  analysisKinds: AnalysisKind[] | undefined,
 ): Promise<string | undefined> {
   const input = actions.getOptionalInput("config-file");
 
@@ -45,7 +47,19 @@ export async function getConfigFileInput(
   const propertyValue =
     repositoryProperties[RepositoryPropertyName.CONFIG_FILE];
 
-  if (propertyValue !== undefined && propertyValue.trim().length > 0) {
+  // Only allow the repository property to be used for standard Code Scanning analyses,
+  // since we don't currently support some customisation options for Code Quality.
+  // We don't expect customisations for Risk Assessments either.
+  const analysisKindSupported =
+    analysisKinds === undefined ||
+    (analysisKinds.includes(AnalysisKind.CodeScanning) &&
+      analysisKinds.length === 1);
+
+  if (
+    analysisKindSupported &&
+    propertyValue !== undefined &&
+    propertyValue.trim().length > 0
+  ) {
     // Only use the repository property value if the FF is enabled.
     const useRepositoryProperty = await features.getValue(
       Feature.ConfigFileRepositoryProperty,

--- a/src/config/file.ts
+++ b/src/config/file.ts
@@ -55,21 +55,21 @@ export async function getConfigFileInput(
     (analysisKinds.includes(AnalysisKind.CodeScanning) &&
       analysisKinds.length === 1);
 
-  if (
-    analysisKindSupported &&
-    propertyValue !== undefined &&
-    propertyValue.trim().length > 0
-  ) {
+  if (propertyValue !== undefined && propertyValue.trim().length > 0) {
     // Only use the repository property value if the FF is enabled.
     const useRepositoryProperty = await features.getValue(
       Feature.ConfigFileRepositoryProperty,
     );
 
-    if (useRepositoryProperty) {
+    if (analysisKindSupported && useRepositoryProperty) {
       logger.info(
         `Using configuration file input from repository property: ${propertyValue}`,
       );
       return propertyValue;
+    } else if (!analysisKindSupported) {
+      logger.info(
+        "Ignoring configuration file input from repository property, because it is unsupported for the current analysis kind.",
+      );
     } else {
       logger.info(
         "Ignoring configuration file input from repository property, because the corresponding feature flag is disabled.",

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -262,12 +262,6 @@ async function run(
 
     core.exportVariable(EnvVar.INIT_ACTION_HAS_RUN, "true");
 
-    const actionStateWithFeatures = { ...actionState, features };
-    configFile = await getConfigFileInput(
-      actionStateWithFeatures,
-      repositoryProperties,
-    );
-
     // path.resolve() respects the intended semantics of source-root. If
     // source-root is relative, it is relative to the GITHUB_WORKSPACE. If
     // source-root is absolute, it is used as given.
@@ -289,6 +283,13 @@ async function run(
         `Failed to parse analysis kinds for 'starting' status report: ${getErrorMessage(err)}`,
       );
     }
+
+    // Compute the value of the `config-file` input.
+    const actionStateWithFeatures = { ...actionState, features };
+    configFile = await getConfigFileInput(
+      actionStateWithFeatures,
+      repositoryProperties,
+    );
 
     // Send a status report indicating that an analysis is starting.
     await sendStartingStatusReport(startedAt, { analysisKinds }, logger);

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -289,6 +289,7 @@ async function run(
     configFile = await getConfigFileInput(
       actionStateWithFeatures,
       repositoryProperties,
+      analysisKinds,
     );
 
     // Send a status report indicating that an analysis is starting.


### PR DESCRIPTION
This PR is a crude change to ignore the configuration file repository property if `analysis-kinds` is anything other than just `code-scanning`. This addresses a potential issue where we want to have a custom configuration file containing query customisations for a repo that has both Code Scanning and Code Quality enabled. We do not currently support query customisation for Code Quality, so that would then result in an error and prevent query customisation via the configuration file.

**Notes for reviewers**

- This is intended merely as a quick fix if we consider the above issue to be sufficiently significant.
- We could accept the issue and suggest use of the `github-codeql-extra-queries` property for query customisation in affected repositories instead.
- A better solution (but which will take more time) is to not fail/ignore if query customisation is applied to a Code Quality analysis or support it.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Test repository** - This change will be tested on a test repository before merging.
- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
