### PR TITLE
ci: update Enterprise release checkout credential

### DIFF
--- a/.github/workflows/update-supported-enterprise-server-versions.yml
+++ b/.github/workflows/update-supported-enterprise-server-versions.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: github/enterprise-releases
-          token: ${{ secrets.ENTERPRISE_RELEASE_TOKEN }}
+          token: ${{ secrets.CODEQL_CI_ENTERPRISE_RELEASE_PAT }}
           path: ${{ github.workspace }}/enterprise-releases/
           sparse-checkout: releases.json
 


### PR DESCRIPTION
Updates the supported-version workflow to use the federated read-only credential when checking out Enterprise release metadata.

No workflow behavior changes beyond the credential reference.