### PR TITLE
Handle network errors when streaming the CodeQL bundle download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ See the [releases page](https://github.com/github/codeql-action/releases) for th
 
 ## [UNRELEASED]
 
-No user facing changes.
+- Fixed a bug where a network error while streaming the download of the CodeQL bundle could terminate the `init` Action instead of falling back to downloading the bundle before extracting it. [#3367](https://github.com/github/codeql-action/issues/3367)
 
 ## 4.37.4 - 29 Jul 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ See the [releases page](https://github.com/github/codeql-action/releases) for th
 
 ## [UNRELEASED]
 
-- Fixed a bug where a network error while streaming the download of the CodeQL bundle could terminate the `init` Action instead of falling back to downloading the bundle before extracting it. [#3367](https://github.com/github/codeql-action/issues/3367)
+- Fixed a bug where a network error while streaming the download of the CodeQL bundle could terminate the `init` Action instead of falling back to downloading the bundle before extracting it. [#4061](https://github.com/github/codeql-action/pull/4061)
 
 ## 4.37.4 - 29 Jul 2026
 

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -7069,7 +7069,7 @@ var require_client_h2 = __commonJS({
   "node_modules/undici/lib/dispatcher/client-h2.js"(exports2, module2) {
     "use strict";
     var assert = require("node:assert");
-    var { pipeline } = require("node:stream");
+    var { pipeline: pipeline2 } = require("node:stream");
     var util3 = require_util();
     var {
       RequestContentLengthMismatchError,
@@ -7516,7 +7516,7 @@ var require_client_h2 = __commonJS({
     }
     function writeStream(abort, socket, expectsPayload, h2stream, body, client, request3, contentLength) {
       assert(contentLength !== 0 || client[kRunning] === 0, "stream body cannot be pipelined");
-      const pipe = pipeline(
+      const pipe = pipeline2(
         body,
         h2stream,
         (err) => {
@@ -10506,7 +10506,7 @@ var require_api_pipeline = __commonJS({
         util3.destroy(ret, err);
       }
     };
-    function pipeline(opts, handler2) {
+    function pipeline2(opts, handler2) {
       try {
         const pipelineHandler = new PipelineHandler(opts, handler2);
         this.dispatch({ ...opts, body: pipelineHandler.req }, pipelineHandler);
@@ -10515,7 +10515,7 @@ var require_api_pipeline = __commonJS({
         return new PassThrough3().destroy(err);
       }
     }
-    module2.exports = pipeline;
+    module2.exports = pipeline2;
   }
 });
 
@@ -13680,7 +13680,7 @@ var require_fetch = __commonJS({
       subresourceSet
     } = require_constants3();
     var EE = require("node:events");
-    var { Readable: Readable3, pipeline, finished } = require("node:stream");
+    var { Readable: Readable3, pipeline: pipeline2, finished } = require("node:stream");
     var { addAbortListener, isErrored, isReadable, bufferToLowerCasedHeaderName } = require_util();
     var { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = require_data_url();
     var { getGlobalDispatcher } = require_global2();
@@ -14624,7 +14624,7 @@ var require_fetch = __commonJS({
                 status,
                 statusText,
                 headersList,
-                body: decoders.length ? pipeline(this.body, ...decoders, (err) => {
+                body: decoders.length ? pipeline2(this.body, ...decoders, (err) => {
                   if (err) {
                     this.onError(err);
                   }
@@ -18604,7 +18604,7 @@ ${value}`;
 var require_eventsource = __commonJS({
   "node_modules/undici/lib/web/eventsource/eventsource.js"(exports2, module2) {
     "use strict";
-    var { pipeline } = require("node:stream");
+    var { pipeline: pipeline2 } = require("node:stream");
     var { fetching } = require_fetch();
     var { makeRequest } = require_request2();
     var { webidl } = require_webidl();
@@ -18762,7 +18762,7 @@ var require_eventsource = __commonJS({
               ));
             }
           });
-          pipeline(
+          pipeline2(
             response.body.stream,
             eventSourceStream,
             (error3) => {
@@ -32788,8 +32788,8 @@ var require_internal_hash_files = __commonJS({
               continue;
             }
             const hash2 = crypto3.createHash("sha256");
-            const pipeline = util3.promisify(stream2.pipeline);
-            yield pipeline(fs31.createReadStream(file), hash2);
+            const pipeline2 = util3.promisify(stream2.pipeline);
+            yield pipeline2(fs31.createReadStream(file), hash2);
             result.write(hash2.digest());
             count++;
             if (!hasMatch) {
@@ -35356,12 +35356,12 @@ var require_pipeline = __commonJS({
       }
       sendRequest(httpClient, request3) {
         const policies = this.getOrderedPolicies();
-        const pipeline = policies.reduceRight((next, policy) => {
+        const pipeline2 = policies.reduceRight((next, policy) => {
           return (req) => {
             return policy.sendRequest(req, next);
           };
         }, (req) => httpClient.sendRequest(req));
-        return pipeline(request3);
+        return pipeline2(request3);
       }
       getOrderedPolicies() {
         if (!this._orderedPolicies) {
@@ -38488,26 +38488,26 @@ var require_createPipelineFromOptions = __commonJS({
     var tlsPolicy_js_1 = require_tlsPolicy();
     var multipartPolicy_js_1 = require_multipartPolicy();
     function createPipelineFromOptions(options) {
-      const pipeline = (0, pipeline_js_1.createEmptyPipeline)();
+      const pipeline2 = (0, pipeline_js_1.createEmptyPipeline)();
       if (checkEnvironment_js_1.isNodeLike) {
         if (options.agent) {
-          pipeline.addPolicy((0, agentPolicy_js_1.agentPolicy)(options.agent));
+          pipeline2.addPolicy((0, agentPolicy_js_1.agentPolicy)(options.agent));
         }
         if (options.tlsOptions) {
-          pipeline.addPolicy((0, tlsPolicy_js_1.tlsPolicy)(options.tlsOptions));
+          pipeline2.addPolicy((0, tlsPolicy_js_1.tlsPolicy)(options.tlsOptions));
         }
-        pipeline.addPolicy((0, proxyPolicy_js_1.proxyPolicy)(options.proxyOptions));
-        pipeline.addPolicy((0, decompressResponsePolicy_js_1.decompressResponsePolicy)());
+        pipeline2.addPolicy((0, proxyPolicy_js_1.proxyPolicy)(options.proxyOptions));
+        pipeline2.addPolicy((0, decompressResponsePolicy_js_1.decompressResponsePolicy)());
       }
-      pipeline.addPolicy((0, formDataPolicy_js_1.formDataPolicy)(), { beforePolicies: [multipartPolicy_js_1.multipartPolicyName] });
-      pipeline.addPolicy((0, userAgentPolicy_js_1.userAgentPolicy)(options.userAgentOptions));
-      pipeline.addPolicy((0, multipartPolicy_js_1.multipartPolicy)(), { afterPhase: "Deserialize" });
-      pipeline.addPolicy((0, defaultRetryPolicy_js_1.defaultRetryPolicy)(options.retryOptions), { phase: "Retry" });
+      pipeline2.addPolicy((0, formDataPolicy_js_1.formDataPolicy)(), { beforePolicies: [multipartPolicy_js_1.multipartPolicyName] });
+      pipeline2.addPolicy((0, userAgentPolicy_js_1.userAgentPolicy)(options.userAgentOptions));
+      pipeline2.addPolicy((0, multipartPolicy_js_1.multipartPolicy)(), { afterPhase: "Deserialize" });
+      pipeline2.addPolicy((0, defaultRetryPolicy_js_1.defaultRetryPolicy)(options.retryOptions), { phase: "Retry" });
       if (checkEnvironment_js_1.isNodeLike) {
-        pipeline.addPolicy((0, redirectPolicy_js_1.redirectPolicy)(options.redirectOptions), { afterPhase: "Retry" });
+        pipeline2.addPolicy((0, redirectPolicy_js_1.redirectPolicy)(options.redirectOptions), { afterPhase: "Retry" });
       }
-      pipeline.addPolicy((0, logPolicy_js_1.logPolicy)(options.loggingOptions), { afterPhase: "Sign" });
-      return pipeline;
+      pipeline2.addPolicy((0, logPolicy_js_1.logPolicy)(options.loggingOptions), { afterPhase: "Sign" });
+      return pipeline2;
     }
   }
 });
@@ -38729,21 +38729,21 @@ var require_clientHelpers = __commonJS({
     var oauth2AuthenticationPolicy_js_1 = require_oauth2AuthenticationPolicy();
     var cachedHttpClient;
     function createDefaultPipeline(options = {}) {
-      const pipeline = (0, createPipelineFromOptions_js_1.createPipelineFromOptions)(options);
-      pipeline.addPolicy((0, apiVersionPolicy_js_1.apiVersionPolicy)(options));
+      const pipeline2 = (0, createPipelineFromOptions_js_1.createPipelineFromOptions)(options);
+      pipeline2.addPolicy((0, apiVersionPolicy_js_1.apiVersionPolicy)(options));
       const { credential, authSchemes, allowInsecureConnection } = options;
       if (credential) {
         if ((0, credentials_js_1.isApiKeyCredential)(credential)) {
-          pipeline.addPolicy((0, apiKeyAuthenticationPolicy_js_1.apiKeyAuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
+          pipeline2.addPolicy((0, apiKeyAuthenticationPolicy_js_1.apiKeyAuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
         } else if ((0, credentials_js_1.isBasicCredential)(credential)) {
-          pipeline.addPolicy((0, basicAuthenticationPolicy_js_1.basicAuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
+          pipeline2.addPolicy((0, basicAuthenticationPolicy_js_1.basicAuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
         } else if ((0, credentials_js_1.isBearerTokenCredential)(credential)) {
-          pipeline.addPolicy((0, bearerAuthenticationPolicy_js_1.bearerAuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
+          pipeline2.addPolicy((0, bearerAuthenticationPolicy_js_1.bearerAuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
         } else if ((0, credentials_js_1.isOAuth2TokenCredential)(credential)) {
-          pipeline.addPolicy((0, oauth2AuthenticationPolicy_js_1.oauth2AuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
+          pipeline2.addPolicy((0, oauth2AuthenticationPolicy_js_1.oauth2AuthenticationPolicy)({ authSchemes, credential, allowInsecureConnection }));
         }
       }
-      return pipeline;
+      return pipeline2;
     }
     function getCachedDefaultHttpsClient() {
       if (!cachedHttpClient) {
@@ -38879,11 +38879,11 @@ var require_sendRequest = __commonJS({
     var clientHelpers_js_1 = require_clientHelpers();
     var typeGuards_js_1 = require_typeGuards();
     var multipart_js_1 = require_multipart();
-    async function sendRequest(method, url2, pipeline, options = {}, customHttpClient) {
+    async function sendRequest(method, url2, pipeline2, options = {}, customHttpClient) {
       const httpClient = customHttpClient ?? (0, clientHelpers_js_1.getCachedDefaultHttpsClient)();
       const request3 = buildPipelineRequest(method, url2, options);
       try {
-        const response = await pipeline.sendRequest(httpClient, request3);
+        const response = await pipeline2.sendRequest(httpClient, request3);
         const headers = response.headers.toJSON();
         const stream2 = response.readableStreamBody ?? response.browserStreamBody;
         const parsedBody = options.responseAsStream || stream2 !== void 0 ? void 0 : getResponseBody(response);
@@ -39146,11 +39146,11 @@ var require_getClient = __commonJS({
     var urlHelpers_js_1 = require_urlHelpers();
     var checkEnvironment_js_1 = require_checkEnvironment();
     function getClient(endpoint2, clientOptions = {}) {
-      const pipeline = clientOptions.pipeline ?? (0, clientHelpers_js_1.createDefaultPipeline)(clientOptions);
+      const pipeline2 = clientOptions.pipeline ?? (0, clientHelpers_js_1.createDefaultPipeline)(clientOptions);
       if (clientOptions.additionalPolicies?.length) {
         for (const { policy, position } of clientOptions.additionalPolicies) {
           const afterPhase = position === "perRetry" ? "Sign" : void 0;
-          pipeline.addPolicy(policy, {
+          pipeline2.addPolicy(policy, {
             afterPhase
           });
         }
@@ -39161,53 +39161,53 @@ var require_getClient = __commonJS({
         const getUrl = (requestOptions) => (0, urlHelpers_js_1.buildRequestUrl)(endpointUrl, path29, args, { allowInsecureConnection, ...requestOptions });
         return {
           get: (requestOptions = {}) => {
-            return buildOperation("GET", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("GET", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           },
           post: (requestOptions = {}) => {
-            return buildOperation("POST", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("POST", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           },
           put: (requestOptions = {}) => {
-            return buildOperation("PUT", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("PUT", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           },
           patch: (requestOptions = {}) => {
-            return buildOperation("PATCH", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("PATCH", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           },
           delete: (requestOptions = {}) => {
-            return buildOperation("DELETE", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("DELETE", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           },
           head: (requestOptions = {}) => {
-            return buildOperation("HEAD", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("HEAD", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           },
           options: (requestOptions = {}) => {
-            return buildOperation("OPTIONS", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("OPTIONS", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           },
           trace: (requestOptions = {}) => {
-            return buildOperation("TRACE", getUrl(requestOptions), pipeline, requestOptions, allowInsecureConnection, httpClient);
+            return buildOperation("TRACE", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
           }
         };
       };
       return {
         path: client,
         pathUnchecked: client,
-        pipeline
+        pipeline: pipeline2
       };
     }
-    function buildOperation(method, url2, pipeline, options, allowInsecureConnection, httpClient) {
+    function buildOperation(method, url2, pipeline2, options, allowInsecureConnection, httpClient) {
       allowInsecureConnection = options.allowInsecureConnection ?? allowInsecureConnection;
       return {
         then: function(onFulfilled, onrejected) {
-          return (0, sendRequest_js_1.sendRequest)(method, url2, pipeline, { ...options, allowInsecureConnection }, httpClient).then(onFulfilled, onrejected);
+          return (0, sendRequest_js_1.sendRequest)(method, url2, pipeline2, { ...options, allowInsecureConnection }, httpClient).then(onFulfilled, onrejected);
         },
         async asBrowserStream() {
           if (checkEnvironment_js_1.isNodeLike) {
             throw new Error("`asBrowserStream` is supported only in the browser environment. Use `asNodeStream` instead to obtain the response body stream. If you require a Web stream of the response in Node, consider using `Readable.toWeb` on the result of `asNodeStream`.");
           } else {
-            return (0, sendRequest_js_1.sendRequest)(method, url2, pipeline, { ...options, allowInsecureConnection, responseAsStream: true }, httpClient);
+            return (0, sendRequest_js_1.sendRequest)(method, url2, pipeline2, { ...options, allowInsecureConnection, responseAsStream: true }, httpClient);
           }
         },
         async asNodeStream() {
           if (checkEnvironment_js_1.isNodeLike) {
-            return (0, sendRequest_js_1.sendRequest)(method, url2, pipeline, { ...options, allowInsecureConnection, responseAsStream: true }, httpClient);
+            return (0, sendRequest_js_1.sendRequest)(method, url2, pipeline2, { ...options, allowInsecureConnection, responseAsStream: true }, httpClient);
           } else {
             throw new Error("`isNodeStream` is not supported in the browser environment. Use `asBrowserStream` to obtain the response body stream.");
           }
@@ -40697,31 +40697,31 @@ var require_createPipelineFromOptions2 = __commonJS({
     var tracingPolicy_js_1 = require_tracingPolicy();
     var wrapAbortSignalLikePolicy_js_1 = require_wrapAbortSignalLikePolicy();
     function createPipelineFromOptions(options) {
-      const pipeline = (0, pipeline_js_1.createEmptyPipeline)();
+      const pipeline2 = (0, pipeline_js_1.createEmptyPipeline)();
       if (core_util_1.isNodeLike) {
         if (options.agent) {
-          pipeline.addPolicy((0, agentPolicy_js_1.agentPolicy)(options.agent));
+          pipeline2.addPolicy((0, agentPolicy_js_1.agentPolicy)(options.agent));
         }
         if (options.tlsOptions) {
-          pipeline.addPolicy((0, tlsPolicy_js_1.tlsPolicy)(options.tlsOptions));
+          pipeline2.addPolicy((0, tlsPolicy_js_1.tlsPolicy)(options.tlsOptions));
         }
-        pipeline.addPolicy((0, proxyPolicy_js_1.proxyPolicy)(options.proxyOptions));
-        pipeline.addPolicy((0, decompressResponsePolicy_js_1.decompressResponsePolicy)());
+        pipeline2.addPolicy((0, proxyPolicy_js_1.proxyPolicy)(options.proxyOptions));
+        pipeline2.addPolicy((0, decompressResponsePolicy_js_1.decompressResponsePolicy)());
       }
-      pipeline.addPolicy((0, wrapAbortSignalLikePolicy_js_1.wrapAbortSignalLikePolicy)());
-      pipeline.addPolicy((0, formDataPolicy_js_1.formDataPolicy)(), { beforePolicies: [multipartPolicy_js_1.multipartPolicyName] });
-      pipeline.addPolicy((0, userAgentPolicy_js_1.userAgentPolicy)(options.userAgentOptions));
-      pipeline.addPolicy((0, setClientRequestIdPolicy_js_1.setClientRequestIdPolicy)(options.telemetryOptions?.clientRequestIdHeaderName));
-      pipeline.addPolicy((0, multipartPolicy_js_1.multipartPolicy)(), { afterPhase: "Deserialize" });
-      pipeline.addPolicy((0, defaultRetryPolicy_js_1.defaultRetryPolicy)(options.retryOptions), { phase: "Retry" });
-      pipeline.addPolicy((0, tracingPolicy_js_1.tracingPolicy)({ ...options.userAgentOptions, ...options.loggingOptions }), {
+      pipeline2.addPolicy((0, wrapAbortSignalLikePolicy_js_1.wrapAbortSignalLikePolicy)());
+      pipeline2.addPolicy((0, formDataPolicy_js_1.formDataPolicy)(), { beforePolicies: [multipartPolicy_js_1.multipartPolicyName] });
+      pipeline2.addPolicy((0, userAgentPolicy_js_1.userAgentPolicy)(options.userAgentOptions));
+      pipeline2.addPolicy((0, setClientRequestIdPolicy_js_1.setClientRequestIdPolicy)(options.telemetryOptions?.clientRequestIdHeaderName));
+      pipeline2.addPolicy((0, multipartPolicy_js_1.multipartPolicy)(), { afterPhase: "Deserialize" });
+      pipeline2.addPolicy((0, defaultRetryPolicy_js_1.defaultRetryPolicy)(options.retryOptions), { phase: "Retry" });
+      pipeline2.addPolicy((0, tracingPolicy_js_1.tracingPolicy)({ ...options.userAgentOptions, ...options.loggingOptions }), {
         afterPhase: "Retry"
       });
       if (core_util_1.isNodeLike) {
-        pipeline.addPolicy((0, redirectPolicy_js_1.redirectPolicy)(options.redirectOptions), { afterPhase: "Retry" });
+        pipeline2.addPolicy((0, redirectPolicy_js_1.redirectPolicy)(options.redirectOptions), { afterPhase: "Retry" });
       }
-      pipeline.addPolicy((0, logPolicy_js_1.logPolicy)(options.loggingOptions), { afterPhase: "Sign" });
-      return pipeline;
+      pipeline2.addPolicy((0, logPolicy_js_1.logPolicy)(options.loggingOptions), { afterPhase: "Sign" });
+      return pipeline2;
     }
   }
 });
@@ -41635,8 +41635,8 @@ var require_disableKeepAlivePolicy = __commonJS({
         }
       };
     }
-    function pipelineContainsDisableKeepAlivePolicy(pipeline) {
-      return pipeline.getOrderedPolicies().some((policy) => policy.name === exports2.disableKeepAlivePolicyName);
+    function pipelineContainsDisableKeepAlivePolicy(pipeline2) {
+      return pipeline2.getOrderedPolicies().some((policy) => policy.name === exports2.disableKeepAlivePolicyName);
     }
   }
 });
@@ -42975,18 +42975,18 @@ var require_pipeline3 = __commonJS({
     var core_rest_pipeline_1 = require_commonjs6();
     var serializationPolicy_js_1 = require_serializationPolicy();
     function createClientPipeline(options = {}) {
-      const pipeline = (0, core_rest_pipeline_1.createPipelineFromOptions)(options ?? {});
+      const pipeline2 = (0, core_rest_pipeline_1.createPipelineFromOptions)(options ?? {});
       if (options.credentialOptions) {
-        pipeline.addPolicy((0, core_rest_pipeline_1.bearerTokenAuthenticationPolicy)({
+        pipeline2.addPolicy((0, core_rest_pipeline_1.bearerTokenAuthenticationPolicy)({
           credential: options.credentialOptions.credential,
           scopes: options.credentialOptions.credentialScopes
         }));
       }
-      pipeline.addPolicy((0, serializationPolicy_js_1.serializationPolicy)(options.serializationOptions), { phase: "Serialize" });
-      pipeline.addPolicy((0, deserializationPolicy_js_1.deserializationPolicy)(options.deserializationOptions), {
+      pipeline2.addPolicy((0, serializationPolicy_js_1.serializationPolicy)(options.serializationOptions), { phase: "Serialize" });
+      pipeline2.addPolicy((0, deserializationPolicy_js_1.deserializationPolicy)(options.deserializationOptions), {
         phase: "Deserialize"
       });
-      return pipeline;
+      return pipeline2;
     }
   }
 });
@@ -50204,11 +50204,11 @@ var require_Pipeline = __commonJS({
     var StorageSharedKeyCredentialPolicyV2_js_1 = require_StorageSharedKeyCredentialPolicyV22();
     var StorageBrowserPolicyFactory_js_1 = require_StorageBrowserPolicyFactory2();
     var StorageCorrectContentLengthPolicy_js_1 = require_StorageCorrectContentLengthPolicy2();
-    function isPipelineLike(pipeline) {
-      if (!pipeline || typeof pipeline !== "object") {
+    function isPipelineLike(pipeline2) {
+      if (!pipeline2 || typeof pipeline2 !== "object") {
         return false;
       }
-      const castPipeline = pipeline;
+      const castPipeline = pipeline2;
       return Array.isArray(castPipeline.factories) && typeof castPipeline.options === "object" && typeof castPipeline.toServiceClientOptions === "function";
     }
     var Pipeline = class {
@@ -50248,11 +50248,11 @@ var require_Pipeline = __commonJS({
       if (!credential) {
         credential = new AnonymousCredential_js_1.AnonymousCredential();
       }
-      const pipeline = new Pipeline([], pipelineOptions);
-      pipeline._credential = credential;
-      return pipeline;
+      const pipeline2 = new Pipeline([], pipelineOptions);
+      pipeline2._credential = credential;
+      return pipeline2;
     }
-    function processDownlevelPipeline(pipeline) {
+    function processDownlevelPipeline(pipeline2) {
       const knownFactoryFunctions = [
         isAnonymousCredential,
         isStorageSharedKeyCredential,
@@ -50262,8 +50262,8 @@ var require_Pipeline = __commonJS({
         isStorageTelemetryPolicyFactory,
         isCoreHttpPolicyFactory
       ];
-      if (pipeline.factories.length) {
-        const novelFactories = pipeline.factories.filter((factory) => {
+      if (pipeline2.factories.length) {
+        const novelFactories = pipeline2.factories.filter((factory) => {
           return !knownFactoryFunctions.some((knownFactory) => knownFactory(factory));
         });
         if (novelFactories.length) {
@@ -50276,14 +50276,14 @@ var require_Pipeline = __commonJS({
       }
       return void 0;
     }
-    function getCoreClientOptions(pipeline) {
-      const { httpClient: v1Client, ...restOptions } = pipeline.options;
-      let httpClient = pipeline._coreHttpClient;
+    function getCoreClientOptions(pipeline2) {
+      const { httpClient: v1Client, ...restOptions } = pipeline2.options;
+      let httpClient = pipeline2._coreHttpClient;
       if (!httpClient) {
         httpClient = v1Client ? (0, core_http_compat_1.convertHttpClient)(v1Client) : (0, storage_common_1.getCachedDefaultHttpClient)();
-        pipeline._coreHttpClient = httpClient;
+        pipeline2._coreHttpClient = httpClient;
       }
-      let corePipeline = pipeline._corePipeline;
+      let corePipeline = pipeline2._corePipeline;
       if (!corePipeline) {
         const packageDetails = `azsdk-js-azure-storage-blob/${constants_js_1.SDK_VERSION}`;
         const userAgentPrefix = restOptions.userAgentOptions && restOptions.userAgentOptions.userAgentPrefix ? `${restOptions.userAgentOptions.userAgentPrefix} ${packageDetails}` : `${packageDetails}`;
@@ -50324,11 +50324,11 @@ var require_Pipeline = __commonJS({
         corePipeline.addPolicy((0, StorageRetryPolicyV2_js_1.storageRetryPolicy)(restOptions.retryOptions), { phase: "Retry" });
         corePipeline.addPolicy((0, storage_common_1.storageRequestFailureDetailsParserPolicy)());
         corePipeline.addPolicy((0, StorageBrowserPolicyV2_js_1.storageBrowserPolicy)());
-        const downlevelResults = processDownlevelPipeline(pipeline);
+        const downlevelResults = processDownlevelPipeline(pipeline2);
         if (downlevelResults) {
           corePipeline.addPolicy(downlevelResults.wrappedPolicies, downlevelResults.afterRetry ? { afterPhase: "Retry" } : void 0);
         }
-        const credential = getCredentialFromPipeline(pipeline);
+        const credential = getCredentialFromPipeline(pipeline2);
         if ((0, core_auth_1.isTokenCredential)(credential)) {
           corePipeline.addPolicy((0, core_rest_pipeline_1.bearerTokenAuthenticationPolicy)({
             credential,
@@ -50341,7 +50341,7 @@ var require_Pipeline = __commonJS({
             accountKey: credential.accountKey
           }), { phase: "Sign" });
         }
-        pipeline._corePipeline = corePipeline;
+        pipeline2._corePipeline = corePipeline;
       }
       return {
         ...restOptions,
@@ -50350,12 +50350,12 @@ var require_Pipeline = __commonJS({
         pipeline: corePipeline
       };
     }
-    function getCredentialFromPipeline(pipeline) {
-      if (pipeline._credential) {
-        return pipeline._credential;
+    function getCredentialFromPipeline(pipeline2) {
+      if (pipeline2._credential) {
+        return pipeline2._credential;
       }
       let credential = new AnonymousCredential_js_1.AnonymousCredential();
-      for (const factory of pipeline.factories) {
+      for (const factory of pipeline2.factories) {
         if ((0, core_auth_1.isTokenCredential)(factory.credential)) {
           credential = factory.credential;
         } else if (isStorageSharedKeyCredential(factory)) {
@@ -63880,13 +63880,13 @@ var require_StorageClient = __commonJS({
        * @param url - url to resource
        * @param pipeline - request policy pipeline.
        */
-      constructor(url2, pipeline) {
+      constructor(url2, pipeline2) {
         this.url = (0, utils_common_js_1.escapeURLPath)(url2);
         this.accountName = (0, utils_common_js_1.getAccountNameFromUrl)(url2);
-        this.pipeline = pipeline;
-        this.storageClientContext = new StorageContextClient_js_1.StorageContextClient(this.url, (0, Pipeline_js_1.getCoreClientOptions)(pipeline));
+        this.pipeline = pipeline2;
+        this.storageClientContext = new StorageContextClient_js_1.StorageContextClient(this.url, (0, Pipeline_js_1.getCoreClientOptions)(pipeline2));
         this.isHttps = (0, utils_common_js_1.iEqual)((0, utils_common_js_1.getURLScheme)(this.url) || "", "https");
-        this.credential = (0, Pipeline_js_1.getCredentialFromPipeline)(pipeline);
+        this.credential = (0, Pipeline_js_1.getCredentialFromPipeline)(pipeline2);
         const storageClientContext = this.storageClientContext;
         storageClientContext.requestContentType = void 0;
       }
@@ -68669,21 +68669,21 @@ var require_Clients = __commonJS({
       }
       constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, options) {
         options = options || {};
-        let pipeline;
+        let pipeline2;
         let url2;
         if ((0, Pipeline_js_1.isPipelineLike)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
-          pipeline = credentialOrPipelineOrContainerName;
+          pipeline2 = credentialOrPipelineOrContainerName;
         } else if (core_util_1.isNodeLike && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential_js_1.StorageSharedKeyCredential || credentialOrPipelineOrContainerName instanceof AnonymousCredential_js_1.AnonymousCredential || (0, core_auth_1.isTokenCredential)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
           options = blobNameOrOptions;
-          pipeline = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
         } else if (!credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName !== "string") {
           url2 = urlOrConnectionString;
           if (blobNameOrOptions && typeof blobNameOrOptions !== "string") {
             options = blobNameOrOptions;
           }
-          pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
         } else if (credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName === "string" && blobNameOrOptions && typeof blobNameOrOptions === "string") {
           const containerName = credentialOrPipelineOrContainerName;
           const blobName = blobNameOrOptions;
@@ -68695,20 +68695,20 @@ var require_Clients = __commonJS({
               if (!options.proxyOptions) {
                 options.proxyOptions = (0, core_rest_pipeline_1.getDefaultProxySettings)(extractedCreds.proxyUri);
               }
-              pipeline = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
+              pipeline2 = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
             } else {
               throw new Error("Account connection string is only supported in Node.js environment");
             }
           } else if (extractedCreds.kind === "SASConnString") {
             url2 = (0, utils_common_js_1.appendToURLPath)((0, utils_common_js_1.appendToURLPath)(extractedCreds.url, encodeURIComponent(containerName)), encodeURIComponent(blobName)) + "?" + extractedCreds.accountSas;
-            pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+            pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
           } else {
             throw new Error("Connection string must be either an Account connection string or a SAS connection string");
           }
         } else {
           throw new Error("Expecting non-empty strings for containerName and blobName parameters");
         }
-        super(url2, pipeline);
+        super(url2, pipeline2);
         ({ blobName: this._name, containerName: this._containerName } = this.getBlobAndContainerNamesFromUrl());
         this.blobContext = this.storageClientContext.blob;
         this._snapshot = (0, utils_common_js_1.getURLParameter)(this.url, constants_js_1.URLConstants.Parameters.SNAPSHOT);
@@ -69694,19 +69694,19 @@ var require_Clients = __commonJS({
        */
       appendBlobContext;
       constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, options) {
-        let pipeline;
+        let pipeline2;
         let url2;
         options = options || {};
         if ((0, Pipeline_js_1.isPipelineLike)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
-          pipeline = credentialOrPipelineOrContainerName;
+          pipeline2 = credentialOrPipelineOrContainerName;
         } else if (core_util_1.isNodeLike && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential_js_1.StorageSharedKeyCredential || credentialOrPipelineOrContainerName instanceof AnonymousCredential_js_1.AnonymousCredential || (0, core_auth_1.isTokenCredential)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
           options = blobNameOrOptions;
-          pipeline = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
         } else if (!credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName !== "string") {
           url2 = urlOrConnectionString;
-          pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
         } else if (credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName === "string" && blobNameOrOptions && typeof blobNameOrOptions === "string") {
           const containerName = credentialOrPipelineOrContainerName;
           const blobName = blobNameOrOptions;
@@ -69718,20 +69718,20 @@ var require_Clients = __commonJS({
               if (!options.proxyOptions) {
                 options.proxyOptions = (0, core_rest_pipeline_1.getDefaultProxySettings)(extractedCreds.proxyUri);
               }
-              pipeline = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
+              pipeline2 = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
             } else {
               throw new Error("Account connection string is only supported in Node.js environment");
             }
           } else if (extractedCreds.kind === "SASConnString") {
             url2 = (0, utils_common_js_1.appendToURLPath)((0, utils_common_js_1.appendToURLPath)(extractedCreds.url, encodeURIComponent(containerName)), encodeURIComponent(blobName)) + "?" + extractedCreds.accountSas;
-            pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+            pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
           } else {
             throw new Error("Connection string must be either an Account connection string or a SAS connection string");
           }
         } else {
           throw new Error("Expecting non-empty strings for containerName and blobName parameters");
         }
-        super(url2, pipeline);
+        super(url2, pipeline2);
         this.appendBlobContext = this.storageClientContext.appendBlob;
       }
       /**
@@ -69967,22 +69967,22 @@ var require_Clients = __commonJS({
        */
       blockBlobContext;
       constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, options) {
-        let pipeline;
+        let pipeline2;
         let url2;
         options = options || {};
         if ((0, Pipeline_js_1.isPipelineLike)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
-          pipeline = credentialOrPipelineOrContainerName;
+          pipeline2 = credentialOrPipelineOrContainerName;
         } else if (core_util_1.isNodeLike && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential_js_1.StorageSharedKeyCredential || credentialOrPipelineOrContainerName instanceof AnonymousCredential_js_1.AnonymousCredential || (0, core_auth_1.isTokenCredential)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
           options = blobNameOrOptions;
-          pipeline = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
         } else if (!credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName !== "string") {
           url2 = urlOrConnectionString;
           if (blobNameOrOptions && typeof blobNameOrOptions !== "string") {
             options = blobNameOrOptions;
           }
-          pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
         } else if (credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName === "string" && blobNameOrOptions && typeof blobNameOrOptions === "string") {
           const containerName = credentialOrPipelineOrContainerName;
           const blobName = blobNameOrOptions;
@@ -69994,20 +69994,20 @@ var require_Clients = __commonJS({
               if (!options.proxyOptions) {
                 options.proxyOptions = (0, core_rest_pipeline_1.getDefaultProxySettings)(extractedCreds.proxyUri);
               }
-              pipeline = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
+              pipeline2 = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
             } else {
               throw new Error("Account connection string is only supported in Node.js environment");
             }
           } else if (extractedCreds.kind === "SASConnString") {
             url2 = (0, utils_common_js_1.appendToURLPath)((0, utils_common_js_1.appendToURLPath)(extractedCreds.url, encodeURIComponent(containerName)), encodeURIComponent(blobName)) + "?" + extractedCreds.accountSas;
-            pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+            pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
           } else {
             throw new Error("Connection string must be either an Account connection string or a SAS connection string");
           }
         } else {
           throw new Error("Expecting non-empty strings for containerName and blobName parameters");
         }
-        super(url2, pipeline);
+        super(url2, pipeline2);
         this.blockBlobContext = this.storageClientContext.blockBlob;
         this._blobContext = this.storageClientContext.blob;
       }
@@ -70579,19 +70579,19 @@ var require_Clients = __commonJS({
        */
       pageBlobContext;
       constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, blobNameOrOptions, options) {
-        let pipeline;
+        let pipeline2;
         let url2;
         options = options || {};
         if ((0, Pipeline_js_1.isPipelineLike)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
-          pipeline = credentialOrPipelineOrContainerName;
+          pipeline2 = credentialOrPipelineOrContainerName;
         } else if (core_util_1.isNodeLike && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential_js_1.StorageSharedKeyCredential || credentialOrPipelineOrContainerName instanceof AnonymousCredential_js_1.AnonymousCredential || (0, core_auth_1.isTokenCredential)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
           options = blobNameOrOptions;
-          pipeline = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
         } else if (!credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName !== "string") {
           url2 = urlOrConnectionString;
-          pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
         } else if (credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName === "string" && blobNameOrOptions && typeof blobNameOrOptions === "string") {
           const containerName = credentialOrPipelineOrContainerName;
           const blobName = blobNameOrOptions;
@@ -70603,20 +70603,20 @@ var require_Clients = __commonJS({
               if (!options.proxyOptions) {
                 options.proxyOptions = (0, core_rest_pipeline_1.getDefaultProxySettings)(extractedCreds.proxyUri);
               }
-              pipeline = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
+              pipeline2 = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
             } else {
               throw new Error("Account connection string is only supported in Node.js environment");
             }
           } else if (extractedCreds.kind === "SASConnString") {
             url2 = (0, utils_common_js_1.appendToURLPath)((0, utils_common_js_1.appendToURLPath)(extractedCreds.url, encodeURIComponent(containerName)), encodeURIComponent(blobName)) + "?" + extractedCreds.accountSas;
-            pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+            pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
           } else {
             throw new Error("Connection string must be either an Account connection string or a SAS connection string");
           }
         } else {
           throw new Error("Expecting non-empty strings for containerName and blobName parameters");
         }
-        super(url2, pipeline);
+        super(url2, pipeline2);
         this.pageBlobContext = this.storageClientContext.pageBlob;
       }
       /**
@@ -71681,10 +71681,10 @@ var require_BlobBatch = __commonJS({
             accountKey: credential.accountKey
           }), { phase: "Sign" });
         }
-        const pipeline = new Pipeline_js_1.Pipeline([]);
-        pipeline._credential = credential;
-        pipeline._corePipeline = corePipeline;
-        return pipeline;
+        const pipeline2 = new Pipeline_js_1.Pipeline([]);
+        pipeline2._credential = credential;
+        pipeline2._corePipeline = corePipeline;
+        return pipeline2;
       }
       appendSubRequestToBody(request3) {
         this.body += [
@@ -71776,15 +71776,15 @@ var require_BlobBatchClient = __commonJS({
     var BlobBatchClient = class {
       serviceOrContainerContext;
       constructor(url2, credentialOrPipeline, options) {
-        let pipeline;
+        let pipeline2;
         if ((0, Pipeline_js_1.isPipelineLike)(credentialOrPipeline)) {
-          pipeline = credentialOrPipeline;
+          pipeline2 = credentialOrPipeline;
         } else if (!credentialOrPipeline) {
-          pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
         } else {
-          pipeline = (0, Pipeline_js_1.newPipeline)(credentialOrPipeline, options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipeline, options);
         }
-        const storageClientContext = new StorageContextClient_js_1.StorageContextClient(url2, (0, Pipeline_js_1.getCoreClientOptions)(pipeline));
+        const storageClientContext = new StorageContextClient_js_1.StorageContextClient(url2, (0, Pipeline_js_1.getCoreClientOptions)(pipeline2));
         const path29 = (0, utils_common_js_1.getURLPath)(url2);
         if (path29 && path29 !== "/") {
           this.serviceOrContainerContext = storageClientContext.container;
@@ -71947,18 +71947,18 @@ var require_ContainerClient = __commonJS({
         return this._containerName;
       }
       constructor(urlOrConnectionString, credentialOrPipelineOrContainerName, options) {
-        let pipeline;
+        let pipeline2;
         let url2;
         options = options || {};
         if ((0, Pipeline_js_1.isPipelineLike)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
-          pipeline = credentialOrPipelineOrContainerName;
+          pipeline2 = credentialOrPipelineOrContainerName;
         } else if (core_util_1.isNodeLike && credentialOrPipelineOrContainerName instanceof StorageSharedKeyCredential_js_1.StorageSharedKeyCredential || credentialOrPipelineOrContainerName instanceof AnonymousCredential_js_1.AnonymousCredential || (0, core_auth_1.isTokenCredential)(credentialOrPipelineOrContainerName)) {
           url2 = urlOrConnectionString;
-          pipeline = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipelineOrContainerName, options);
         } else if (!credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName !== "string") {
           url2 = urlOrConnectionString;
-          pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
         } else if (credentialOrPipelineOrContainerName && typeof credentialOrPipelineOrContainerName === "string") {
           const containerName = credentialOrPipelineOrContainerName;
           const extractedCreds = (0, utils_common_js_1.extractConnectionStringParts)(urlOrConnectionString);
@@ -71969,20 +71969,20 @@ var require_ContainerClient = __commonJS({
               if (!options.proxyOptions) {
                 options.proxyOptions = (0, core_rest_pipeline_1.getDefaultProxySettings)(extractedCreds.proxyUri);
               }
-              pipeline = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
+              pipeline2 = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
             } else {
               throw new Error("Account connection string is only supported in Node.js environment");
             }
           } else if (extractedCreds.kind === "SASConnString") {
             url2 = (0, utils_common_js_1.appendToURLPath)(extractedCreds.url, encodeURIComponent(containerName)) + "?" + extractedCreds.accountSas;
-            pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+            pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
           } else {
             throw new Error("Connection string must be either an Account connection string or a SAS connection string");
           }
         } else {
           throw new Error("Expecting non-empty strings for containerName parameter");
         }
-        super(url2, pipeline);
+        super(url2, pipeline2);
         this._containerName = this.getContainerNameFromUrl();
         this.containerContext = this.storageClientContext.container;
       }
@@ -73660,28 +73660,28 @@ var require_BlobServiceClient = __commonJS({
             if (!options.proxyOptions) {
               options.proxyOptions = (0, core_rest_pipeline_1.getDefaultProxySettings)(extractedCreds.proxyUri);
             }
-            const pipeline = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
-            return new _BlobServiceClient(extractedCreds.url, pipeline);
+            const pipeline2 = (0, Pipeline_js_1.newPipeline)(sharedKeyCredential, options);
+            return new _BlobServiceClient(extractedCreds.url, pipeline2);
           } else {
             throw new Error("Account connection string is only supported in Node.js environment");
           }
         } else if (extractedCreds.kind === "SASConnString") {
-          const pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
-          return new _BlobServiceClient(extractedCreds.url + "?" + extractedCreds.accountSas, pipeline);
+          const pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          return new _BlobServiceClient(extractedCreds.url + "?" + extractedCreds.accountSas, pipeline2);
         } else {
           throw new Error("Connection string must be either an Account connection string or a SAS connection string");
         }
       }
       constructor(url2, credentialOrPipeline, options) {
-        let pipeline;
+        let pipeline2;
         if ((0, Pipeline_js_1.isPipelineLike)(credentialOrPipeline)) {
-          pipeline = credentialOrPipeline;
+          pipeline2 = credentialOrPipeline;
         } else if (core_util_1.isNodeLike && credentialOrPipeline instanceof StorageSharedKeyCredential_js_1.StorageSharedKeyCredential || credentialOrPipeline instanceof AnonymousCredential_js_1.AnonymousCredential || (0, core_auth_1.isTokenCredential)(credentialOrPipeline)) {
-          pipeline = (0, Pipeline_js_1.newPipeline)(credentialOrPipeline, options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipeline, options);
         } else {
-          pipeline = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
+          pipeline2 = (0, Pipeline_js_1.newPipeline)(new AnonymousCredential_js_1.AnonymousCredential(), options);
         }
-        super(url2, pipeline);
+        super(url2, pipeline2);
         this.serviceContext = this.storageClientContext.service;
       }
       /**
@@ -75082,8 +75082,8 @@ var require_downloadUtils = __commonJS({
     var abort_controller_1 = require_dist4();
     function pipeResponseToStream(response, output) {
       return __awaiter2(this, void 0, void 0, function* () {
-        const pipeline = util3.promisify(stream2.pipeline);
-        yield pipeline(response.message, output);
+        const pipeline2 = util3.promisify(stream2.pipeline);
+        yield pipeline2(response.message, output);
       });
     }
     var DownloadProgress = class {
@@ -82212,12 +82212,12 @@ var require_tool_cache = __commonJS({
           core31.debug(`Failed to download from "${url2}". Code(${response.message.statusCode}) Message(${response.message.statusMessage})`);
           throw err;
         }
-        const pipeline = util3.promisify(stream2.pipeline);
+        const pipeline2 = util3.promisify(stream2.pipeline);
         const responseMessageFactory = _getGlobal("TEST_DOWNLOAD_TOOL_RESPONSE_MESSAGE_FACTORY", () => response.message);
         const readStream = responseMessageFactory();
         let succeeded = false;
         try {
-          yield pipeline(readStream, fs31.createWriteStream(dest));
+          yield pipeline2(readStream, fs31.createWriteStream(dest));
           core31.debug("download complete");
           succeeded = true;
           return dest;
@@ -100809,7 +100809,7 @@ var require_pipeline4 = __commonJS({
         }
       }
     }
-    function pipeline(...streams) {
+    function pipeline2(...streams) {
       return pipelineImpl(streams, once(popCallback(streams)));
     }
     function pipelineImpl(streams, callback, opts) {
@@ -101075,7 +101075,7 @@ var require_pipeline4 = __commonJS({
     }
     module2.exports = {
       pipelineImpl,
-      pipeline
+      pipeline: pipeline2
     };
   }
 });
@@ -101084,7 +101084,7 @@ var require_pipeline4 = __commonJS({
 var require_compose = __commonJS({
   "node_modules/readable-stream/lib/internal/streams/compose.js"(exports2, module2) {
     "use strict";
-    var { pipeline } = require_pipeline4();
+    var { pipeline: pipeline2 } = require_pipeline4();
     var Duplex = require_duplex();
     var { destroyer } = require_destroy2();
     var {
@@ -101144,7 +101144,7 @@ var require_compose = __commonJS({
         }
       }
       const head = streams[0];
-      const tail = pipeline(streams, onfinished);
+      const tail = pipeline2(streams, onfinished);
       const writable = !!(isWritable(head) || isWritableStream(head) || isTransformStream(head));
       const readable = !!(isReadable(tail) || isReadableStream(tail) || isTransformStream(tail));
       d = new Duplex({
@@ -101687,7 +101687,7 @@ var require_promises = __commonJS({
     var { pipelineImpl: pl } = require_pipeline4();
     var { finished } = require_end_of_stream();
     require_stream2();
-    function pipeline(...streams) {
+    function pipeline2(...streams) {
       return new Promise2((resolve14, reject) => {
         let signal;
         let end;
@@ -101715,7 +101715,7 @@ var require_promises = __commonJS({
     }
     module2.exports = {
       finished,
-      pipeline
+      pipeline: pipeline2
     };
   }
 });
@@ -101735,7 +101735,7 @@ var require_stream2 = __commonJS({
     } = require_errors4();
     var compose = require_compose();
     var { setDefaultHighWaterMark, getDefaultHighWaterMark } = require_state3();
-    var { pipeline } = require_pipeline4();
+    var { pipeline: pipeline2 } = require_pipeline4();
     var { destroyer } = require_destroy2();
     var eos = require_end_of_stream();
     var promises6 = require_promises();
@@ -101799,7 +101799,7 @@ var require_stream2 = __commonJS({
     Stream.Duplex = require_duplex();
     Stream.Transform = require_transform();
     Stream.PassThrough = require_passthrough2();
-    Stream.pipeline = pipeline;
+    Stream.pipeline = pipeline2;
     var { addAbortSignal } = require_add_abort_signal();
     Stream.addAbortSignal = addAbortSignal;
     Stream.finished = eos;
@@ -101815,7 +101815,7 @@ var require_stream2 = __commonJS({
         return promises6;
       }
     });
-    ObjectDefineProperty(pipeline, customPromisify, {
+    ObjectDefineProperty(pipeline2, customPromisify, {
       __proto__: null,
       enumerable: true,
       get() {
@@ -109038,13 +109038,13 @@ var require_streamx = __commonJS({
     }
     function pipelinePromise(...streams) {
       return new Promise((resolve14, reject) => {
-        return pipeline(...streams, (err) => {
+        return pipeline2(...streams, (err) => {
           if (err) return reject(err);
           resolve14();
         });
       });
     }
-    function pipeline(stream2, ...streams) {
+    function pipeline2(stream2, ...streams) {
       const all = Array.isArray(stream2) ? [...stream2, ...streams] : [stream2, ...streams];
       const done = all.length && typeof all[all.length - 1] === "function" ? all.pop() : null;
       if (all.length < 2) throw new Error("Pipeline requires at least 2 streams");
@@ -109129,7 +109129,7 @@ var require_streamx = __commonJS({
       return s._writev !== Writable.prototype._writev && s._writev !== Duplex.prototype._writev;
     }
     module2.exports = {
-      pipeline,
+      pipeline: pipeline2,
       pipelinePromise,
       isStream: isStream2,
       isStreamx,
@@ -150565,10 +150565,12 @@ async function extractTarZst(tar, dest, tarVersion, logger) {
         reject(new Error(`Error while extracting tar: ${err}`));
       });
       if (tar instanceof stream.Readable) {
-        tar.pipe(tarProcess.stdin).on("error", (err) => {
-          reject(
-            new Error(`Error while downloading and extracting tar: ${err}`)
-          );
+        stream.pipeline(tar, tarProcess.stdin, (err) => {
+          if (err) {
+            reject(
+              new Error(`Error while downloading and extracting tar: ${err}`)
+            );
+          }
         });
       }
       tarProcess.on("exit", (code) => {
@@ -150615,6 +150617,7 @@ var toolcache2 = __toESM(require_tool_cache());
 var import_follow_redirects = __toESM(require_follow_redirects());
 var semver8 = __toESM(require_semver2());
 var STREAMING_HIGH_WATERMARK_BYTES = 4 * 1024 * 1024;
+var STREAMING_STALL_TIMEOUT_MS = 5 * 60 * 1e3;
 var TOOLCACHE_TOOL_NAME = "CodeQL";
 async function downloadAndExtract(codeqlURL, compressionMethod, dest, authorization, headers, tarVersion, logger) {
   logger.info(
@@ -150692,8 +150695,8 @@ async function downloadAndExtractZstdWithStreaming(codeqlURL, dest, authorizatio
     authorization ? { authorization } : {},
     headers
   );
-  const response = await new Promise(
-    (resolve14) => import_follow_redirects.https.get(
+  const response = await new Promise((resolve14, reject) => {
+    const request3 = import_follow_redirects.https.get(
       codeqlURL,
       {
         headers,
@@ -150703,9 +150706,18 @@ async function downloadAndExtractZstdWithStreaming(codeqlURL, dest, authorizatio
         agent
       },
       (r) => resolve14(r)
-    )
-  );
+    );
+    request3.on("error", reject);
+    request3.setTimeout(STREAMING_STALL_TIMEOUT_MS, () => {
+      request3.destroy(
+        new Error(
+          `No data received for ${formatDuration(STREAMING_STALL_TIMEOUT_MS)}.`
+        )
+      );
+    });
+  });
   if (response.statusCode !== 200) {
+    response.resume();
     throw new Error(
       `Failed to download CodeQL bundle from ${codeqlURL}. HTTP status code: ${response.statusCode}.`
     );

--- a/src/tar.test.ts
+++ b/src/tar.test.ts
@@ -1,0 +1,33 @@
+import * as path from "path";
+import * as stream from "stream";
+
+import test from "ava";
+
+import { getRunnerLogger } from "./logging";
+import { extractTarZst } from "./tar";
+import { setupTests } from "./testing-utils";
+import { withTmpDir } from "./util";
+
+setupTests(test);
+
+test("extractTarZst rejects if the input stream errors", async (t) => {
+  await withTmpDir(async (tmpDir) => {
+    const archive = new stream.PassThrough();
+    const promise = extractTarZst(
+      archive,
+      path.join(tmpDir, "dest"),
+      { type: "gnu", version: "1.34" },
+      getRunnerLogger(true),
+    );
+
+    archive.destroy(
+      Object.assign(new Error("socket hang up"), {
+        code: "ECONNRESET",
+      }),
+    );
+
+    await t.throwsAsync(promise, {
+      message: /Error while downloading and extracting tar/,
+    });
+  });
+});

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -194,10 +194,15 @@ export async function extractTarZst(
       });
 
       if (tar instanceof stream.Readable) {
-        tar.pipe(tarProcess.stdin).on("error", (err) => {
-          reject(
-            new Error(`Error while downloading and extracting tar: ${err}`),
-          );
+        // Use `pipeline` rather than `pipe` so that an error on either stream is reported here
+        // rather than being emitted as an unhandled `error` event, and so that `tar`'s standard
+        // input is closed if the download fails partway through.
+        stream.pipeline(tar, tarProcess.stdin, (err) => {
+          if (err) {
+            reject(
+              new Error(`Error while downloading and extracting tar: ${err}`),
+            );
+          }
         });
       }
 

--- a/src/tools-download.test.ts
+++ b/src/tools-download.test.ts
@@ -39,6 +39,43 @@ test.serial(
 );
 
 test.serial(
+  "downloadAndExtract falls back to downloading before extracting if streaming fails",
+  async (t) => {
+    await withTmpDir(async (tmpDir) => {
+      sinon.stub(process, "platform").value("linux");
+      const archivePath = path.join(tmpDir, "codeql-bundle.tar.zst");
+      const destination = path.join(tmpDir, "codeql");
+      const downloadTool = sinon
+        .stub(toolcache, "downloadTool")
+        .resolves(archivePath);
+      const extract = sinon.stub(tar, "extract").resolves(destination);
+      const extractTarZst = sinon.stub(tar, "extractTarZst").resolves();
+      const request = nock("https://example.com")
+        .get("/codeql-bundle.tar.zst")
+        .replyWithError(
+          Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
+        );
+
+      const statusReport = await downloadAndExtract(
+        "https://example.com/codeql-bundle.tar.zst",
+        "zstd",
+        destination,
+        undefined,
+        {},
+        { type: "gnu", version: "1.34" },
+        getRunnerLogger(true),
+      );
+
+      t.assert(Number.isInteger(statusReport.downloadDurationMs));
+      t.true(request.isDone());
+      t.false(extractTarZst.called);
+      t.true(downloadTool.calledOnce);
+      t.true(extract.calledOnce);
+    });
+  },
+);
+
+test.serial(
   "downloadAndExtract omits the download duration when streaming extraction",
   async (t) => {
     await withTmpDir(async (tmpDir) => {

--- a/src/tools-download.ts
+++ b/src/tools-download.ts
@@ -20,6 +20,12 @@ import { cleanUpPath, getErrorMessage, getRequiredEnvParam } from "./util";
 const STREAMING_HIGH_WATERMARK_BYTES = 4 * 1024 * 1024; // 4 MiB
 
 /**
+ * How long the streaming download of the CodeQL tools may stall for before we abort it. This
+ * applies both to establishing the connection and to gaps between chunks of the response body.
+ */
+const STREAMING_STALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
  * The name of the tool cache directory for the CodeQL tools.
  */
 const TOOLCACHE_TOOL_NAME = "CodeQL";
@@ -137,8 +143,8 @@ async function downloadAndExtractZstdWithStreaming(
     authorization ? { authorization } : {},
     headers,
   );
-  const response = await new Promise<IncomingMessage>((resolve) =>
-    https.get(
+  const response = await new Promise<IncomingMessage>((resolve, reject) => {
+    const request = https.get(
       codeqlURL,
       {
         headers,
@@ -148,10 +154,24 @@ async function downloadAndExtractZstdWithStreaming(
         agent,
       } as unknown as RequestOptions,
       (r) => resolve(r),
-    ),
-  );
+    );
+    // Without this listener, connection failures such as `ECONNRESET` are emitted as unhandled
+    // `error` events, which terminate the process instead of letting us fall back to downloading
+    // the bundle before extracting it. This listener stays attached after the response arrives, so
+    // it also handles errors that occur while the response is being streamed.
+    request.on("error", reject);
+    request.setTimeout(STREAMING_STALL_TIMEOUT_MS, () => {
+      request.destroy(
+        new Error(
+          `No data received for ${formatDuration(STREAMING_STALL_TIMEOUT_MS)}.`,
+        ),
+      );
+    });
+  });
 
   if (response.statusCode !== 200) {
+    // Discard the response body so that the connection can be released.
+    response.resume();
     throw new Error(
       `Failed to download CodeQL bundle from ${codeqlURL}. HTTP status code: ${response.statusCode}.`,
     );


### PR DESCRIPTION
When we stream the download and extraction of the CodeQL bundle, a network error such as `ECONNRESET` terminates the `init` Action rather than falling back to downloading the bundle before extracting it. This is because we never attached an `error` listener to the request returned by `https.get`, so `follow-redirects` emits the error as an unhandled `error` event, which is fatal. See [#3367](https://github.com/github/codeql-action/issues/3367).

Attaching the listener is enough to turn the crash into the fallback path we already have. This PR also switches the pipe from the response into `tar` over to `stream.pipeline`, since `tar.pipe(stdin).on("error", ...)` only listens for errors on `tar`'s standard input: an error on the response itself was unhandled, and would have left `tar` waiting indefinitely on a pipe that was never going to be closed. Finally, we abort the request if it stalls for five minutes so that a hung connection can't take the whole job with it.

I've deliberately not added a retry loop around the streaming attempt: `toolcache.downloadTool`, which we fall back to, already retries three times with exponential backoff and already avoids retrying non-transient status codes. The bug here was never that we don't retry, it's that we crashed before we got the chance.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** This only affects what happens when the streaming download fails, which currently means the job dies. Both new failure paths are covered by unit tests that were confirmed to fail without the fix.

#### Which use cases does this change impact?

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

- **Unit tests** - New tests simulate a mid-connection `ECONNRESET` and assert that we fall back rather than crashing.
- **End-to-end tests** - The existing bundle toolcache PR checks continue to exercise the streaming download on Linux.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

- **Telemetry** - Streaming failures now surface as the existing fallback warning and show up in the download duration status field, rather than as a hard job failure.

#### Are there any special considerations for merging or releasing this change?

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.