### PR TITLE
Persist CodeQL version output to file rather than environment

### DIFF
--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146258,7 +146258,7 @@ function cacheCodeQlVersion(cmd, version, env = getEnv()) {
   cachedCodeQlVersion = version;
   fs3.writeFileSync(
     getCommandCacheFilePath(env),
-    JSON.stringify({ cmd, version }),
+    JSON.stringify({ cmd, entries: { ["version" /* Version */]: version } }),
     "utf8"
   );
 }
@@ -146281,7 +146281,7 @@ function getCachedCodeQlVersion(cmd, env = getEnv()) {
   if (!isPersistedVersionInfo(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
     return void 0;
   }
-  cachedCodeQlVersion = persisted.version;
+  cachedCodeQlVersion = persisted.entries["version" /* Version */];
   return cachedCodeQlVersion;
 }
 function isVersionInfo(x) {
@@ -146290,7 +146290,7 @@ function isVersionInfo(x) {
 }
 function isPersistedVersionInfo(x) {
   const candidate = x;
-  return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && isVersionInfo(candidate.version);
+  return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && candidate.entries !== void 0 && isVersionInfo(candidate.entries["version" /* Version */]);
 }
 
 // src/config/pack-registries.ts

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146258,7 +146258,7 @@ function cacheCodeQlVersion(env, cmd, version) {
   cachedCodeQlVersion = version;
   const outputCache = {
     cmd,
-    entries: { ["version" /* Version */]: version }
+    entries: { version }
   };
   fs3.writeFileSync(
     getCommandCacheFilePath(env),
@@ -146285,7 +146285,7 @@ function getCachedCodeQlVersion(env, cmd) {
   if (!isOutputCache(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
     return void 0;
   }
-  cachedCodeQlVersion = persisted.entries["version" /* Version */];
+  cachedCodeQlVersion = persisted.entries.version;
   return cachedCodeQlVersion;
 }
 function isVersionInfo(x) {
@@ -146294,7 +146294,7 @@ function isVersionInfo(x) {
 }
 function isOutputCache(x) {
   const candidate = x;
-  return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && candidate.entries !== void 0 && isVersionInfo(candidate.entries["version" /* Version */]);
+  return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && candidate.entries !== void 0 && isVersionInfo(candidate.entries.version);
 }
 
 // src/config/pack-registries.ts

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146256,9 +146256,13 @@ function cacheCodeQlVersion(cmd, version, env) {
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
   cachedCodeQlVersion = version;
+  const outputCache = {
+    cmd,
+    entries: { ["version" /* Version */]: version }
+  };
   fs3.writeFileSync(
     getCommandCacheFilePath(env),
-    JSON.stringify({ cmd, entries: { ["version" /* Version */]: version } }),
+    JSON.stringify(outputCache),
     "utf8"
   );
 }

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146251,7 +146251,7 @@ var cachedCodeQlVersion = void 0;
 function getCommandCacheFilePath(env) {
   return import_path.default.join(getTemporaryDirectory(env), COMMAND_CACHE_FILENAME);
 }
-function cacheCodeQlVersion(cmd, version, env = getEnv()) {
+function cacheCodeQlVersion(cmd, version, env) {
   if (cachedCodeQlVersion !== void 0) {
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
@@ -146262,7 +146262,7 @@ function cacheCodeQlVersion(cmd, version, env = getEnv()) {
     "utf8"
   );
 }
-function getCachedCodeQlVersion(cmd, env = getEnv()) {
+function getCachedCodeQlVersion(env, cmd) {
   if (cachedCodeQlVersion !== void 0) {
     return cachedCodeQlVersion;
   }
@@ -146834,7 +146834,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       core7.exportVariable("CODEQL_WORKFLOW_STARTED_AT" /* WORKFLOW_STARTED_AT */, workflowStartedAt);
     }
     const runnerOs = getRequiredEnvParam("RUNNER_OS");
-    const codeQlCliVersion = getCachedCodeQlVersion();
+    const codeQlCliVersion = getCachedCodeQlVersion(getEnv());
     const actionRef = process.env["GITHUB_ACTION_REF"] || "";
     const testingEnvironment = getTestingEnvironment();
     if (testingEnvironment) {
@@ -151870,7 +151870,7 @@ async function getCodeQLForCmd(cmd, checkVersion) {
       return cmd;
     },
     async getVersion() {
-      let result = getCachedCodeQlVersion(cmd);
+      let result = getCachedCodeQlVersion(getEnv(), cmd);
       if (result === void 0) {
         result = await runCliJson(
           cmd,
@@ -151879,7 +151879,7 @@ async function getCodeQLForCmd(cmd, checkVersion) {
             noStreamStdout: true
           }
         );
-        cacheCodeQlVersion(cmd, result);
+        cacheCodeQlVersion(cmd, result, getEnv());
       }
       return result;
     },

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146747,20 +146747,24 @@ function cacheCodeQlVersion(env, cmd, version) {
     "utf8"
   );
 }
-function getCachedCodeQlVersion(env, cmd) {
+function getCachedCodeQlVersion(logger, env, cmd) {
   if (cachedCodeQlVersion !== void 0) {
     return cachedCodeQlVersion;
   }
   let serialized;
   try {
     serialized = fs3.readFileSync(getCommandCacheFilePath(env), "utf8");
-  } catch {
+  } catch (e) {
+    logger.debug(
+      `Cannot read CLI-cache file ${getCommandCacheFilePath(env)}: ${e}`
+    );
     return void 0;
   }
   let persisted;
   try {
     persisted = JSON.parse(serialized);
-  } catch {
+  } catch (e) {
+    logger.debug(`Cannot parse CLI-cache data as JSON: ${e}`);
     return void 0;
   }
   if (!isOutputCache(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
@@ -147319,7 +147323,7 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       core7.exportVariable("CODEQL_WORKFLOW_STARTED_AT" /* WORKFLOW_STARTED_AT */, workflowStartedAt);
     }
     const runnerOs = getRequiredEnvParam("RUNNER_OS");
-    const codeQlCliVersion = getCachedCodeQlVersion(getEnv());
+    const codeQlCliVersion = getCachedCodeQlVersion(logger, getEnv());
     const actionRef = process.env["GITHUB_ACTION_REF"] || "";
     const testingEnvironment = getTestingEnvironment();
     if (testingEnvironment) {
@@ -152339,7 +152343,7 @@ async function getCodeQLForCmd(logger, cmd, checkVersion) {
       return cmd;
     },
     async getVersion() {
-      let result = getCachedCodeQlVersion(getEnv(), cmd);
+      let result = getCachedCodeQlVersion(logger, getEnv(), cmd);
       if (result === void 0) {
         result = await runCliJson(
           cmd,

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146278,7 +146278,7 @@ function getCachedCodeQlVersion(env, cmd) {
   } catch {
     return void 0;
   }
-  if (!isCommandCacheRecord(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
+  if (!isOutputCache(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
     return void 0;
   }
   cachedCodeQlVersion = persisted.entries["version" /* Version */];
@@ -146288,7 +146288,7 @@ function isVersionInfo(x) {
   const candidate = x;
   return typeof candidate === "object" && candidate !== null && typeof candidate.version === "string" && (candidate.features === void 0 || typeof candidate.features === "object" && candidate.features !== null) && (candidate.overlayVersion === void 0 || typeof candidate.overlayVersion === "number");
 }
-function isCommandCacheRecord(x) {
+function isOutputCache(x) {
   const candidate = x;
   return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && candidate.entries !== void 0 && isVersionInfo(candidate.entries["version" /* Version */]);
 }

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -145241,14 +145241,6 @@ function asHTTPError(arg) {
   }
   return void 0;
 }
-function isVersionInfo(x) {
-  const candidate = x;
-  return typeof candidate === "object" && candidate !== null && typeof candidate.version === "string" && (candidate.features === void 0 || typeof candidate.features === "object" && candidate.features !== null) && (candidate.overlayVersion === void 0 || typeof candidate.overlayVersion === "number");
-}
-function isPersistedVersionInfo(x) {
-  const candidate = x;
-  return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && isVersionInfo(candidate.version);
-}
 async function codeQlVersionAtLeast(codeql, requiredVersion) {
   return semver.gte((await codeql.getVersion()).version, requiredVersion);
 }
@@ -146291,6 +146283,14 @@ function getCachedCodeQlVersion(cmd, env = getEnv()) {
   }
   cachedCodeQlVersion = persisted.version;
   return cachedCodeQlVersion;
+}
+function isVersionInfo(x) {
+  const candidate = x;
+  return typeof candidate === "object" && candidate !== null && typeof candidate.version === "string" && (candidate.features === void 0 || typeof candidate.features === "object" && candidate.features !== null) && (candidate.overlayVersion === void 0 || typeof candidate.overlayVersion === "number");
+}
+function isPersistedVersionInfo(x) {
+  const candidate = x;
+  return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && isVersionInfo(candidate.version);
 }
 
 // src/config/pack-registries.ts
@@ -157827,7 +157827,7 @@ var import_async = __toESM(require_async(), 1);
 var import_path7 = require("path");
 
 // node_modules/archiver/lib/error.js
-var import_util35 = __toESM(require("util"), 1);
+var import_util34 = __toESM(require("util"), 1);
 var ERROR_CODES = {
   ABORTED: "archive was aborted",
   DIRECTORYDIRPATHREQUIRED: "diretory dirpath argument must be a non-empty string value",
@@ -157852,7 +157852,7 @@ function ArchiverError(code, data) {
   this.code = code;
   this.data = data;
 }
-import_util35.default.inherits(ArchiverError, Error);
+import_util34.default.inherits(ArchiverError, Error);
 
 // node_modules/archiver/lib/core.js
 var import_readable_stream2 = __toESM(require_ours(), 1);

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146278,7 +146278,7 @@ function getCachedCodeQlVersion(cmd, env = getEnv()) {
   } catch {
     return void 0;
   }
-  if (!isPersistedVersionInfo(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
+  if (!isCommandCacheRecord(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
     return void 0;
   }
   cachedCodeQlVersion = persisted.entries["version" /* Version */];
@@ -146288,7 +146288,7 @@ function isVersionInfo(x) {
   const candidate = x;
   return typeof candidate === "object" && candidate !== null && typeof candidate.version === "string" && (candidate.features === void 0 || typeof candidate.features === "object" && candidate.features !== null) && (candidate.overlayVersion === void 0 || typeof candidate.overlayVersion === "number");
 }
-function isPersistedVersionInfo(x) {
+function isCommandCacheRecord(x) {
   const candidate = x;
   return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && candidate.entries !== void 0 && isVersionInfo(candidate.entries["version" /* Version */]);
 }

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146251,7 +146251,7 @@ var cachedCodeQlVersion = void 0;
 function getCommandCacheFilePath(env) {
   return import_path.default.join(getTemporaryDirectory(env), COMMAND_CACHE_FILENAME);
 }
-function cacheCodeQlVersion(cmd, version, env) {
+function cacheCodeQlVersion(env, cmd, version) {
   if (cachedCodeQlVersion !== void 0) {
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
@@ -151883,7 +151883,7 @@ async function getCodeQLForCmd(cmd, checkVersion) {
             noStreamStdout: true
           }
         );
-        cacheCodeQlVersion(cmd, result, getEnv());
+        cacheCodeQlVersion(getEnv(), cmd, result);
       }
       return result;
     },

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -145250,22 +145250,28 @@ function isPersistedVersionInfo(x) {
   const candidate = x;
   return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && isVersionInfo(candidate.version);
 }
-function cacheCodeQlVersion(cmd, version) {
+function getPathToCodeQLVersionCacheFile(env) {
+  return path.join(getTemporaryDirectory(env), "version.json");
+}
+function cacheCodeQlVersion(cmd, version, env = getEnv()) {
   if (cachedCodeQlVersion !== void 0) {
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
   cachedCodeQlVersion = version;
-  core2.exportVariable(
-    "CODEQL_ACTION_CLI_VERSION_INFO" /* CODEQL_VERSION_INFO */,
-    JSON.stringify({ cmd, version })
+  fs.writeFileSync(
+    getPathToCodeQLVersionCacheFile(env),
+    JSON.stringify({ cmd, version }),
+    "utf8"
   );
 }
-function getCachedCodeQlVersion(cmd) {
+function getCachedCodeQlVersion(cmd, env = getEnv()) {
   if (cachedCodeQlVersion !== void 0) {
     return cachedCodeQlVersion;
   }
-  const serialized = process.env["CODEQL_ACTION_CLI_VERSION_INFO" /* CODEQL_VERSION_INFO */];
-  if (!serialized) {
+  let serialized;
+  try {
+    serialized = fs.readFileSync(getPathToCodeQLVersionCacheFile(env), "utf8");
+  } catch {
     return void 0;
   }
   let persisted;

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -213,7 +213,7 @@ var require_file_command = __commonJS({
     exports2.issueFileCommand = issueFileCommand;
     exports2.prepareKeyValueMessage = prepareKeyValueMessage;
     var crypto3 = __importStar2(require("crypto"));
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var os7 = __importStar2(require("os"));
     var utils_1 = require_utils();
     function issueFileCommand(command, message) {
@@ -221,10 +221,10 @@ var require_file_command = __commonJS({
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
       }
-      if (!fs31.existsSync(filePath)) {
+      if (!fs32.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
       }
-      fs31.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os7.EOL}`, {
+      fs32.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os7.EOL}`, {
         encoding: "utf8"
       });
     }
@@ -1362,14 +1362,14 @@ var require_util = __commonJS({
         }
         const port = url2.port != null ? url2.port : url2.protocol === "https:" ? 443 : 80;
         let origin = url2.origin != null ? url2.origin : `${url2.protocol || ""}//${url2.hostname || ""}:${port}`;
-        let path29 = url2.path != null ? url2.path : `${url2.pathname || ""}${url2.search || ""}`;
+        let path30 = url2.path != null ? url2.path : `${url2.pathname || ""}${url2.search || ""}`;
         if (origin[origin.length - 1] === "/") {
           origin = origin.slice(0, origin.length - 1);
         }
-        if (path29 && path29[0] !== "/") {
-          path29 = `/${path29}`;
+        if (path30 && path30[0] !== "/") {
+          path30 = `/${path30}`;
         }
-        return new URL(`${origin}${path29}`);
+        return new URL(`${origin}${path30}`);
       }
       if (!isHttpOrHttpsPrefixed(url2.origin || url2.protocol)) {
         throw new InvalidArgumentError("Invalid URL protocol: the URL must start with `http:` or `https:`.");
@@ -1820,39 +1820,39 @@ var require_diagnostics = __commonJS({
       });
       diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
         const {
-          request: { method, path: path29, origin }
+          request: { method, path: path30, origin }
         } = evt;
-        debuglog("sending request to %s %s/%s", method, origin, path29);
+        debuglog("sending request to %s %s/%s", method, origin, path30);
       });
       diagnosticsChannel.channel("undici:request:headers").subscribe((evt) => {
         const {
-          request: { method, path: path29, origin },
+          request: { method, path: path30, origin },
           response: { statusCode }
         } = evt;
         debuglog(
           "received response to %s %s/%s - HTTP %d",
           method,
           origin,
-          path29,
+          path30,
           statusCode
         );
       });
       diagnosticsChannel.channel("undici:request:trailers").subscribe((evt) => {
         const {
-          request: { method, path: path29, origin }
+          request: { method, path: path30, origin }
         } = evt;
-        debuglog("trailers received from %s %s/%s", method, origin, path29);
+        debuglog("trailers received from %s %s/%s", method, origin, path30);
       });
       diagnosticsChannel.channel("undici:request:error").subscribe((evt) => {
         const {
-          request: { method, path: path29, origin },
+          request: { method, path: path30, origin },
           error: error3
         } = evt;
         debuglog(
           "request to %s %s/%s errored - %s",
           method,
           origin,
-          path29,
+          path30,
           error3.message
         );
       });
@@ -1901,9 +1901,9 @@ var require_diagnostics = __commonJS({
         });
         diagnosticsChannel.channel("undici:client:sendHeaders").subscribe((evt) => {
           const {
-            request: { method, path: path29, origin }
+            request: { method, path: path30, origin }
           } = evt;
-          debuglog("sending request to %s %s/%s", method, origin, path29);
+          debuglog("sending request to %s %s/%s", method, origin, path30);
         });
       }
       diagnosticsChannel.channel("undici:websocket:open").subscribe((evt) => {
@@ -1966,7 +1966,7 @@ var require_request = __commonJS({
     var kHandler = /* @__PURE__ */ Symbol("handler");
     var Request = class {
       constructor(origin, {
-        path: path29,
+        path: path30,
         method,
         body,
         headers,
@@ -1981,11 +1981,11 @@ var require_request = __commonJS({
         expectContinue,
         servername
       }, handler2) {
-        if (typeof path29 !== "string") {
+        if (typeof path30 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path29[0] !== "/" && !(path29.startsWith("http://") || path29.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path30[0] !== "/" && !(path30.startsWith("http://") || path30.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.test(path29)) {
+        } else if (invalidPathRegex.test(path30)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -2051,7 +2051,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? buildURL(path29, query) : path29;
+        this.path = query ? buildURL(path30, query) : path30;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6673,7 +6673,7 @@ var require_client_h1 = __commonJS({
       return method !== "GET" && method !== "HEAD" && method !== "OPTIONS" && method !== "TRACE" && method !== "CONNECT";
     }
     function writeH1(client, request3) {
-      const { method, path: path29, host, upgrade, blocking, reset } = request3;
+      const { method, path: path30, host, upgrade, blocking, reset } = request3;
       let { body, headers, contentLength } = request3;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH" || method === "QUERY" || method === "PROPFIND" || method === "PROPPATCH";
       if (util3.isFormDataLike(body)) {
@@ -6740,7 +6740,7 @@ var require_client_h1 = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path29} HTTP/1.1\r
+      let header = `${method} ${path30} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -7266,7 +7266,7 @@ var require_client_h2 = __commonJS({
     }
     function writeH2(client, request3) {
       const session = client[kHTTP2Session];
-      const { method, path: path29, host, upgrade, expectContinue, signal, headers: reqHeaders } = request3;
+      const { method, path: path30, host, upgrade, expectContinue, signal, headers: reqHeaders } = request3;
       let { body } = request3;
       if (upgrade) {
         util3.errorRequest(client, request3, new Error("Upgrade not supported for H2"));
@@ -7333,7 +7333,7 @@ var require_client_h2 = __commonJS({
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path29;
+      headers[HTTP2_HEADER_PATH] = path30;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -7686,9 +7686,9 @@ var require_redirect_handler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util3.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path29 = search ? `${pathname}${search}` : pathname;
+        const path30 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path29;
+        this.opts.path = path30;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8923,10 +8923,10 @@ var require_proxy_agent = __commonJS({
         };
         const {
           origin,
-          path: path29 = "/",
+          path: path30 = "/",
           headers = {}
         } = opts;
-        opts.path = origin + path29;
+        opts.path = origin + path30;
         if (!("host" in headers) && !("Host" in headers)) {
           const { host } = new URL2(origin);
           headers.host = host;
@@ -10847,20 +10847,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path29) {
-      if (typeof path29 !== "string") {
-        return path29;
+    function safeUrl(path30) {
+      if (typeof path30 !== "string") {
+        return path30;
       }
-      const pathSegments = path29.split("?");
+      const pathSegments = path30.split("?");
       if (pathSegments.length !== 2) {
-        return path29;
+        return path30;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path29, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path29);
+    function matchKey(mockDispatch2, { path: path30, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path30);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10882,7 +10882,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path29 }) => matchValue(safeUrl(path29), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path30 }) => matchValue(safeUrl(path30), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10920,9 +10920,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path29, method, body, headers, query } = opts;
+      const { path: path30, method, body, headers, query } = opts;
       return {
-        path: path29,
+        path: path30,
         method,
         body,
         headers,
@@ -11385,10 +11385,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path29, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path30, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path29,
+            Path: path30,
             "Status code": statusCode,
             Persistent: persist ? PERSISTENT : NOT_PERSISTENT,
             Invocations: timesInvoked,
@@ -16269,9 +16269,9 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path29) {
-      for (let i = 0; i < path29.length; ++i) {
-        const code = path29.charCodeAt(i);
+    function validateCookiePath(path30) {
+      for (let i = 0; i < path30.length; ++i) {
+        const code = path30.charCodeAt(i);
         if (code < 32 || // exclude CTLs (0-31)
         code === 127 || // DEL
         code === 59) {
@@ -18964,11 +18964,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path29 = opts.path;
+          let path30 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path29 = `/${path29}`;
+            path30 = `/${path30}`;
           }
-          url2 = new URL(util3.parseOrigin(url2).origin + path29);
+          url2 = new URL(util3.parseOrigin(url2).origin + path30);
         } else {
           if (!opts) {
             opts = typeof url2 === "object" ? url2 : {};
@@ -20271,7 +20271,7 @@ var require_path_utils = __commonJS({
     exports2.toPosixPath = toPosixPath;
     exports2.toWin32Path = toWin32Path;
     exports2.toPlatformPath = toPlatformPath;
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -20279,7 +20279,7 @@ var require_path_utils = __commonJS({
       return pth.replace(/[/]/g, "\\");
     }
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path29.sep);
+      return pth.replace(/[/\\]/g, path30.sep);
     }
   }
 });
@@ -20361,13 +20361,13 @@ var require_io_util = __commonJS({
     exports2.isRooted = isRooted;
     exports2.tryGetExecutablePath = tryGetExecutablePath;
     exports2.getCmdPath = getCmdPath;
-    var fs31 = __importStar2(require("fs"));
-    var path29 = __importStar2(require("path"));
-    _a2 = fs31.promises, exports2.chmod = _a2.chmod, exports2.copyFile = _a2.copyFile, exports2.lstat = _a2.lstat, exports2.mkdir = _a2.mkdir, exports2.open = _a2.open, exports2.readdir = _a2.readdir, exports2.rename = _a2.rename, exports2.rm = _a2.rm, exports2.rmdir = _a2.rmdir, exports2.stat = _a2.stat, exports2.symlink = _a2.symlink, exports2.unlink = _a2.unlink;
+    var fs32 = __importStar2(require("fs"));
+    var path30 = __importStar2(require("path"));
+    _a2 = fs32.promises, exports2.chmod = _a2.chmod, exports2.copyFile = _a2.copyFile, exports2.lstat = _a2.lstat, exports2.mkdir = _a2.mkdir, exports2.open = _a2.open, exports2.readdir = _a2.readdir, exports2.rename = _a2.rename, exports2.rm = _a2.rm, exports2.rmdir = _a2.rmdir, exports2.stat = _a2.stat, exports2.symlink = _a2.symlink, exports2.unlink = _a2.unlink;
     exports2.IS_WINDOWS = process.platform === "win32";
     function readlink(fsPath) {
       return __awaiter2(this, void 0, void 0, function* () {
-        const result = yield fs31.promises.readlink(fsPath);
+        const result = yield fs32.promises.readlink(fsPath);
         if (exports2.IS_WINDOWS && !result.endsWith("\\")) {
           return `${result}\\`;
         }
@@ -20375,7 +20375,7 @@ var require_io_util = __commonJS({
       });
     }
     exports2.UV_FS_O_EXLOCK = 268435456;
-    exports2.READONLY = fs31.constants.O_RDONLY;
+    exports2.READONLY = fs32.constants.O_RDONLY;
     function exists(fsPath) {
       return __awaiter2(this, void 0, void 0, function* () {
         try {
@@ -20417,7 +20417,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path29.extname(filePath).toUpperCase();
+            const upperExt = path30.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -20441,11 +20441,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports2.IS_WINDOWS) {
               try {
-                const directory = path29.dirname(filePath);
-                const upperName = path29.basename(filePath).toUpperCase();
+                const directory = path30.dirname(filePath);
+                const upperName = path30.basename(filePath).toUpperCase();
                 for (const actualName of yield (0, exports2.readdir)(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path29.join(directory, actualName);
+                    filePath = path30.join(directory, actualName);
                     break;
                   }
                 }
@@ -20557,7 +20557,7 @@ var require_io = __commonJS({
     exports2.which = which9;
     exports2.findInPath = findInPath;
     var assert_1 = require("assert");
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var ioUtil = __importStar2(require_io_util());
     function cp(source_1, dest_1) {
       return __awaiter2(this, arguments, void 0, function* (source, dest, options = {}) {
@@ -20566,7 +20566,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path29.join(dest, path29.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path30.join(dest, path30.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -20578,7 +20578,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path29.relative(source, newDest) === "") {
+          if (path30.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile2(source, newDest, force);
@@ -20590,7 +20590,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path29.join(dest, path29.basename(source));
+            dest = path30.join(dest, path30.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -20601,7 +20601,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path29.dirname(dest));
+        yield mkdirP(path30.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -20660,7 +20660,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path29.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path30.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -20673,12 +20673,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path29.sep)) {
+        if (tool.includes(path30.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path29.delimiter)) {
+          for (const p of process.env.PATH.split(path30.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -20686,7 +20686,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path29.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path30.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -20816,7 +20816,7 @@ var require_toolrunner = __commonJS({
     var os7 = __importStar2(require("os"));
     var events = __importStar2(require("events"));
     var child = __importStar2(require("child_process"));
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var io9 = __importStar2(require_io());
     var ioUtil = __importStar2(require_io_util());
     var timers_1 = require("timers");
@@ -21031,7 +21031,7 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter2(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path29.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path30.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io9.which(this.toolPath, true);
           return new Promise((resolve14, reject) => __awaiter2(this, void 0, void 0, function* () {
@@ -21584,7 +21584,7 @@ var require_core = __commonJS({
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os7 = __importStar2(require("os"));
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -21610,7 +21610,7 @@ var require_core = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path29.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path30.delimiter}${process.env["PATH"]}`;
     }
     function getInput2(name, options) {
       const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
@@ -21747,8 +21747,8 @@ var require_context = __commonJS({
           if ((0, fs_1.existsSync)(process.env.GITHUB_EVENT_PATH)) {
             this.payload = JSON.parse((0, fs_1.readFileSync)(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
           } else {
-            const path29 = process.env.GITHUB_EVENT_PATH;
-            process.stdout.write(`GITHUB_EVENT_PATH ${path29} does not exist${os_1.EOL}`);
+            const path30 = process.env.GITHUB_EVENT_PATH;
+            process.stdout.write(`GITHUB_EVENT_PATH ${path30} does not exist${os_1.EOL}`);
           }
         }
         this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -29356,14 +29356,14 @@ var require_light = __commonJS({
 var require_helpers = __commonJS({
   "node_modules/jsonschema/lib/helpers.js"(exports2, module2) {
     "use strict";
-    var ValidationError = exports2.ValidationError = function ValidationError2(message, instance, schema, path29, name, argument) {
-      if (Array.isArray(path29)) {
-        this.path = path29;
-        this.property = path29.reduce(function(sum, item) {
+    var ValidationError = exports2.ValidationError = function ValidationError2(message, instance, schema, path30, name, argument) {
+      if (Array.isArray(path30)) {
+        this.path = path30;
+        this.property = path30.reduce(function(sum, item) {
           return sum + makeSuffix(item);
         }, "instance");
-      } else if (path29 !== void 0) {
-        this.property = path29;
+      } else if (path30 !== void 0) {
+        this.property = path30;
       }
       if (message) {
         this.message = message;
@@ -29456,16 +29456,16 @@ var require_helpers = __commonJS({
         name: { value: "SchemaError", enumerable: false }
       }
     );
-    var SchemaContext = exports2.SchemaContext = function SchemaContext2(schema, options, path29, base, schemas) {
+    var SchemaContext = exports2.SchemaContext = function SchemaContext2(schema, options, path30, base, schemas) {
       this.schema = schema;
       this.options = options;
-      if (Array.isArray(path29)) {
-        this.path = path29;
-        this.propertyPath = path29.reduce(function(sum, item) {
+      if (Array.isArray(path30)) {
+        this.path = path30;
+        this.propertyPath = path30.reduce(function(sum, item) {
           return sum + makeSuffix(item);
         }, "instance");
       } else {
-        this.propertyPath = path29;
+        this.propertyPath = path30;
       }
       this.base = base;
       this.schemas = schemas;
@@ -29474,10 +29474,10 @@ var require_helpers = __commonJS({
       return (() => resolveUrl(this.base, target))();
     };
     SchemaContext.prototype.makeChild = function makeChild(schema, propertyName) {
-      var path29 = propertyName === void 0 ? this.path : this.path.concat([propertyName]);
+      var path30 = propertyName === void 0 ? this.path : this.path.concat([propertyName]);
       var id = schema.$id || schema.id;
       let base = (() => resolveUrl(this.base, id || ""))();
-      var ctx = new SchemaContext(schema, this.options, path29, base, Object.create(this.schemas));
+      var ctx = new SchemaContext(schema, this.options, path30, base, Object.create(this.schemas));
       if (id && !ctx.schemas[base]) {
         ctx.schemas[base] = schema;
       }
@@ -30938,7 +30938,7 @@ var require_internal_path_helper = __commonJS({
     exports2.hasRoot = hasRoot;
     exports2.normalizeSeparators = normalizeSeparators;
     exports2.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var assert_1 = __importDefault2(require("assert"));
     var IS_WINDOWS = process.platform === "win32";
     function dirname6(p) {
@@ -30946,7 +30946,7 @@ var require_internal_path_helper = __commonJS({
       if (IS_WINDOWS && /^\\\\[^\\]+(\\[^\\]+)?$/.test(p)) {
         return p;
       }
-      let result = path29.dirname(p);
+      let result = path30.dirname(p);
       if (IS_WINDOWS && /^\\\\[^\\]+\\[^\\]+\\$/.test(result)) {
         result = safeTrimTrailingSeparator(result);
       }
@@ -30983,7 +30983,7 @@ var require_internal_path_helper = __commonJS({
       (0, assert_1.default)(hasAbsoluteRoot(root), `ensureAbsoluteRoot parameter 'root' must have an absolute root`);
       if (root.endsWith("/") || IS_WINDOWS && root.endsWith("\\")) {
       } else {
-        root += path29.sep;
+        root += path30.sep;
       }
       return root + itemPath;
     }
@@ -31017,10 +31017,10 @@ var require_internal_path_helper = __commonJS({
         return "";
       }
       p = normalizeSeparators(p);
-      if (!p.endsWith(path29.sep)) {
+      if (!p.endsWith(path30.sep)) {
         return p;
       }
-      if (p === path29.sep) {
+      if (p === path30.sep) {
         return p;
       }
       if (IS_WINDOWS && /^[A-Z]:\\$/i.test(p)) {
@@ -31459,7 +31459,7 @@ var require_minimatch = __commonJS({
   "node_modules/minimatch/minimatch.js"(exports2, module2) {
     module2.exports = minimatch2;
     minimatch2.Minimatch = Minimatch2;
-    var path29 = (function() {
+    var path30 = (function() {
       try {
         return require("path");
       } catch (e) {
@@ -31467,7 +31467,7 @@ var require_minimatch = __commonJS({
     })() || {
       sep: "/"
     };
-    minimatch2.sep = path29.sep;
+    minimatch2.sep = path30.sep;
     var GLOBSTAR2 = minimatch2.GLOBSTAR = Minimatch2.GLOBSTAR = {};
     var expand3 = require_brace_expansion();
     var plTypes = {
@@ -31556,8 +31556,8 @@ var require_minimatch = __commonJS({
       assertValidPattern2(pattern);
       if (!options) options = {};
       pattern = pattern.trim();
-      if (!options.allowWindowsEscape && path29.sep !== "/") {
-        pattern = pattern.split(path29.sep).join("/");
+      if (!options.allowWindowsEscape && path30.sep !== "/") {
+        pattern = pattern.split(path30.sep).join("/");
       }
       this.options = options;
       this.maxGlobstarRecursion = options.maxGlobstarRecursion !== void 0 ? options.maxGlobstarRecursion : 200;
@@ -31928,8 +31928,8 @@ var require_minimatch = __commonJS({
       if (this.empty) return f === "";
       if (f === "/" && partial) return true;
       var options = this.options;
-      if (path29.sep !== "/") {
-        f = f.split(path29.sep).join("/");
+      if (path30.sep !== "/") {
+        f = f.split(path30.sep).join("/");
       }
       f = f.split(slashSplit);
       this.debug(this.pattern, "split", f);
@@ -32172,7 +32172,7 @@ var require_internal_path = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.Path = void 0;
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var pathHelper = __importStar2(require_internal_path_helper());
     var assert_1 = __importDefault2(require("assert"));
     var IS_WINDOWS = process.platform === "win32";
@@ -32187,12 +32187,12 @@ var require_internal_path = __commonJS({
           (0, assert_1.default)(itemPath, `Parameter 'itemPath' must not be empty`);
           itemPath = pathHelper.safeTrimTrailingSeparator(itemPath);
           if (!pathHelper.hasRoot(itemPath)) {
-            this.segments = itemPath.split(path29.sep);
+            this.segments = itemPath.split(path30.sep);
           } else {
             let remaining = itemPath;
             let dir = pathHelper.dirname(remaining);
             while (dir !== remaining) {
-              const basename2 = path29.basename(remaining);
+              const basename2 = path30.basename(remaining);
               this.segments.unshift(basename2);
               remaining = dir;
               dir = pathHelper.dirname(remaining);
@@ -32210,7 +32210,7 @@ var require_internal_path = __commonJS({
               (0, assert_1.default)(segment === pathHelper.dirname(segment), `Parameter 'itemPath' root segment contains information for multiple segments`);
               this.segments.push(segment);
             } else {
-              (0, assert_1.default)(!segment.includes(path29.sep), `Parameter 'itemPath' contains unexpected path separators`);
+              (0, assert_1.default)(!segment.includes(path30.sep), `Parameter 'itemPath' contains unexpected path separators`);
               this.segments.push(segment);
             }
           }
@@ -32221,12 +32221,12 @@ var require_internal_path = __commonJS({
        */
       toString() {
         let result = this.segments[0];
-        let skipSlash = result.endsWith(path29.sep) || IS_WINDOWS && /^[A-Z]:$/i.test(result);
+        let skipSlash = result.endsWith(path30.sep) || IS_WINDOWS && /^[A-Z]:$/i.test(result);
         for (let i = 1; i < this.segments.length; i++) {
           if (skipSlash) {
             skipSlash = false;
           } else {
-            result += path29.sep;
+            result += path30.sep;
           }
           result += this.segments[i];
         }
@@ -32284,7 +32284,7 @@ var require_internal_pattern = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.Pattern = void 0;
     var os7 = __importStar2(require("os"));
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var pathHelper = __importStar2(require_internal_path_helper());
     var assert_1 = __importDefault2(require("assert"));
     var minimatch_1 = require_minimatch();
@@ -32313,7 +32313,7 @@ var require_internal_pattern = __commonJS({
         }
         pattern = _Pattern.fixupPattern(pattern, homedir2);
         this.segments = new internal_path_1.Path(pattern).segments;
-        this.trailingSeparator = pathHelper.normalizeSeparators(pattern).endsWith(path29.sep);
+        this.trailingSeparator = pathHelper.normalizeSeparators(pattern).endsWith(path30.sep);
         pattern = pathHelper.safeTrimTrailingSeparator(pattern);
         let foundGlob = false;
         const searchSegments = this.segments.map((x) => _Pattern.getLiteral(x)).filter((x) => !foundGlob && !(foundGlob = x === ""));
@@ -32337,8 +32337,8 @@ var require_internal_pattern = __commonJS({
       match(itemPath) {
         if (this.segments[this.segments.length - 1] === "**") {
           itemPath = pathHelper.normalizeSeparators(itemPath);
-          if (!itemPath.endsWith(path29.sep) && this.isImplicitPattern === false) {
-            itemPath = `${itemPath}${path29.sep}`;
+          if (!itemPath.endsWith(path30.sep) && this.isImplicitPattern === false) {
+            itemPath = `${itemPath}${path30.sep}`;
           }
         } else {
           itemPath = pathHelper.safeTrimTrailingSeparator(itemPath);
@@ -32373,9 +32373,9 @@ var require_internal_pattern = __commonJS({
         (0, assert_1.default)(literalSegments.every((x, i) => (x !== "." || i === 0) && x !== ".."), `Invalid pattern '${pattern}'. Relative pathing '.' and '..' is not allowed.`);
         (0, assert_1.default)(!pathHelper.hasRoot(pattern) || literalSegments[0], `Invalid pattern '${pattern}'. Root segment must not contain globs.`);
         pattern = pathHelper.normalizeSeparators(pattern);
-        if (pattern === "." || pattern.startsWith(`.${path29.sep}`)) {
+        if (pattern === "." || pattern.startsWith(`.${path30.sep}`)) {
           pattern = _Pattern.globEscape(process.cwd()) + pattern.substr(1);
-        } else if (pattern === "~" || pattern.startsWith(`~${path29.sep}`)) {
+        } else if (pattern === "~" || pattern.startsWith(`~${path30.sep}`)) {
           homedir2 = homedir2 || os7.homedir();
           (0, assert_1.default)(homedir2, "Unable to determine HOME directory");
           (0, assert_1.default)(pathHelper.hasAbsoluteRoot(homedir2), `Expected HOME directory to be a rooted path. Actual '${homedir2}'`);
@@ -32459,8 +32459,8 @@ var require_internal_search_state = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.SearchState = void 0;
     var SearchState = class {
-      constructor(path29, level) {
-        this.path = path29;
+      constructor(path30, level) {
+        this.path = path30;
         this.level = level;
       }
     };
@@ -32602,9 +32602,9 @@ var require_internal_globber = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.DefaultGlobber = void 0;
     var core31 = __importStar2(require_core());
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var globOptionsHelper = __importStar2(require_internal_glob_options_helper());
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var patternHelper = __importStar2(require_internal_pattern_helper());
     var internal_match_kind_1 = require_internal_match_kind();
     var internal_pattern_1 = require_internal_pattern();
@@ -32656,7 +32656,7 @@ var require_internal_globber = __commonJS({
           for (const searchPath of patternHelper.getSearchPaths(patterns)) {
             core31.debug(`Search path '${searchPath}'`);
             try {
-              yield __await2(fs31.promises.lstat(searchPath));
+              yield __await2(fs32.promises.lstat(searchPath));
             } catch (err) {
               if (err.code === "ENOENT") {
                 continue;
@@ -32680,7 +32680,7 @@ var require_internal_globber = __commonJS({
             if (!stats) {
               continue;
             }
-            if (options.excludeHiddenFiles && path29.basename(item.path).match(/^\./)) {
+            if (options.excludeHiddenFiles && path30.basename(item.path).match(/^\./)) {
               continue;
             }
             if (stats.isDirectory()) {
@@ -32690,7 +32690,7 @@ var require_internal_globber = __commonJS({
                 continue;
               }
               const childLevel = item.level + 1;
-              const childItems = (yield __await2(fs31.promises.readdir(item.path))).map((x) => new internal_search_state_1.SearchState(path29.join(item.path, x), childLevel));
+              const childItems = (yield __await2(fs32.promises.readdir(item.path))).map((x) => new internal_search_state_1.SearchState(path30.join(item.path, x), childLevel));
               stack.push(...childItems.reverse());
             } else if (match2 & internal_match_kind_1.MatchKind.File) {
               yield yield __await2(item.path);
@@ -32725,7 +32725,7 @@ var require_internal_globber = __commonJS({
           let stats;
           if (options.followSymbolicLinks) {
             try {
-              stats = yield fs31.promises.stat(item.path);
+              stats = yield fs32.promises.stat(item.path);
             } catch (err) {
               if (err.code === "ENOENT") {
                 if (options.omitBrokenSymbolicLinks) {
@@ -32737,10 +32737,10 @@ var require_internal_globber = __commonJS({
               throw err;
             }
           } else {
-            stats = yield fs31.promises.lstat(item.path);
+            stats = yield fs32.promises.lstat(item.path);
           }
           if (stats.isDirectory() && options.followSymbolicLinks) {
-            const realPath = yield fs31.promises.realpath(item.path);
+            const realPath = yield fs32.promises.realpath(item.path);
             while (traversalChain.length >= item.level) {
               traversalChain.pop();
             }
@@ -32849,10 +32849,10 @@ var require_internal_hash_files = __commonJS({
     exports2.hashFiles = hashFiles2;
     var crypto3 = __importStar2(require("crypto"));
     var core31 = __importStar2(require_core());
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var stream2 = __importStar2(require("stream"));
     var util3 = __importStar2(require("util"));
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     function hashFiles2(globber_1, currentWorkspace_1) {
       return __awaiter2(this, arguments, void 0, function* (globber, currentWorkspace, verbose = false) {
         var _a2, e_1, _b, _c;
@@ -32868,17 +32868,17 @@ var require_internal_hash_files = __commonJS({
             _e = false;
             const file = _c;
             writeDelegate(file);
-            if (!file.startsWith(`${githubWorkspace}${path29.sep}`)) {
+            if (!file.startsWith(`${githubWorkspace}${path30.sep}`)) {
               writeDelegate(`Ignore '${file}' since it is not under GITHUB_WORKSPACE.`);
               continue;
             }
-            if (fs31.statSync(file).isDirectory()) {
+            if (fs32.statSync(file).isDirectory()) {
               writeDelegate(`Skip directory '${file}'.`);
               continue;
             }
             const hash2 = crypto3.createHash("sha256");
             const pipeline2 = util3.promisify(stream2.pipeline);
-            yield pipeline2(fs31.createReadStream(file), hash2);
+            yield pipeline2(fs32.createReadStream(file), hash2);
             result.write(hash2.digest());
             count++;
             if (!hasMatch) {
@@ -34254,8 +34254,8 @@ var require_cacheUtils = __commonJS({
     var glob2 = __importStar2(require_glob());
     var io9 = __importStar2(require_io());
     var crypto3 = __importStar2(require("crypto"));
-    var fs31 = __importStar2(require("fs"));
-    var path29 = __importStar2(require("path"));
+    var fs32 = __importStar2(require("fs"));
+    var path30 = __importStar2(require("path"));
     var semver11 = __importStar2(require_semver3());
     var util3 = __importStar2(require("util"));
     var constants_1 = require_constants7();
@@ -34275,15 +34275,15 @@ var require_cacheUtils = __commonJS({
               baseLocation = "/home";
             }
           }
-          tempDirectory = path29.join(baseLocation, "actions", "temp");
+          tempDirectory = path30.join(baseLocation, "actions", "temp");
         }
-        const dest = path29.join(tempDirectory, crypto3.randomUUID());
+        const dest = path30.join(tempDirectory, crypto3.randomUUID());
         yield io9.mkdirP(dest);
         return dest;
       });
     }
     function getArchiveFileSizeInBytes(filePath) {
-      return fs31.statSync(filePath).size;
+      return fs32.statSync(filePath).size;
     }
     function resolvePaths(patterns) {
       return __awaiter2(this, void 0, void 0, function* () {
@@ -34299,7 +34299,7 @@ var require_cacheUtils = __commonJS({
             _c = _g.value;
             _e = false;
             const file = _c;
-            const relativeFile = path29.relative(workspace, file).replace(new RegExp(`\\${path29.sep}`, "g"), "/");
+            const relativeFile = path30.relative(workspace, file).replace(new RegExp(`\\${path30.sep}`, "g"), "/");
             core31.debug(`Matched: ${relativeFile}`);
             if (relativeFile === "") {
               paths.push(".");
@@ -34321,7 +34321,7 @@ var require_cacheUtils = __commonJS({
     }
     function unlinkFile(filePath) {
       return __awaiter2(this, void 0, void 0, function* () {
-        return util3.promisify(fs31.unlink)(filePath);
+        return util3.promisify(fs32.unlink)(filePath);
       });
     }
     function getVersion(app_1) {
@@ -34363,7 +34363,7 @@ var require_cacheUtils = __commonJS({
     }
     function getGnuTarPathOnWindows() {
       return __awaiter2(this, void 0, void 0, function* () {
-        if (fs31.existsSync(constants_1.GnuTarPathOnWindows)) {
+        if (fs32.existsSync(constants_1.GnuTarPathOnWindows)) {
           return constants_1.GnuTarPathOnWindows;
         }
         const versionOutput = yield getVersion("tar");
@@ -34826,13 +34826,13 @@ function __disposeResources(env) {
   }
   return next();
 }
-function __rewriteRelativeImportExtension(path29, preserveJsx) {
-  if (typeof path29 === "string" && /^\.\.?\//.test(path29)) {
-    return path29.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+?)?)\.([cm]?)ts$/i, function(m, tsx, d, ext2, cm) {
+function __rewriteRelativeImportExtension(path30, preserveJsx) {
+  if (typeof path30 === "string" && /^\.\.?\//.test(path30)) {
+    return path30.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+?)?)\.([cm]?)ts$/i, function(m, tsx, d, ext2, cm) {
       return tsx ? preserveJsx ? ".jsx" : ".js" : d && (!ext2 || !cm) ? m : d + ext2 + "." + cm.toLowerCase() + "js";
     });
   }
-  return path29;
+  return path30;
 }
 var extendStatics, __assign, __createBinding, __setModuleDefault, ownKeys, _SuppressedError, tslib_es6_default;
 var init_tslib_es6 = __esm({
@@ -39246,8 +39246,8 @@ var require_getClient = __commonJS({
       }
       const { allowInsecureConnection, httpClient } = clientOptions;
       const endpointUrl = clientOptions.endpoint ?? endpoint2;
-      const client = (path29, ...args) => {
-        const getUrl = (requestOptions) => (0, urlHelpers_js_1.buildRequestUrl)(endpointUrl, path29, args, { allowInsecureConnection, ...requestOptions });
+      const client = (path30, ...args) => {
+        const getUrl = (requestOptions) => (0, urlHelpers_js_1.buildRequestUrl)(endpointUrl, path30, args, { allowInsecureConnection, ...requestOptions });
         return {
           get: (requestOptions = {}) => {
             return buildOperation("GET", getUrl(requestOptions), pipeline2, requestOptions, allowInsecureConnection, httpClient);
@@ -43118,15 +43118,15 @@ var require_urlHelpers2 = __commonJS({
       let isAbsolutePath = false;
       let requestUrl = replaceAll(baseUri, urlReplacements);
       if (operationSpec.path) {
-        let path29 = replaceAll(operationSpec.path, urlReplacements);
-        if (operationSpec.path === "/{nextLink}" && path29.startsWith("/")) {
-          path29 = path29.substring(1);
+        let path30 = replaceAll(operationSpec.path, urlReplacements);
+        if (operationSpec.path === "/{nextLink}" && path30.startsWith("/")) {
+          path30 = path30.substring(1);
         }
-        if (isAbsoluteUrl(path29)) {
-          requestUrl = path29;
+        if (isAbsoluteUrl(path30)) {
+          requestUrl = path30;
           isAbsolutePath = true;
         } else {
-          requestUrl = appendPath(requestUrl, path29);
+          requestUrl = appendPath(requestUrl, path30);
         }
       }
       const { queryParams, sequenceParams } = calculateQueryParameters(operationSpec, operationArguments, fallbackObject);
@@ -43172,9 +43172,9 @@ var require_urlHelpers2 = __commonJS({
       }
       const searchStart = pathToAppend.indexOf("?");
       if (searchStart !== -1) {
-        const path29 = pathToAppend.substring(0, searchStart);
+        const path30 = pathToAppend.substring(0, searchStart);
         const search = pathToAppend.substring(searchStart + 1);
-        newPath = newPath + path29;
+        newPath = newPath + path30;
         if (search) {
           parsedUrl.search = parsedUrl.search ? `${parsedUrl.search}&${search}` : search;
         }
@@ -46090,10 +46090,10 @@ var require_utils_common = __commonJS({
     var constants_js_1 = require_constants10();
     function escapeURLPath(url2) {
       const urlParsed = new URL(url2);
-      let path29 = urlParsed.pathname;
-      path29 = path29 || "/";
-      path29 = escape3(path29);
-      urlParsed.pathname = path29;
+      let path30 = urlParsed.pathname;
+      path30 = path30 || "/";
+      path30 = escape3(path30);
+      urlParsed.pathname = path30;
       return urlParsed.toString();
     }
     function getProxyUriFromDevConnString(connectionString) {
@@ -46178,9 +46178,9 @@ var require_utils_common = __commonJS({
     }
     function appendToURLPath(url2, name) {
       const urlParsed = new URL(url2);
-      let path29 = urlParsed.pathname;
-      path29 = path29 ? path29.endsWith("/") ? `${path29}${name}` : `${path29}/${name}` : name;
-      urlParsed.pathname = path29;
+      let path30 = urlParsed.pathname;
+      path30 = path30 ? path30.endsWith("/") ? `${path30}${name}` : `${path30}/${name}` : name;
+      urlParsed.pathname = path30;
       return urlParsed.toString();
     }
     function setURLParameter(url2, name, value) {
@@ -47407,9 +47407,9 @@ var require_StorageSharedKeyCredentialPolicy = __commonJS({
        * @param request -
        */
       getCanonicalizedResourceString(request3) {
-        const path29 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
+        const path30 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
         let canonicalizedResourceString = "";
-        canonicalizedResourceString += `/${this.factory.accountName}${path29}`;
+        canonicalizedResourceString += `/${this.factory.accountName}${path30}`;
         const queries = (0, utils_common_js_1.getURLQueries)(request3.url);
         const lowercaseQueries = {};
         if (queries) {
@@ -48148,10 +48148,10 @@ var require_utils_common2 = __commonJS({
     var constants_js_1 = require_constants11();
     function escapeURLPath(url2) {
       const urlParsed = new URL(url2);
-      let path29 = urlParsed.pathname;
-      path29 = path29 || "/";
-      path29 = escape3(path29);
-      urlParsed.pathname = path29;
+      let path30 = urlParsed.pathname;
+      path30 = path30 || "/";
+      path30 = escape3(path30);
+      urlParsed.pathname = path30;
       return urlParsed.toString();
     }
     function getProxyUriFromDevConnString(connectionString) {
@@ -48236,9 +48236,9 @@ var require_utils_common2 = __commonJS({
     }
     function appendToURLPath(url2, name) {
       const urlParsed = new URL(url2);
-      let path29 = urlParsed.pathname;
-      path29 = path29 ? path29.endsWith("/") ? `${path29}${name}` : `${path29}/${name}` : name;
-      urlParsed.pathname = path29;
+      let path30 = urlParsed.pathname;
+      path30 = path30 ? path30.endsWith("/") ? `${path30}${name}` : `${path30}/${name}` : name;
+      urlParsed.pathname = path30;
       return urlParsed.toString();
     }
     function setURLParameter(url2, name, value) {
@@ -49159,9 +49159,9 @@ var require_StorageSharedKeyCredentialPolicy2 = __commonJS({
        * @param request -
        */
       getCanonicalizedResourceString(request3) {
-        const path29 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
+        const path30 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
         let canonicalizedResourceString = "";
-        canonicalizedResourceString += `/${this.factory.accountName}${path29}`;
+        canonicalizedResourceString += `/${this.factory.accountName}${path30}`;
         const queries = (0, utils_common_js_1.getURLQueries)(request3.url);
         const lowercaseQueries = {};
         if (queries) {
@@ -49791,9 +49791,9 @@ var require_StorageSharedKeyCredentialPolicyV2 = __commonJS({
         return canonicalizedHeadersStringToSign;
       }
       function getCanonicalizedResourceString(request3) {
-        const path29 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
+        const path30 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
         let canonicalizedResourceString = "";
-        canonicalizedResourceString += `/${options.accountName}${path29}`;
+        canonicalizedResourceString += `/${options.accountName}${path30}`;
         const queries = (0, utils_common_js_1.getURLQueries)(request3.url);
         const lowercaseQueries = {};
         if (queries) {
@@ -50138,9 +50138,9 @@ var require_StorageSharedKeyCredentialPolicyV22 = __commonJS({
         return canonicalizedHeadersStringToSign;
       }
       function getCanonicalizedResourceString(request3) {
-        const path29 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
+        const path30 = (0, utils_common_js_1.getURLPath)(request3.url) || "/";
         let canonicalizedResourceString = "";
-        canonicalizedResourceString += `/${options.accountName}${path29}`;
+        canonicalizedResourceString += `/${options.accountName}${path30}`;
         const queries = (0, utils_common_js_1.getURLQueries)(request3.url);
         const lowercaseQueries = {};
         if (queries) {
@@ -71795,8 +71795,8 @@ var require_BlobBatch = __commonJS({
         if (this.operationCount >= constants_js_1.BATCH_MAX_REQUEST) {
           throw new RangeError(`Cannot exceed ${constants_js_1.BATCH_MAX_REQUEST} sub requests in a single batch`);
         }
-        const path29 = (0, utils_common_js_1.getURLPath)(subRequest.url);
-        if (!path29 || path29 === "") {
+        const path30 = (0, utils_common_js_1.getURLPath)(subRequest.url);
+        if (!path30 || path30 === "") {
           throw new RangeError(`Invalid url for sub request: '${subRequest.url}'`);
         }
       }
@@ -71874,8 +71874,8 @@ var require_BlobBatchClient = __commonJS({
           pipeline2 = (0, Pipeline_js_1.newPipeline)(credentialOrPipeline, options);
         }
         const storageClientContext = new StorageContextClient_js_1.StorageContextClient(url2, (0, Pipeline_js_1.getCoreClientOptions)(pipeline2));
-        const path29 = (0, utils_common_js_1.getURLPath)(url2);
-        if (path29 && path29 !== "/") {
+        const path30 = (0, utils_common_js_1.getURLPath)(url2);
+        if (path30 && path30 !== "/") {
           this.serviceOrContainerContext = storageClientContext.container;
         } else {
           this.serviceOrContainerContext = storageClientContext.service;
@@ -75162,7 +75162,7 @@ var require_downloadUtils = __commonJS({
     var http_client_1 = require_lib();
     var storage_blob_1 = require_commonjs15();
     var buffer = __importStar2(require("buffer"));
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var stream2 = __importStar2(require("stream"));
     var util3 = __importStar2(require("util"));
     var utils = __importStar2(require_cacheUtils());
@@ -75273,7 +75273,7 @@ var require_downloadUtils = __commonJS({
     exports2.DownloadProgress = DownloadProgress;
     function downloadCacheHttpClient(archiveLocation, archivePath) {
       return __awaiter2(this, void 0, void 0, function* () {
-        const writeStream = fs31.createWriteStream(archivePath);
+        const writeStream = fs32.createWriteStream(archivePath);
         const httpClient = new http_client_1.HttpClient("actions/cache");
         const downloadResponse = yield (0, requestUtils_1.retryHttpClientResponse)("downloadCache", () => __awaiter2(this, void 0, void 0, function* () {
           return httpClient.get(archiveLocation);
@@ -75298,7 +75298,7 @@ var require_downloadUtils = __commonJS({
     function downloadCacheHttpClientConcurrent(archiveLocation, archivePath, options) {
       return __awaiter2(this, void 0, void 0, function* () {
         var _a2;
-        const archiveDescriptor = yield fs31.promises.open(archivePath, "w");
+        const archiveDescriptor = yield fs32.promises.open(archivePath, "w");
         const httpClient = new http_client_1.HttpClient("actions/cache", void 0, {
           socketTimeout: options.timeoutInMs,
           keepAlive: true
@@ -75414,7 +75414,7 @@ var require_downloadUtils = __commonJS({
         } else {
           const maxSegmentSize = Math.min(134217728, buffer.constants.MAX_LENGTH);
           const downloadProgress = new DownloadProgress(contentLength);
-          const fd = fs31.openSync(archivePath, "w");
+          const fd = fs32.openSync(archivePath, "w");
           try {
             downloadProgress.startDisplayTimer();
             const controller = new abort_controller_1.AbortController();
@@ -75432,12 +75432,12 @@ var require_downloadUtils = __commonJS({
                 controller.abort();
                 throw new Error("Aborting cache download as the download time exceeded the timeout.");
               } else if (Buffer.isBuffer(result)) {
-                fs31.writeFileSync(fd, result);
+                fs32.writeFileSync(fd, result);
               }
             }
           } finally {
             downloadProgress.stopDisplayTimer();
-            fs31.closeSync(fd);
+            fs32.closeSync(fd);
           }
         }
       });
@@ -75776,7 +75776,7 @@ var require_cacheHttpClient = __commonJS({
     var core31 = __importStar2(require_core());
     var http_client_1 = require_lib();
     var auth_1 = require_auth();
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var url_1 = require("url");
     var utils = __importStar2(require_cacheUtils());
     var uploadUtils_1 = require_uploadUtils();
@@ -75917,7 +75917,7 @@ Other caches with similar key:`);
       return __awaiter2(this, void 0, void 0, function* () {
         const fileSize = utils.getArchiveFileSizeInBytes(archivePath);
         const resourceUrl = getCacheApiUrl(`caches/${cacheId.toString()}`);
-        const fd = fs31.openSync(archivePath, "r");
+        const fd = fs32.openSync(archivePath, "r");
         const uploadOptions = (0, options_1.getUploadOptions)(options);
         const concurrency = utils.assertDefined("uploadConcurrency", uploadOptions.uploadConcurrency);
         const maxChunkSize = utils.assertDefined("uploadChunkSize", uploadOptions.uploadChunkSize);
@@ -75931,7 +75931,7 @@ Other caches with similar key:`);
               const start = offset;
               const end = offset + chunkSize - 1;
               offset += maxChunkSize;
-              yield uploadChunk(httpClient, resourceUrl, () => fs31.createReadStream(archivePath, {
+              yield uploadChunk(httpClient, resourceUrl, () => fs32.createReadStream(archivePath, {
                 fd,
                 start,
                 end,
@@ -75942,7 +75942,7 @@ Other caches with similar key:`);
             }
           })));
         } finally {
-          fs31.closeSync(fd);
+          fs32.closeSync(fd);
         }
         return;
       });
@@ -81207,7 +81207,7 @@ var require_tar = __commonJS({
     var exec_1 = require_exec();
     var io9 = __importStar2(require_io());
     var fs_1 = require("fs");
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var utils = __importStar2(require_cacheUtils());
     var constants_1 = require_constants7();
     var IS_WINDOWS = process.platform === "win32";
@@ -81253,13 +81253,13 @@ var require_tar = __commonJS({
         const BSD_TAR_ZSTD = tarPath.type === constants_1.ArchiveToolType.BSD && compressionMethod !== constants_1.CompressionMethod.Gzip && IS_WINDOWS;
         switch (type) {
           case "create":
-            args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path29.sep}`, "g"), "/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path29.sep}`, "g"), "/"), "-P", "-C", workingDirectory.replace(new RegExp(`\\${path29.sep}`, "g"), "/"), "--files-from", constants_1.ManifestFilename);
+            args.push("--posix", "-cf", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path30.sep}`, "g"), "/"), "--exclude", BSD_TAR_ZSTD ? tarFile : cacheFileName.replace(new RegExp(`\\${path30.sep}`, "g"), "/"), "-P", "-C", workingDirectory.replace(new RegExp(`\\${path30.sep}`, "g"), "/"), "--files-from", constants_1.ManifestFilename);
             break;
           case "extract":
-            args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path29.sep}`, "g"), "/"), "-P", "-C", workingDirectory.replace(new RegExp(`\\${path29.sep}`, "g"), "/"));
+            args.push("-xf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path30.sep}`, "g"), "/"), "-P", "-C", workingDirectory.replace(new RegExp(`\\${path30.sep}`, "g"), "/"));
             break;
           case "list":
-            args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path29.sep}`, "g"), "/"), "-P");
+            args.push("-tf", BSD_TAR_ZSTD ? tarFile : archivePath.replace(new RegExp(`\\${path30.sep}`, "g"), "/"), "-P");
             break;
         }
         if (tarPath.type === constants_1.ArchiveToolType.GNU) {
@@ -81305,7 +81305,7 @@ var require_tar = __commonJS({
             return BSD_TAR_ZSTD ? [
               "zstd -d --long=30 --force -o",
               constants_1.TarFilename,
-              archivePath.replace(new RegExp(`\\${path29.sep}`, "g"), "/")
+              archivePath.replace(new RegExp(`\\${path30.sep}`, "g"), "/")
             ] : [
               "--use-compress-program",
               IS_WINDOWS ? '"zstd -d --long=30"' : "unzstd --long=30"
@@ -81314,7 +81314,7 @@ var require_tar = __commonJS({
             return BSD_TAR_ZSTD ? [
               "zstd -d --force -o",
               constants_1.TarFilename,
-              archivePath.replace(new RegExp(`\\${path29.sep}`, "g"), "/")
+              archivePath.replace(new RegExp(`\\${path30.sep}`, "g"), "/")
             ] : ["--use-compress-program", IS_WINDOWS ? '"zstd -d"' : "unzstd"];
           default:
             return ["-z"];
@@ -81329,7 +81329,7 @@ var require_tar = __commonJS({
           case constants_1.CompressionMethod.Zstd:
             return BSD_TAR_ZSTD ? [
               "zstd -T0 --long=30 --force -o",
-              cacheFileName.replace(new RegExp(`\\${path29.sep}`, "g"), "/"),
+              cacheFileName.replace(new RegExp(`\\${path30.sep}`, "g"), "/"),
               constants_1.TarFilename
             ] : [
               "--use-compress-program",
@@ -81338,7 +81338,7 @@ var require_tar = __commonJS({
           case constants_1.CompressionMethod.ZstdWithoutLong:
             return BSD_TAR_ZSTD ? [
               "zstd -T0 --force -o",
-              cacheFileName.replace(new RegExp(`\\${path29.sep}`, "g"), "/"),
+              cacheFileName.replace(new RegExp(`\\${path30.sep}`, "g"), "/"),
               constants_1.TarFilename
             ] : ["--use-compress-program", IS_WINDOWS ? '"zstd -T0"' : "zstdmt"];
           default:
@@ -81376,7 +81376,7 @@ var require_tar = __commonJS({
     }
     function createTar(archiveFolder, sourceDirectories, compressionMethod) {
       return __awaiter2(this, void 0, void 0, function* () {
-        (0, fs_1.writeFileSync)(path29.join(archiveFolder, constants_1.ManifestFilename), sourceDirectories.join("\n"));
+        (0, fs_1.writeFileSync)(path30.join(archiveFolder, constants_1.ManifestFilename), sourceDirectories.join("\n"));
         const commands = yield getCommands(compressionMethod, "create");
         yield execCommands(commands, archiveFolder);
       });
@@ -81458,7 +81458,7 @@ var require_cache4 = __commonJS({
     exports2.restoreCache = restoreCache5;
     exports2.saveCache = saveCache5;
     var core31 = __importStar2(require_core());
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var utils = __importStar2(require_cacheUtils());
     var cacheHttpClient = __importStar2(require_cacheHttpClient());
     var cacheTwirpClient = __importStar2(require_cacheTwirpClient());
@@ -81588,7 +81588,7 @@ var require_cache4 = __commonJS({
             core31.info("Lookup only - skipping download");
             return cacheEntry.cacheKey;
           }
-          archivePath = path29.join(yield utils.createTempDirectory(), utils.getCacheFileName(compressionMethod));
+          archivePath = path30.join(yield utils.createTempDirectory(), utils.getCacheFileName(compressionMethod));
           core31.debug(`Archive Path: ${archivePath}`);
           yield cacheHttpClient.downloadCache(cacheEntry.archiveLocation, archivePath, options);
           if (core31.isDebug()) {
@@ -81667,7 +81667,7 @@ var require_cache4 = __commonJS({
             core31.info("Lookup only - skipping download");
             return response.matchedKey;
           }
-          archivePath = path29.join(yield utils.createTempDirectory(), utils.getCacheFileName(compressionMethod));
+          archivePath = path30.join(yield utils.createTempDirectory(), utils.getCacheFileName(compressionMethod));
           core31.debug(`Archive path: ${archivePath}`);
           core31.debug(`Starting download of archive to: ${archivePath}`);
           yield cacheHttpClient.downloadCache(response.signedDownloadUrl, archivePath, options);
@@ -81735,7 +81735,7 @@ var require_cache4 = __commonJS({
           throw new Error(`Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`);
         }
         const archiveFolder = yield utils.createTempDirectory();
-        const archivePath = path29.join(archiveFolder, utils.getCacheFileName(compressionMethod));
+        const archivePath = path30.join(archiveFolder, utils.getCacheFileName(compressionMethod));
         core31.debug(`Archive Path: ${archivePath}`);
         try {
           yield (0, tar_1.createTar)(archiveFolder, cachePaths, compressionMethod);
@@ -81806,7 +81806,7 @@ var require_cache4 = __commonJS({
           throw new Error(`Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`);
         }
         const archiveFolder = yield utils.createTempDirectory();
-        const archivePath = path29.join(archiveFolder, utils.getCacheFileName(compressionMethod));
+        const archivePath = path30.join(archiveFolder, utils.getCacheFileName(compressionMethod));
         core31.debug(`Archive Path: ${archivePath}`);
         try {
           yield (0, tar_1.createTar)(archiveFolder, cachePaths, compressionMethod);
@@ -81962,7 +81962,7 @@ var require_manifest = __commonJS({
     var core_1 = require_core();
     var os7 = require("os");
     var cp = require("child_process");
-    var fs31 = require("fs");
+    var fs32 = require("fs");
     function _findMatch(versionSpec, stable, candidates, archFilter) {
       return __awaiter2(this, void 0, void 0, function* () {
         const platFilter = os7.platform();
@@ -82024,10 +82024,10 @@ var require_manifest = __commonJS({
       const lsbReleaseFile = "/etc/lsb-release";
       const osReleaseFile = "/etc/os-release";
       let contents = "";
-      if (fs31.existsSync(lsbReleaseFile)) {
-        contents = fs31.readFileSync(lsbReleaseFile).toString();
-      } else if (fs31.existsSync(osReleaseFile)) {
-        contents = fs31.readFileSync(osReleaseFile).toString();
+      if (fs32.existsSync(lsbReleaseFile)) {
+        contents = fs32.readFileSync(lsbReleaseFile).toString();
+      } else if (fs32.existsSync(osReleaseFile)) {
+        contents = fs32.readFileSync(osReleaseFile).toString();
       }
       return contents;
     }
@@ -82236,10 +82236,10 @@ var require_tool_cache = __commonJS({
     var core31 = __importStar2(require_core());
     var io9 = __importStar2(require_io());
     var crypto3 = __importStar2(require("crypto"));
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var mm = __importStar2(require_manifest());
     var os7 = __importStar2(require("os"));
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var httpm = __importStar2(require_lib());
     var semver11 = __importStar2(require_semver2());
     var stream2 = __importStar2(require("stream"));
@@ -82260,8 +82260,8 @@ var require_tool_cache = __commonJS({
     var userAgent2 = "actions/tool-cache";
     function downloadTool3(url2, dest, auth2, headers) {
       return __awaiter2(this, void 0, void 0, function* () {
-        dest = dest || path29.join(_getTempDirectory(), crypto3.randomUUID());
-        yield io9.mkdirP(path29.dirname(dest));
+        dest = dest || path30.join(_getTempDirectory(), crypto3.randomUUID());
+        yield io9.mkdirP(path30.dirname(dest));
         core31.debug(`Downloading ${url2}`);
         core31.debug(`Destination ${dest}`);
         const maxAttempts = 3;
@@ -82282,7 +82282,7 @@ var require_tool_cache = __commonJS({
     }
     function downloadToolAttempt(url2, dest, auth2, headers) {
       return __awaiter2(this, void 0, void 0, function* () {
-        if (fs31.existsSync(dest)) {
+        if (fs32.existsSync(dest)) {
           throw new Error(`Destination file path ${dest} already exists`);
         }
         const http = new httpm.HttpClient(userAgent2, [], {
@@ -82306,7 +82306,7 @@ var require_tool_cache = __commonJS({
         const readStream = responseMessageFactory();
         let succeeded = false;
         try {
-          yield pipeline2(readStream, fs31.createWriteStream(dest));
+          yield pipeline2(readStream, fs32.createWriteStream(dest));
           core31.debug("download complete");
           succeeded = true;
           return dest;
@@ -82351,7 +82351,7 @@ var require_tool_cache = __commonJS({
             process.chdir(originalCwd);
           }
         } else {
-          const escapedScript = path29.join(__dirname, "..", "scripts", "Invoke-7zdec.ps1").replace(/'/g, "''").replace(/"|\n|\r/g, "");
+          const escapedScript = path30.join(__dirname, "..", "scripts", "Invoke-7zdec.ps1").replace(/'/g, "''").replace(/"|\n|\r/g, "");
           const escapedFile = file.replace(/'/g, "''").replace(/"|\n|\r/g, "");
           const escapedTarget = dest.replace(/'/g, "''").replace(/"|\n|\r/g, "");
           const command = `& '${escapedScript}' -Source '${escapedFile}' -Target '${escapedTarget}'`;
@@ -82518,12 +82518,12 @@ var require_tool_cache = __commonJS({
         arch2 = arch2 || os7.arch();
         core31.debug(`Caching tool ${tool} ${version} ${arch2}`);
         core31.debug(`source dir: ${sourceDir}`);
-        if (!fs31.statSync(sourceDir).isDirectory()) {
+        if (!fs32.statSync(sourceDir).isDirectory()) {
           throw new Error("sourceDir is not a directory");
         }
         const destPath = yield _createToolPath(tool, version, arch2);
-        for (const itemName of fs31.readdirSync(sourceDir)) {
-          const s = path29.join(sourceDir, itemName);
+        for (const itemName of fs32.readdirSync(sourceDir)) {
+          const s = path30.join(sourceDir, itemName);
           yield io9.cp(s, destPath, { recursive: true });
         }
         _completeToolPath(tool, version, arch2);
@@ -82536,11 +82536,11 @@ var require_tool_cache = __commonJS({
         arch2 = arch2 || os7.arch();
         core31.debug(`Caching tool ${tool} ${version} ${arch2}`);
         core31.debug(`source file: ${sourceFile}`);
-        if (!fs31.statSync(sourceFile).isFile()) {
+        if (!fs32.statSync(sourceFile).isFile()) {
           throw new Error("sourceFile is not a file");
         }
         const destFolder = yield _createToolPath(tool, version, arch2);
-        const destPath = path29.join(destFolder, targetFile);
+        const destPath = path30.join(destFolder, targetFile);
         core31.debug(`destination file ${destPath}`);
         yield io9.cp(sourceFile, destPath);
         _completeToolPath(tool, version, arch2);
@@ -82563,9 +82563,9 @@ var require_tool_cache = __commonJS({
       let toolPath = "";
       if (versionSpec) {
         versionSpec = semver11.clean(versionSpec) || "";
-        const cachePath = path29.join(_getCacheDirectory(), toolName, versionSpec, arch2);
+        const cachePath = path30.join(_getCacheDirectory(), toolName, versionSpec, arch2);
         core31.debug(`checking cache: ${cachePath}`);
-        if (fs31.existsSync(cachePath) && fs31.existsSync(`${cachePath}.complete`)) {
+        if (fs32.existsSync(cachePath) && fs32.existsSync(`${cachePath}.complete`)) {
           core31.debug(`Found tool in cache ${toolName} ${versionSpec} ${arch2}`);
           toolPath = cachePath;
         } else {
@@ -82577,13 +82577,13 @@ var require_tool_cache = __commonJS({
     function findAllVersions2(toolName, arch2) {
       const versions = [];
       arch2 = arch2 || os7.arch();
-      const toolPath = path29.join(_getCacheDirectory(), toolName);
-      if (fs31.existsSync(toolPath)) {
-        const children = fs31.readdirSync(toolPath);
+      const toolPath = path30.join(_getCacheDirectory(), toolName);
+      if (fs32.existsSync(toolPath)) {
+        const children = fs32.readdirSync(toolPath);
         for (const child of children) {
           if (isExplicitVersion(child)) {
-            const fullPath = path29.join(toolPath, child, arch2 || "");
-            if (fs31.existsSync(fullPath) && fs31.existsSync(`${fullPath}.complete`)) {
+            const fullPath = path30.join(toolPath, child, arch2 || "");
+            if (fs32.existsSync(fullPath) && fs32.existsSync(`${fullPath}.complete`)) {
               versions.push(child);
             }
           }
@@ -82634,7 +82634,7 @@ var require_tool_cache = __commonJS({
     function _createExtractFolder(dest) {
       return __awaiter2(this, void 0, void 0, function* () {
         if (!dest) {
-          dest = path29.join(_getTempDirectory(), crypto3.randomUUID());
+          dest = path30.join(_getTempDirectory(), crypto3.randomUUID());
         }
         yield io9.mkdirP(dest);
         return dest;
@@ -82642,7 +82642,7 @@ var require_tool_cache = __commonJS({
     }
     function _createToolPath(tool, version, arch2) {
       return __awaiter2(this, void 0, void 0, function* () {
-        const folderPath = path29.join(_getCacheDirectory(), tool, semver11.clean(version) || version, arch2 || "");
+        const folderPath = path30.join(_getCacheDirectory(), tool, semver11.clean(version) || version, arch2 || "");
         core31.debug(`destination ${folderPath}`);
         const markerPath = `${folderPath}.complete`;
         yield io9.rmRF(folderPath);
@@ -82652,9 +82652,9 @@ var require_tool_cache = __commonJS({
       });
     }
     function _completeToolPath(tool, version, arch2) {
-      const folderPath = path29.join(_getCacheDirectory(), tool, semver11.clean(version) || version, arch2 || "");
+      const folderPath = path30.join(_getCacheDirectory(), tool, semver11.clean(version) || version, arch2 || "");
       const markerPath = `${folderPath}.complete`;
-      fs31.writeFileSync(markerPath, "");
+      fs32.writeFileSync(markerPath, "");
       core31.debug("finished caching tool");
     }
     function isExplicitVersion(versionSpec) {
@@ -88345,13 +88345,13 @@ These characters are not allowed in the artifact name due to limitations with ce
       (0, core_1.info)(`Artifact name is valid!`);
     }
     exports2.validateArtifactName = validateArtifactName;
-    function validateFilePath(path29) {
-      if (!path29) {
+    function validateFilePath(path30) {
+      if (!path30) {
         throw new Error(`Provided file path input during validation is empty`);
       }
       for (const [invalidCharacterKey, errorMessageForCharacter] of invalidArtifactFilePathCharacters) {
-        if (path29.includes(invalidCharacterKey)) {
-          throw new Error(`The path for one of the files in artifact is not valid: ${path29}. Contains the following character: ${errorMessageForCharacter}
+        if (path30.includes(invalidCharacterKey)) {
+          throw new Error(`The path for one of the files in artifact is not valid: ${path30}. Contains the following character: ${errorMessageForCharacter}
           
 Invalid characters include: ${Array.from(invalidArtifactFilePathCharacters.values()).toString()}
           
@@ -88896,15 +88896,15 @@ var require_upload_zip_specification = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getUploadZipSpecification = exports2.validateRootDirectory = void 0;
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var core_1 = require_core();
     var path_1 = require("path");
     var path_and_artifact_name_validation_1 = require_path_and_artifact_name_validation();
     function validateRootDirectory(rootDirectory) {
-      if (!fs31.existsSync(rootDirectory)) {
+      if (!fs32.existsSync(rootDirectory)) {
         throw new Error(`The provided rootDirectory ${rootDirectory} does not exist`);
       }
-      if (!fs31.statSync(rootDirectory).isDirectory()) {
+      if (!fs32.statSync(rootDirectory).isDirectory()) {
         throw new Error(`The provided rootDirectory ${rootDirectory} is not a valid directory`);
       }
       (0, core_1.info)(`Root directory input is valid!`);
@@ -88915,7 +88915,7 @@ var require_upload_zip_specification = __commonJS({
       rootDirectory = (0, path_1.normalize)(rootDirectory);
       rootDirectory = (0, path_1.resolve)(rootDirectory);
       for (let file of filesToZip) {
-        const stats = fs31.lstatSync(file, { throwIfNoEntry: false });
+        const stats = fs32.lstatSync(file, { throwIfNoEntry: false });
         if (!stats) {
           throw new Error(`File ${file} does not exist`);
         }
@@ -89324,8 +89324,8 @@ var require_minimatch2 = __commonJS({
       return new Minimatch2(pattern, options).match(p);
     };
     module2.exports = minimatch2;
-    var path29 = require_path();
-    minimatch2.sep = path29.sep;
+    var path30 = require_path();
+    minimatch2.sep = path30.sep;
     var GLOBSTAR2 = /* @__PURE__ */ Symbol("globstar **");
     minimatch2.GLOBSTAR = GLOBSTAR2;
     var expand3 = require_brace_expansion2();
@@ -89931,8 +89931,8 @@ var require_minimatch2 = __commonJS({
         if (this.empty) return f === "";
         if (f === "/" && partial) return true;
         const options = this.options;
-        if (path29.sep !== "/") {
-          f = f.split(path29.sep).join("/");
+        if (path30.sep !== "/") {
+          f = f.split(path30.sep).join("/");
         }
         f = f.split(slashSplit);
         this.debug(this.pattern, "split", f);
@@ -89970,13 +89970,13 @@ var require_minimatch2 = __commonJS({
 var require_readdir_glob = __commonJS({
   "node_modules/@actions/artifact/node_modules/readdir-glob/index.js"(exports2, module2) {
     module2.exports = readdirGlob2;
-    var fs31 = require("fs");
+    var fs32 = require("fs");
     var { EventEmitter: EventEmitter2 } = require("events");
     var { Minimatch: Minimatch2 } = require_minimatch2();
     var { resolve: resolve14 } = require("path");
     function readdir3(dir, strict) {
       return new Promise((resolve15, reject) => {
-        fs31.readdir(dir, { withFileTypes: true }, (err, files) => {
+        fs32.readdir(dir, { withFileTypes: true }, (err, files) => {
           if (err) {
             switch (err.code) {
               case "ENOTDIR":
@@ -90009,7 +90009,7 @@ var require_readdir_glob = __commonJS({
     }
     function stat2(file, followSymlinks) {
       return new Promise((resolve15, reject) => {
-        const statFunc = followSymlinks ? fs31.stat : fs31.lstat;
+        const statFunc = followSymlinks ? fs32.stat : fs32.lstat;
         statFunc(file, (err, stats) => {
           if (err) {
             switch (err.code) {
@@ -90030,8 +90030,8 @@ var require_readdir_glob = __commonJS({
         });
       });
     }
-    async function* exploreWalkAsync2(dir, path29, followSymlinks, useStat, shouldSkip, strict) {
-      let files = await readdir3(path29 + dir, strict);
+    async function* exploreWalkAsync2(dir, path30, followSymlinks, useStat, shouldSkip, strict) {
+      let files = await readdir3(path30 + dir, strict);
       for (const file of files) {
         let name = file.name;
         if (name === void 0) {
@@ -90040,7 +90040,7 @@ var require_readdir_glob = __commonJS({
         }
         const filename = dir + "/" + name;
         const relative3 = filename.slice(1);
-        const absolute = path29 + "/" + relative3;
+        const absolute = path30 + "/" + relative3;
         let stats = null;
         if (useStat || followSymlinks) {
           stats = await stat2(absolute, followSymlinks);
@@ -90054,15 +90054,15 @@ var require_readdir_glob = __commonJS({
         if (stats.isDirectory()) {
           if (!shouldSkip(relative3)) {
             yield { relative: relative3, absolute, stats };
-            yield* exploreWalkAsync2(filename, path29, followSymlinks, useStat, shouldSkip, false);
+            yield* exploreWalkAsync2(filename, path30, followSymlinks, useStat, shouldSkip, false);
           }
         } else {
           yield { relative: relative3, absolute, stats };
         }
       }
     }
-    async function* explore2(path29, followSymlinks, useStat, shouldSkip) {
-      yield* exploreWalkAsync2("", path29, followSymlinks, useStat, shouldSkip, true);
+    async function* explore2(path30, followSymlinks, useStat, shouldSkip) {
+      yield* exploreWalkAsync2("", path30, followSymlinks, useStat, shouldSkip, true);
     }
     function readOptions2(options) {
       return {
@@ -92074,54 +92074,54 @@ var require_polyfills = __commonJS({
     }
     var chdir;
     module2.exports = patch;
-    function patch(fs31) {
+    function patch(fs32) {
       if (constants.hasOwnProperty("O_SYMLINK") && process.version.match(/^v0\.6\.[0-2]|^v0\.5\./)) {
-        patchLchmod(fs31);
+        patchLchmod(fs32);
       }
-      if (!fs31.lutimes) {
-        patchLutimes(fs31);
+      if (!fs32.lutimes) {
+        patchLutimes(fs32);
       }
-      fs31.chown = chownFix(fs31.chown);
-      fs31.fchown = chownFix(fs31.fchown);
-      fs31.lchown = chownFix(fs31.lchown);
-      fs31.chmod = chmodFix(fs31.chmod);
-      fs31.fchmod = chmodFix(fs31.fchmod);
-      fs31.lchmod = chmodFix(fs31.lchmod);
-      fs31.chownSync = chownFixSync(fs31.chownSync);
-      fs31.fchownSync = chownFixSync(fs31.fchownSync);
-      fs31.lchownSync = chownFixSync(fs31.lchownSync);
-      fs31.chmodSync = chmodFixSync(fs31.chmodSync);
-      fs31.fchmodSync = chmodFixSync(fs31.fchmodSync);
-      fs31.lchmodSync = chmodFixSync(fs31.lchmodSync);
-      fs31.stat = statFix(fs31.stat);
-      fs31.fstat = statFix(fs31.fstat);
-      fs31.lstat = statFix(fs31.lstat);
-      fs31.statSync = statFixSync(fs31.statSync);
-      fs31.fstatSync = statFixSync(fs31.fstatSync);
-      fs31.lstatSync = statFixSync(fs31.lstatSync);
-      if (fs31.chmod && !fs31.lchmod) {
-        fs31.lchmod = function(path29, mode, cb) {
+      fs32.chown = chownFix(fs32.chown);
+      fs32.fchown = chownFix(fs32.fchown);
+      fs32.lchown = chownFix(fs32.lchown);
+      fs32.chmod = chmodFix(fs32.chmod);
+      fs32.fchmod = chmodFix(fs32.fchmod);
+      fs32.lchmod = chmodFix(fs32.lchmod);
+      fs32.chownSync = chownFixSync(fs32.chownSync);
+      fs32.fchownSync = chownFixSync(fs32.fchownSync);
+      fs32.lchownSync = chownFixSync(fs32.lchownSync);
+      fs32.chmodSync = chmodFixSync(fs32.chmodSync);
+      fs32.fchmodSync = chmodFixSync(fs32.fchmodSync);
+      fs32.lchmodSync = chmodFixSync(fs32.lchmodSync);
+      fs32.stat = statFix(fs32.stat);
+      fs32.fstat = statFix(fs32.fstat);
+      fs32.lstat = statFix(fs32.lstat);
+      fs32.statSync = statFixSync(fs32.statSync);
+      fs32.fstatSync = statFixSync(fs32.fstatSync);
+      fs32.lstatSync = statFixSync(fs32.lstatSync);
+      if (fs32.chmod && !fs32.lchmod) {
+        fs32.lchmod = function(path30, mode, cb) {
           if (cb) process.nextTick(cb);
         };
-        fs31.lchmodSync = function() {
+        fs32.lchmodSync = function() {
         };
       }
-      if (fs31.chown && !fs31.lchown) {
-        fs31.lchown = function(path29, uid, gid, cb) {
+      if (fs32.chown && !fs32.lchown) {
+        fs32.lchown = function(path30, uid, gid, cb) {
           if (cb) process.nextTick(cb);
         };
-        fs31.lchownSync = function() {
+        fs32.lchownSync = function() {
         };
       }
       if (platform2 === "win32") {
-        fs31.rename = typeof fs31.rename !== "function" ? fs31.rename : (function(fs$rename) {
+        fs32.rename = typeof fs32.rename !== "function" ? fs32.rename : (function(fs$rename) {
           function rename(from, to, cb) {
             var start = Date.now();
             var backoff = 0;
             fs$rename(from, to, function CB(er) {
               if (er && (er.code === "EACCES" || er.code === "EPERM") && Date.now() - start < 6e4) {
                 setTimeout(function() {
-                  fs31.stat(to, function(stater, st) {
+                  fs32.stat(to, function(stater, st) {
                     if (stater && stater.code === "ENOENT")
                       fs$rename(from, to, CB);
                     else
@@ -92137,9 +92137,9 @@ var require_polyfills = __commonJS({
           }
           if (Object.setPrototypeOf) Object.setPrototypeOf(rename, fs$rename);
           return rename;
-        })(fs31.rename);
+        })(fs32.rename);
       }
-      fs31.read = typeof fs31.read !== "function" ? fs31.read : (function(fs$read) {
+      fs32.read = typeof fs32.read !== "function" ? fs32.read : (function(fs$read) {
         function read(fd, buffer, offset, length, position, callback_) {
           var callback;
           if (callback_ && typeof callback_ === "function") {
@@ -92147,22 +92147,22 @@ var require_polyfills = __commonJS({
             callback = function(er, _2, __) {
               if (er && er.code === "EAGAIN" && eagCounter < 10) {
                 eagCounter++;
-                return fs$read.call(fs31, fd, buffer, offset, length, position, callback);
+                return fs$read.call(fs32, fd, buffer, offset, length, position, callback);
               }
               callback_.apply(this, arguments);
             };
           }
-          return fs$read.call(fs31, fd, buffer, offset, length, position, callback);
+          return fs$read.call(fs32, fd, buffer, offset, length, position, callback);
         }
         if (Object.setPrototypeOf) Object.setPrototypeOf(read, fs$read);
         return read;
-      })(fs31.read);
-      fs31.readSync = typeof fs31.readSync !== "function" ? fs31.readSync : /* @__PURE__ */ (function(fs$readSync) {
+      })(fs32.read);
+      fs32.readSync = typeof fs32.readSync !== "function" ? fs32.readSync : /* @__PURE__ */ (function(fs$readSync) {
         return function(fd, buffer, offset, length, position) {
           var eagCounter = 0;
           while (true) {
             try {
-              return fs$readSync.call(fs31, fd, buffer, offset, length, position);
+              return fs$readSync.call(fs32, fd, buffer, offset, length, position);
             } catch (er) {
               if (er.code === "EAGAIN" && eagCounter < 10) {
                 eagCounter++;
@@ -92172,11 +92172,11 @@ var require_polyfills = __commonJS({
             }
           }
         };
-      })(fs31.readSync);
-      function patchLchmod(fs32) {
-        fs32.lchmod = function(path29, mode, callback) {
-          fs32.open(
-            path29,
+      })(fs32.readSync);
+      function patchLchmod(fs33) {
+        fs33.lchmod = function(path30, mode, callback) {
+          fs33.open(
+            path30,
             constants.O_WRONLY | constants.O_SYMLINK,
             mode,
             function(err, fd) {
@@ -92184,80 +92184,80 @@ var require_polyfills = __commonJS({
                 if (callback) callback(err);
                 return;
               }
-              fs32.fchmod(fd, mode, function(err2) {
-                fs32.close(fd, function(err22) {
+              fs33.fchmod(fd, mode, function(err2) {
+                fs33.close(fd, function(err22) {
                   if (callback) callback(err2 || err22);
                 });
               });
             }
           );
         };
-        fs32.lchmodSync = function(path29, mode) {
-          var fd = fs32.openSync(path29, constants.O_WRONLY | constants.O_SYMLINK, mode);
+        fs33.lchmodSync = function(path30, mode) {
+          var fd = fs33.openSync(path30, constants.O_WRONLY | constants.O_SYMLINK, mode);
           var threw = true;
           var ret;
           try {
-            ret = fs32.fchmodSync(fd, mode);
+            ret = fs33.fchmodSync(fd, mode);
             threw = false;
           } finally {
             if (threw) {
               try {
-                fs32.closeSync(fd);
+                fs33.closeSync(fd);
               } catch (er) {
               }
             } else {
-              fs32.closeSync(fd);
+              fs33.closeSync(fd);
             }
           }
           return ret;
         };
       }
-      function patchLutimes(fs32) {
-        if (constants.hasOwnProperty("O_SYMLINK") && fs32.futimes) {
-          fs32.lutimes = function(path29, at, mt, cb) {
-            fs32.open(path29, constants.O_SYMLINK, function(er, fd) {
+      function patchLutimes(fs33) {
+        if (constants.hasOwnProperty("O_SYMLINK") && fs33.futimes) {
+          fs33.lutimes = function(path30, at, mt, cb) {
+            fs33.open(path30, constants.O_SYMLINK, function(er, fd) {
               if (er) {
                 if (cb) cb(er);
                 return;
               }
-              fs32.futimes(fd, at, mt, function(er2) {
-                fs32.close(fd, function(er22) {
+              fs33.futimes(fd, at, mt, function(er2) {
+                fs33.close(fd, function(er22) {
                   if (cb) cb(er2 || er22);
                 });
               });
             });
           };
-          fs32.lutimesSync = function(path29, at, mt) {
-            var fd = fs32.openSync(path29, constants.O_SYMLINK);
+          fs33.lutimesSync = function(path30, at, mt) {
+            var fd = fs33.openSync(path30, constants.O_SYMLINK);
             var ret;
             var threw = true;
             try {
-              ret = fs32.futimesSync(fd, at, mt);
+              ret = fs33.futimesSync(fd, at, mt);
               threw = false;
             } finally {
               if (threw) {
                 try {
-                  fs32.closeSync(fd);
+                  fs33.closeSync(fd);
                 } catch (er) {
                 }
               } else {
-                fs32.closeSync(fd);
+                fs33.closeSync(fd);
               }
             }
             return ret;
           };
-        } else if (fs32.futimes) {
-          fs32.lutimes = function(_a2, _b, _c, cb) {
+        } else if (fs33.futimes) {
+          fs33.lutimes = function(_a2, _b, _c, cb) {
             if (cb) process.nextTick(cb);
           };
-          fs32.lutimesSync = function() {
+          fs33.lutimesSync = function() {
           };
         }
       }
       function chmodFix(orig) {
         if (!orig) return orig;
         return function(target, mode, cb) {
-          return orig.call(fs31, target, mode, function(er) {
+          return orig.call(fs32, target, mode, function(er) {
             if (chownErOk(er)) er = null;
             if (cb) cb.apply(this, arguments);
           });
@@ -92267,7 +92267,7 @@ var require_polyfills = __commonJS({
         if (!orig) return orig;
         return function(target, mode) {
           try {
-            return orig.call(fs31, target, mode);
+            return orig.call(fs32, target, mode);
           } catch (er) {
             if (!chownErOk(er)) throw er;
           }
@@ -92276,7 +92276,7 @@ var require_polyfills = __commonJS({
       function chownFix(orig) {
         if (!orig) return orig;
         return function(target, uid, gid, cb) {
-          return orig.call(fs31, target, uid, gid, function(er) {
+          return orig.call(fs32, target, uid, gid, function(er) {
             if (chownErOk(er)) er = null;
             if (cb) cb.apply(this, arguments);
           });
@@ -92286,7 +92286,7 @@ var require_polyfills = __commonJS({
         if (!orig) return orig;
         return function(target, uid, gid) {
           try {
-            return orig.call(fs31, target, uid, gid);
+            return orig.call(fs32, target, uid, gid);
           } catch (er) {
             if (!chownErOk(er)) throw er;
           }
@@ -92306,13 +92306,13 @@ var require_polyfills = __commonJS({
             }
             if (cb) cb.apply(this, arguments);
           }
-          return options ? orig.call(fs31, target, options, callback) : orig.call(fs31, target, callback);
+          return options ? orig.call(fs32, target, options, callback) : orig.call(fs32, target, callback);
         };
       }
       function statFixSync(orig) {
         if (!orig) return orig;
         return function(target, options) {
-          var stats = options ? orig.call(fs31, target, options) : orig.call(fs31, target);
+          var stats = options ? orig.call(fs32, target, options) : orig.call(fs32, target);
           if (stats) {
             if (stats.uid < 0) stats.uid += 4294967296;
             if (stats.gid < 0) stats.gid += 4294967296;
@@ -92341,16 +92341,16 @@ var require_legacy_streams = __commonJS({
   "node_modules/graceful-fs/legacy-streams.js"(exports2, module2) {
     var Stream = require("stream").Stream;
     module2.exports = legacy;
-    function legacy(fs31) {
+    function legacy(fs32) {
       return {
         ReadStream,
         WriteStream
       };
-      function ReadStream(path29, options) {
-        if (!(this instanceof ReadStream)) return new ReadStream(path29, options);
+      function ReadStream(path30, options) {
+        if (!(this instanceof ReadStream)) return new ReadStream(path30, options);
         Stream.call(this);
         var self2 = this;
-        this.path = path29;
+        this.path = path30;
         this.fd = null;
         this.readable = true;
         this.paused = false;
@@ -92384,7 +92384,7 @@ var require_legacy_streams = __commonJS({
           });
           return;
         }
-        fs31.open(this.path, this.flags, this.mode, function(err, fd) {
+        fs32.open(this.path, this.flags, this.mode, function(err, fd) {
           if (err) {
             self2.emit("error", err);
             self2.readable = false;
@@ -92395,10 +92395,10 @@ var require_legacy_streams = __commonJS({
           self2._read();
         });
       }
-      function WriteStream(path29, options) {
-        if (!(this instanceof WriteStream)) return new WriteStream(path29, options);
+      function WriteStream(path30, options) {
+        if (!(this instanceof WriteStream)) return new WriteStream(path30, options);
         Stream.call(this);
-        this.path = path29;
+        this.path = path30;
         this.fd = null;
         this.writable = true;
         this.flags = "w";
@@ -92423,7 +92423,7 @@ var require_legacy_streams = __commonJS({
         this.busy = false;
         this._queue = [];
         if (this.fd === null) {
-          this._open = fs31.open;
+          this._open = fs32.open;
           this._queue.push([this._open, this.path, this.flags, this.mode, void 0]);
           this.flush();
         }
@@ -92458,7 +92458,7 @@ var require_clone = __commonJS({
 // node_modules/graceful-fs/graceful-fs.js
 var require_graceful_fs = __commonJS({
   "node_modules/graceful-fs/graceful-fs.js"(exports2, module2) {
-    var fs31 = require("fs");
+    var fs32 = require("fs");
     var polyfills = require_polyfills();
     var legacy = require_legacy_streams();
     var clone = require_clone();
@@ -92490,12 +92490,12 @@ var require_graceful_fs = __commonJS({
         m = "GFS4: " + m.split(/\n/).join("\nGFS4: ");
         console.error(m);
       };
-    if (!fs31[gracefulQueue]) {
+    if (!fs32[gracefulQueue]) {
       queue2 = global[gracefulQueue] || [];
-      publishQueue(fs31, queue2);
-      fs31.close = (function(fs$close) {
+      publishQueue(fs32, queue2);
+      fs32.close = (function(fs$close) {
         function close(fd, cb) {
-          return fs$close.call(fs31, fd, function(err) {
+          return fs$close.call(fs32, fd, function(err) {
             if (!err) {
               resetQueue();
             }
@@ -92507,48 +92507,48 @@ var require_graceful_fs = __commonJS({
           value: fs$close
         });
         return close;
-      })(fs31.close);
-      fs31.closeSync = (function(fs$closeSync) {
+      })(fs32.close);
+      fs32.closeSync = (function(fs$closeSync) {
         function closeSync(fd) {
-          fs$closeSync.apply(fs31, arguments);
+          fs$closeSync.apply(fs32, arguments);
           resetQueue();
         }
         Object.defineProperty(closeSync, previousSymbol, {
           value: fs$closeSync
         });
         return closeSync;
-      })(fs31.closeSync);
+      })(fs32.closeSync);
       if (/\bgfs4\b/i.test(process.env.NODE_DEBUG || "")) {
         process.on("exit", function() {
-          debug6(fs31[gracefulQueue]);
-          require("assert").equal(fs31[gracefulQueue].length, 0);
+          debug6(fs32[gracefulQueue]);
+          require("assert").equal(fs32[gracefulQueue].length, 0);
         });
       }
     }
     var queue2;
     if (!global[gracefulQueue]) {
-      publishQueue(global, fs31[gracefulQueue]);
+      publishQueue(global, fs32[gracefulQueue]);
     }
-    module2.exports = patch(clone(fs31));
-    if (process.env.TEST_GRACEFUL_FS_GLOBAL_PATCH && !fs31.__patched) {
-      module2.exports = patch(fs31);
-      fs31.__patched = true;
+    module2.exports = patch(clone(fs32));
+    if (process.env.TEST_GRACEFUL_FS_GLOBAL_PATCH && !fs32.__patched) {
+      module2.exports = patch(fs32);
+      fs32.__patched = true;
     }
-    function patch(fs32) {
-      polyfills(fs32);
-      fs32.gracefulify = patch;
-      fs32.createReadStream = createReadStream4;
-      fs32.createWriteStream = createWriteStream3;
-      var fs$readFile = fs32.readFile;
-      fs32.readFile = readFile;
-      function readFile(path29, options, cb) {
+    function patch(fs33) {
+      polyfills(fs33);
+      fs33.gracefulify = patch;
+      fs33.createReadStream = createReadStream4;
+      fs33.createWriteStream = createWriteStream3;
+      var fs$readFile = fs33.readFile;
+      fs33.readFile = readFile;
+      function readFile(path30, options, cb) {
         if (typeof options === "function")
           cb = options, options = null;
-        return go$readFile(path29, options, cb);
-        function go$readFile(path30, options2, cb2, startTime) {
-          return fs$readFile(path30, options2, function(err) {
+        return go$readFile(path30, options, cb);
+        function go$readFile(path31, options2, cb2, startTime) {
+          return fs$readFile(path31, options2, function(err) {
             if (err && (err.code === "EMFILE" || err.code === "ENFILE"))
-              enqueue([go$readFile, [path30, options2, cb2], err, startTime || Date.now(), Date.now()]);
+              enqueue([go$readFile, [path31, options2, cb2], err, startTime || Date.now(), Date.now()]);
             else {
               if (typeof cb2 === "function")
                 cb2.apply(this, arguments);
@@ -92556,16 +92556,16 @@ var require_graceful_fs = __commonJS({
           });
         }
       }
-      var fs$writeFile = fs32.writeFile;
-      fs32.writeFile = writeFile;
-      function writeFile(path29, data, options, cb) {
+      var fs$writeFile = fs33.writeFile;
+      fs33.writeFile = writeFile;
+      function writeFile(path30, data, options, cb) {
         if (typeof options === "function")
           cb = options, options = null;
-        return go$writeFile(path29, data, options, cb);
-        function go$writeFile(path30, data2, options2, cb2, startTime) {
-          return fs$writeFile(path30, data2, options2, function(err) {
+        return go$writeFile(path30, data, options, cb);
+        function go$writeFile(path31, data2, options2, cb2, startTime) {
+          return fs$writeFile(path31, data2, options2, function(err) {
             if (err && (err.code === "EMFILE" || err.code === "ENFILE"))
-              enqueue([go$writeFile, [path30, data2, options2, cb2], err, startTime || Date.now(), Date.now()]);
+              enqueue([go$writeFile, [path31, data2, options2, cb2], err, startTime || Date.now(), Date.now()]);
             else {
               if (typeof cb2 === "function")
                 cb2.apply(this, arguments);
@@ -92573,17 +92573,17 @@ var require_graceful_fs = __commonJS({
           });
         }
       }
-      var fs$appendFile = fs32.appendFile;
+      var fs$appendFile = fs33.appendFile;
       if (fs$appendFile)
-        fs32.appendFile = appendFile;
-      function appendFile(path29, data, options, cb) {
+        fs33.appendFile = appendFile;
+      function appendFile(path30, data, options, cb) {
         if (typeof options === "function")
           cb = options, options = null;
-        return go$appendFile(path29, data, options, cb);
-        function go$appendFile(path30, data2, options2, cb2, startTime) {
-          return fs$appendFile(path30, data2, options2, function(err) {
+        return go$appendFile(path30, data, options, cb);
+        function go$appendFile(path31, data2, options2, cb2, startTime) {
+          return fs$appendFile(path31, data2, options2, function(err) {
             if (err && (err.code === "EMFILE" || err.code === "ENFILE"))
-              enqueue([go$appendFile, [path30, data2, options2, cb2], err, startTime || Date.now(), Date.now()]);
+              enqueue([go$appendFile, [path31, data2, options2, cb2], err, startTime || Date.now(), Date.now()]);
             else {
               if (typeof cb2 === "function")
                 cb2.apply(this, arguments);
@@ -92591,9 +92591,9 @@ var require_graceful_fs = __commonJS({
           });
         }
       }
-      var fs$copyFile = fs32.copyFile;
+      var fs$copyFile = fs33.copyFile;
       if (fs$copyFile)
-        fs32.copyFile = copyFile2;
+        fs33.copyFile = copyFile2;
       function copyFile2(src, dest, flags, cb) {
         if (typeof flags === "function") {
           cb = flags;
@@ -92611,34 +92611,34 @@ var require_graceful_fs = __commonJS({
           });
         }
       }
-      var fs$readdir = fs32.readdir;
-      fs32.readdir = readdir3;
+      var fs$readdir = fs33.readdir;
+      fs33.readdir = readdir3;
       var noReaddirOptionVersions = /^v[0-5]\./;
-      function readdir3(path29, options, cb) {
+      function readdir3(path30, options, cb) {
         if (typeof options === "function")
           cb = options, options = null;
-        var go$readdir = noReaddirOptionVersions.test(process.version) ? function go$readdir2(path30, options2, cb2, startTime) {
-          return fs$readdir(path30, fs$readdirCallback(
-            path30,
+        var go$readdir = noReaddirOptionVersions.test(process.version) ? function go$readdir2(path31, options2, cb2, startTime) {
+          return fs$readdir(path31, fs$readdirCallback(
+            path31,
             options2,
             cb2,
             startTime
           ));
-        } : function go$readdir2(path30, options2, cb2, startTime) {
-          return fs$readdir(path30, options2, fs$readdirCallback(
-            path30,
+        } : function go$readdir2(path31, options2, cb2, startTime) {
+          return fs$readdir(path31, options2, fs$readdirCallback(
+            path31,
             options2,
             cb2,
             startTime
           ));
         };
-        return go$readdir(path29, options, cb);
-        function fs$readdirCallback(path30, options2, cb2, startTime) {
+        return go$readdir(path30, options, cb);
+        function fs$readdirCallback(path31, options2, cb2, startTime) {
           return function(err, files) {
             if (err && (err.code === "EMFILE" || err.code === "ENFILE"))
               enqueue([
                 go$readdir,
-                [path30, options2, cb2],
+                [path31, options2, cb2],
                 err,
                 startTime || Date.now(),
                 Date.now()
@@ -92653,21 +92653,21 @@ var require_graceful_fs = __commonJS({
         }
       }
       if (process.version.substr(0, 4) === "v0.8") {
-        var legStreams = legacy(fs32);
+        var legStreams = legacy(fs33);
         ReadStream = legStreams.ReadStream;
         WriteStream = legStreams.WriteStream;
       }
-      var fs$ReadStream = fs32.ReadStream;
+      var fs$ReadStream = fs33.ReadStream;
       if (fs$ReadStream) {
         ReadStream.prototype = Object.create(fs$ReadStream.prototype);
         ReadStream.prototype.open = ReadStream$open;
       }
-      var fs$WriteStream = fs32.WriteStream;
+      var fs$WriteStream = fs33.WriteStream;
       if (fs$WriteStream) {
         WriteStream.prototype = Object.create(fs$WriteStream.prototype);
         WriteStream.prototype.open = WriteStream$open;
       }
-      Object.defineProperty(fs32, "ReadStream", {
+      Object.defineProperty(fs33, "ReadStream", {
         get: function() {
           return ReadStream;
         },
@@ -92677,7 +92677,7 @@ var require_graceful_fs = __commonJS({
         enumerable: true,
         configurable: true
       });
-      Object.defineProperty(fs32, "WriteStream", {
+      Object.defineProperty(fs33, "WriteStream", {
         get: function() {
           return WriteStream;
         },
@@ -92688,7 +92688,7 @@ var require_graceful_fs = __commonJS({
         configurable: true
       });
       var FileReadStream = ReadStream;
-      Object.defineProperty(fs32, "FileReadStream", {
+      Object.defineProperty(fs33, "FileReadStream", {
         get: function() {
           return FileReadStream;
         },
@@ -92699,7 +92699,7 @@ var require_graceful_fs = __commonJS({
         configurable: true
       });
       var FileWriteStream = WriteStream;
-      Object.defineProperty(fs32, "FileWriteStream", {
+      Object.defineProperty(fs33, "FileWriteStream", {
         get: function() {
           return FileWriteStream;
         },
@@ -92709,7 +92709,7 @@ var require_graceful_fs = __commonJS({
         enumerable: true,
         configurable: true
       });
-      function ReadStream(path29, options) {
+      function ReadStream(path30, options) {
         if (this instanceof ReadStream)
           return fs$ReadStream.apply(this, arguments), this;
         else
@@ -92729,7 +92729,7 @@ var require_graceful_fs = __commonJS({
           }
         });
       }
-      function WriteStream(path29, options) {
+      function WriteStream(path30, options) {
         if (this instanceof WriteStream)
           return fs$WriteStream.apply(this, arguments), this;
         else
@@ -92747,22 +92747,22 @@ var require_graceful_fs = __commonJS({
           }
         });
       }
-      function createReadStream4(path29, options) {
-        return new fs32.ReadStream(path29, options);
+      function createReadStream4(path30, options) {
+        return new fs33.ReadStream(path30, options);
       }
-      function createWriteStream3(path29, options) {
-        return new fs32.WriteStream(path29, options);
+      function createWriteStream3(path30, options) {
+        return new fs33.WriteStream(path30, options);
       }
-      var fs$open = fs32.open;
-      fs32.open = open;
-      function open(path29, flags, mode, cb) {
+      var fs$open = fs33.open;
+      fs33.open = open;
+      function open(path30, flags, mode, cb) {
         if (typeof mode === "function")
           cb = mode, mode = null;
-        return go$open(path29, flags, mode, cb);
-        function go$open(path30, flags2, mode2, cb2, startTime) {
-          return fs$open(path30, flags2, mode2, function(err, fd) {
+        return go$open(path30, flags, mode, cb);
+        function go$open(path31, flags2, mode2, cb2, startTime) {
+          return fs$open(path31, flags2, mode2, function(err, fd) {
             if (err && (err.code === "EMFILE" || err.code === "ENFILE"))
-              enqueue([go$open, [path30, flags2, mode2, cb2], err, startTime || Date.now(), Date.now()]);
+              enqueue([go$open, [path31, flags2, mode2, cb2], err, startTime || Date.now(), Date.now()]);
             else {
               if (typeof cb2 === "function")
                 cb2.apply(this, arguments);
@@ -92770,20 +92770,20 @@ var require_graceful_fs = __commonJS({
           });
         }
       }
-      return fs32;
+      return fs33;
     }
     function enqueue(elem) {
       debug6("ENQUEUE", elem[0].name, elem[1]);
-      fs31[gracefulQueue].push(elem);
+      fs32[gracefulQueue].push(elem);
       retry2();
     }
     var retryTimer;
     function resetQueue() {
       var now = Date.now();
-      for (var i = 0; i < fs31[gracefulQueue].length; ++i) {
-        if (fs31[gracefulQueue][i].length > 2) {
-          fs31[gracefulQueue][i][3] = now;
-          fs31[gracefulQueue][i][4] = now;
+      for (var i = 0; i < fs32[gracefulQueue].length; ++i) {
+        if (fs32[gracefulQueue][i].length > 2) {
+          fs32[gracefulQueue][i][3] = now;
+          fs32[gracefulQueue][i][4] = now;
         }
       }
       retry2();
@@ -92791,9 +92791,9 @@ var require_graceful_fs = __commonJS({
     function retry2() {
       clearTimeout(retryTimer);
       retryTimer = void 0;
-      if (fs31[gracefulQueue].length === 0)
+      if (fs32[gracefulQueue].length === 0)
         return;
-      var elem = fs31[gracefulQueue].shift();
+      var elem = fs32[gracefulQueue].shift();
       var fn = elem[0];
       var args = elem[1];
       var err = elem[2];
@@ -92815,7 +92815,7 @@ var require_graceful_fs = __commonJS({
           debug6("RETRY", fn.name, args);
           fn.apply(null, args.concat([startTime]));
         } else {
-          fs31[gracefulQueue].push(elem);
+          fs32[gracefulQueue].push(elem);
         }
       }
       if (retryTimer === void 0) {
@@ -94867,22 +94867,22 @@ var require_lazystream = __commonJS({
 // node_modules/normalize-path/index.js
 var require_normalize_path = __commonJS({
   "node_modules/normalize-path/index.js"(exports2, module2) {
-    module2.exports = function(path29, stripTrailing) {
-      if (typeof path29 !== "string") {
+    module2.exports = function(path30, stripTrailing) {
+      if (typeof path30 !== "string") {
         throw new TypeError("expected path to be a string");
       }
-      if (path29 === "\\" || path29 === "/") return "/";
-      var len = path29.length;
-      if (len <= 1) return path29;
+      if (path30 === "\\" || path30 === "/") return "/";
+      var len = path30.length;
+      if (len <= 1) return path30;
       var prefix = "";
-      if (len > 4 && path29[3] === "\\") {
-        var ch = path29[2];
-        if ((ch === "?" || ch === ".") && path29.slice(0, 2) === "\\\\") {
-          path29 = path29.slice(2);
+      if (len > 4 && path30[3] === "\\") {
+        var ch = path30[2];
+        if ((ch === "?" || ch === ".") && path30.slice(0, 2) === "\\\\") {
+          path30 = path30.slice(2);
           prefix = "//";
         }
       }
-      var segs = path29.split(/[/\\]+/);
+      var segs = path30.split(/[/\\]+/);
       if (stripTrailing !== false && segs[segs.length - 1] === "") {
         segs.pop();
       }
@@ -103638,7 +103638,7 @@ globstar while`, t, d, e, u, m), this.matchOne(t.slice(d), e.slice(u), s)) retur
       g.minimatch.escape = vi.escape;
       g.minimatch.unescape = Ei.unescape;
     });
-    var fs31 = R((Wt) => {
+    var fs32 = R((Wt) => {
       "use strict";
       Object.defineProperty(Wt, "__esModule", { value: true });
       Wt.LRUCache = void 0;
@@ -104507,7 +104507,7 @@ globstar while`, t, d, e, u, m), this.matchOne(t.slice(d), e.slice(u), s)) retur
       };
       Object.defineProperty(_2, "__esModule", { value: true });
       _2.PathScurry = _2.Path = _2.PathScurryDarwin = _2.PathScurryPosix = _2.PathScurryWin32 = _2.PathScurryBase = _2.PathPosix = _2.PathWin32 = _2.PathBase = _2.ChildrenCache = _2.ResolveCache = void 0;
-      var Qt = fs31(), Yt = require("node:path"), yr = require("node:url"), pt = require("fs"), Sr = br(require("node:fs")), vr = pt.realpathSync.native, Ht = require("node:fs/promises"), bs = Oe(), mt = { lstatSync: pt.lstatSync, readdir: pt.readdir, readdirSync: pt.readdirSync, readlinkSync: pt.readlinkSync, realpathSync: vr, promises: { lstat: Ht.lstat, readdir: Ht.readdir, readlink: Ht.readlink, realpath: Ht.realpath } }, _s = (n) => !n || n === mt || n === Sr ? mt : { ...mt, ...n, promises: { ...mt.promises, ...n.promises || {} } }, Os = /^\\\\\?\\([a-z]:)\\?$/i, Er = (n) => n.replace(/\//g, "\\").replace(Os, "$1\\"), _r = /[\\\/]/, N = 0, xs = 1, Ts = 2, G = 4, Cs = 6, Rs = 8, Q = 10, As = 12, j = 15, dt = ~j, xe = 16, ys = 32, gt = 64, W = 128, Vt = 256, Xt = 512, Ss = gt | W | Xt, Or = 1023, Te = (n) => n.isFile() ? Rs : n.isDirectory() ? G : n.isSymbolicLink() ? Q : n.isCharacterDevice() ? Ts : n.isBlockDevice() ? Cs : n.isSocket() ? As : n.isFIFO() ? xs : N, vs = new Qt.LRUCache({ max: 2 ** 12 }), wt = (n) => {
+      var Qt = fs32(), Yt = require("node:path"), yr = require("node:url"), pt = require("fs"), Sr = br(require("node:fs")), vr = pt.realpathSync.native, Ht = require("node:fs/promises"), bs = Oe(), mt = { lstatSync: pt.lstatSync, readdir: pt.readdir, readdirSync: pt.readdirSync, readlinkSync: pt.readlinkSync, realpathSync: vr, promises: { lstat: Ht.lstat, readdir: Ht.readdir, readlink: Ht.readlink, realpath: Ht.realpath } }, _s = (n) => !n || n === mt || n === Sr ? mt : { ...mt, ...n, promises: { ...mt.promises, ...n.promises || {} } }, Os = /^\\\\\?\\([a-z]:)\\?$/i, Er = (n) => n.replace(/\//g, "\\").replace(Os, "$1\\"), _r = /[\\\/]/, N = 0, xs = 1, Ts = 2, G = 4, Cs = 6, Rs = 8, Q = 10, As = 12, j = 15, dt = ~j, xe = 16, ys = 32, gt = 64, W = 128, Vt = 256, Xt = 512, Ss = gt | W | Xt, Or = 1023, Te = (n) => n.isFile() ? Rs : n.isDirectory() ? G : n.isSymbolicLink() ? Q : n.isCharacterDevice() ? Ts : n.isBlockDevice() ? Cs : n.isSocket() ? As : n.isFIFO() ? xs : N, vs = new Qt.LRUCache({ max: 2 ** 12 }), wt = (n) => {
         let t = vs.get(n);
         if (t) return t;
         let e = n.normalize("NFKD");
@@ -105885,8 +105885,8 @@ globstar while`, t, d, e, u, m), this.matchOne(t.slice(d), e.slice(u), s)) retur
 // node_modules/archiver-utils/file.js
 var require_file3 = __commonJS({
   "node_modules/archiver-utils/file.js"(exports2, module2) {
-    var fs31 = require_graceful_fs();
-    var path29 = require("path");
+    var fs32 = require_graceful_fs();
+    var path30 = require("path");
     var flatten = require_flatten();
     var difference = require_difference();
     var union = require_union();
@@ -105911,8 +105911,8 @@ var require_file3 = __commonJS({
       return result;
     };
     file.exists = function() {
-      var filepath = path29.join.apply(path29, arguments);
-      return fs31.existsSync(filepath);
+      var filepath = path30.join.apply(path30, arguments);
+      return fs32.existsSync(filepath);
     };
     file.expand = function(...args) {
       var options = isPlainObject4(args[0]) ? args.shift() : {};
@@ -105925,12 +105925,12 @@ var require_file3 = __commonJS({
       });
       if (options.filter) {
         matches = matches.filter(function(filepath) {
-          filepath = path29.join(options.cwd || "", filepath);
+          filepath = path30.join(options.cwd || "", filepath);
           try {
             if (typeof options.filter === "function") {
               return options.filter(filepath);
             } else {
-              return fs31.statSync(filepath)[options.filter]();
+              return fs32.statSync(filepath)[options.filter]();
             }
           } catch (e) {
             return false;
@@ -105942,7 +105942,7 @@ var require_file3 = __commonJS({
     file.expandMapping = function(patterns, destBase, options) {
       options = Object.assign({
         rename: function(destBase2, destPath) {
-          return path29.join(destBase2 || "", destPath);
+          return path30.join(destBase2 || "", destPath);
         }
       }, options);
       var files = [];
@@ -105950,14 +105950,14 @@ var require_file3 = __commonJS({
       file.expand(options, patterns).forEach(function(src) {
         var destPath = src;
         if (options.flatten) {
-          destPath = path29.basename(destPath);
+          destPath = path30.basename(destPath);
         }
         if (options.ext) {
           destPath = destPath.replace(/(\.[^\/]*)?$/, options.ext);
         }
         var dest = options.rename(destBase, destPath, options);
         if (options.cwd) {
-          src = path29.join(options.cwd, src);
+          src = path30.join(options.cwd, src);
         }
         dest = dest.replace(pathSeparatorRe, "/");
         src = src.replace(pathSeparatorRe, "/");
@@ -106038,8 +106038,8 @@ var require_file3 = __commonJS({
 // node_modules/archiver-utils/index.js
 var require_archiver_utils = __commonJS({
   "node_modules/archiver-utils/index.js"(exports2, module2) {
-    var fs31 = require_graceful_fs();
-    var path29 = require("path");
+    var fs32 = require_graceful_fs();
+    var path30 = require("path");
     var isStream2 = require_is_stream();
     var lazystream = require_lazystream();
     var normalizePath4 = require_normalize_path();
@@ -106087,7 +106087,7 @@ var require_archiver_utils = __commonJS({
     };
     utils.lazyReadStream = function(filepath) {
       return new lazystream.Readable(function() {
-        return fs31.createReadStream(filepath);
+        return fs32.createReadStream(filepath);
       });
     };
     utils.normalizeInputSource = function(source) {
@@ -106115,7 +106115,7 @@ var require_archiver_utils = __commonJS({
         callback = base;
         base = dirpath;
       }
-      fs31.readdir(dirpath, function(err, list) {
+      fs32.readdir(dirpath, function(err, list) {
         var i = 0;
         var file;
         var filepath;
@@ -106127,11 +106127,11 @@ var require_archiver_utils = __commonJS({
           if (!file) {
             return callback(null, results);
           }
-          filepath = path29.join(dirpath, file);
-          fs31.stat(filepath, function(err2, stats) {
+          filepath = path30.join(dirpath, file);
+          fs32.stat(filepath, function(err2, stats) {
             results.push({
               path: filepath,
-              relative: path29.relative(base, filepath).replace(/\\/g, "/"),
+              relative: path30.relative(base, filepath).replace(/\\/g, "/"),
               stats
             });
             if (stats && stats.isDirectory()) {
@@ -106190,10 +106190,10 @@ var require_error3 = __commonJS({
 // node_modules/@actions/artifact/node_modules/archiver/lib/core.js
 var require_core2 = __commonJS({
   "node_modules/@actions/artifact/node_modules/archiver/lib/core.js"(exports2, module2) {
-    var fs31 = require("fs");
+    var fs32 = require("fs");
     var glob2 = require_readdir_glob();
     var async = require_async();
-    var path29 = require("path");
+    var path30 = require("path");
     var util3 = require_archiver_utils();
     var inherits = require("util").inherits;
     var ArchiverError2 = require_error3();
@@ -106254,7 +106254,7 @@ var require_core2 = __commonJS({
       data.sourcePath = filepath;
       task.data = data;
       this._entriesCount++;
-      if (data.stats && data.stats instanceof fs31.Stats) {
+      if (data.stats && data.stats instanceof fs32.Stats) {
         task = this._updateQueueTaskWithStats(task, data.stats);
         if (task) {
           if (data.stats.size) {
@@ -106425,7 +106425,7 @@ var require_core2 = __commonJS({
         callback();
         return;
       }
-      fs31.lstat(task.filepath, function(err, stats) {
+      fs32.lstat(task.filepath, function(err, stats) {
         if (this._state.aborted) {
           setImmediate(callback);
           return;
@@ -106468,10 +106468,10 @@ var require_core2 = __commonJS({
         task.data.sourceType = "buffer";
         task.source = Buffer.concat([]);
       } else if (stats.isSymbolicLink() && this._moduleSupports("symlink")) {
-        var linkPath = fs31.readlinkSync(task.filepath);
-        var dirName = path29.dirname(task.filepath);
+        var linkPath = fs32.readlinkSync(task.filepath);
+        var dirName = path30.dirname(task.filepath);
         task.data.type = "symlink";
-        task.data.linkname = path29.relative(dirName, path29.resolve(dirName, linkPath));
+        task.data.linkname = path30.relative(dirName, path30.resolve(dirName, linkPath));
         task.data.sourceType = "buffer";
         task.source = Buffer.concat([]);
       } else {
@@ -110921,8 +110921,8 @@ var require_context2 = __commonJS({
           if ((0, fs_1.existsSync)(process.env.GITHUB_EVENT_PATH)) {
             this.payload = JSON.parse((0, fs_1.readFileSync)(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
           } else {
-            const path29 = process.env.GITHUB_EVENT_PATH;
-            process.stdout.write(`GITHUB_EVENT_PATH ${path29} does not exist${os_1.EOL}`);
+            const path30 = process.env.GITHUB_EVENT_PATH;
+            process.stdout.write(`GITHUB_EVENT_PATH ${path30} does not exist${os_1.EOL}`);
           }
         }
         this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -115818,7 +115818,7 @@ var require_traverse = __commonJS({
       })(this.value);
     };
     function walk(root, cb, immutable) {
-      var path29 = [];
+      var path30 = [];
       var parents = [];
       var alive = true;
       return (function walker(node_) {
@@ -115827,11 +115827,11 @@ var require_traverse = __commonJS({
         var state = {
           node,
           node_,
-          path: [].concat(path29),
+          path: [].concat(path30),
           parent: parents.slice(-1)[0],
-          key: path29.slice(-1)[0],
-          isRoot: path29.length === 0,
-          level: path29.length,
+          key: path30.slice(-1)[0],
+          isRoot: path30.length === 0,
+          level: path30.length,
           circular: null,
           update: function(x) {
             if (!state.isRoot) {
@@ -115886,7 +115886,7 @@ var require_traverse = __commonJS({
           parents.push(state);
           var keys = Object.keys(state.node);
           keys.forEach(function(key, i2) {
-            path29.push(key);
+            path30.push(key);
             if (modifiers.pre) modifiers.pre.call(state, state.node[key], key);
             var child = walker(state.node[key]);
             if (immutable && Object.hasOwnProperty.call(state.node, key)) {
@@ -115895,7 +115895,7 @@ var require_traverse = __commonJS({
             child.isLast = i2 == keys.length - 1;
             child.isFirst = i2 == 0;
             if (modifiers.post) modifiers.post.call(state, child);
-            path29.pop();
+            path30.pop();
           });
           parents.pop();
         }
@@ -116916,11 +116916,11 @@ var require_unzip_stream = __commonJS({
           return requiredLength;
         case states.CENTRAL_DIRECTORY_FILE_HEADER_SUFFIX:
           var isUtf8 = (this.parsedEntity.flags & 2048) !== 0;
-          var path29 = this._decodeString(chunk.slice(0, this.parsedEntity.fileNameLength), isUtf8);
+          var path30 = this._decodeString(chunk.slice(0, this.parsedEntity.fileNameLength), isUtf8);
           var extraDataBuffer = chunk.slice(this.parsedEntity.fileNameLength, this.parsedEntity.fileNameLength + this.parsedEntity.extraFieldLength);
           var extra = this._readExtraFields(extraDataBuffer);
           if (extra && extra.parsed && extra.parsed.path && !isUtf8) {
-            path29 = extra.parsed.path;
+            path30 = extra.parsed.path;
           }
           this.parsedEntity.extra = extra.parsed;
           var isUnix = (this.parsedEntity.versionMadeBy & 65280) >> 8 === 3;
@@ -116932,7 +116932,7 @@ var require_unzip_stream = __commonJS({
           }
           if (this.options.debug) {
             const debugObj = Object.assign({}, this.parsedEntity, {
-              path: path29,
+              path: path30,
               flags: "0x" + this.parsedEntity.flags.toString(16),
               unixAttrs: unixAttrs && "0" + unixAttrs.toString(8),
               isSymlink,
@@ -117369,8 +117369,8 @@ var require_parser_stream = __commonJS({
 // node_modules/mkdirp/index.js
 var require_mkdirp = __commonJS({
   "node_modules/mkdirp/index.js"(exports2, module2) {
-    var path29 = require("path");
-    var fs31 = require("fs");
+    var path30 = require("path");
+    var fs32 = require("fs");
     var _0777 = parseInt("0777", 8);
     module2.exports = mkdirP.mkdirp = mkdirP.mkdirP = mkdirP;
     function mkdirP(p, opts, f, made) {
@@ -117381,7 +117381,7 @@ var require_mkdirp = __commonJS({
         opts = { mode: opts };
       }
       var mode = opts.mode;
-      var xfs = opts.fs || fs31;
+      var xfs = opts.fs || fs32;
       if (mode === void 0) {
         mode = _0777;
       }
@@ -117389,7 +117389,7 @@ var require_mkdirp = __commonJS({
       var cb = f || /* istanbul ignore next */
       function() {
       };
-      p = path29.resolve(p);
+      p = path30.resolve(p);
       xfs.mkdir(p, mode, function(er) {
         if (!er) {
           made = made || p;
@@ -117397,8 +117397,8 @@ var require_mkdirp = __commonJS({
         }
         switch (er.code) {
           case "ENOENT":
-            if (path29.dirname(p) === p) return cb(er);
-            mkdirP(path29.dirname(p), opts, function(er2, made2) {
+            if (path30.dirname(p) === p) return cb(er);
+            mkdirP(path30.dirname(p), opts, function(er2, made2) {
               if (er2) cb(er2, made2);
               else mkdirP(p, opts, cb, made2);
             });
@@ -117420,19 +117420,19 @@ var require_mkdirp = __commonJS({
         opts = { mode: opts };
       }
       var mode = opts.mode;
-      var xfs = opts.fs || fs31;
+      var xfs = opts.fs || fs32;
       if (mode === void 0) {
         mode = _0777;
       }
       if (!made) made = null;
-      p = path29.resolve(p);
+      p = path30.resolve(p);
       try {
         xfs.mkdirSync(p, mode);
         made = made || p;
       } catch (err0) {
         switch (err0.code) {
           case "ENOENT":
-            made = sync(path29.dirname(p), opts, made);
+            made = sync(path30.dirname(p), opts, made);
             sync(p, opts, made);
             break;
           // In the case of any other error, just see if there's a dir
@@ -117457,8 +117457,8 @@ var require_mkdirp = __commonJS({
 // node_modules/unzip-stream/lib/extract.js
 var require_extract2 = __commonJS({
   "node_modules/unzip-stream/lib/extract.js"(exports2, module2) {
-    var fs31 = require("fs");
-    var path29 = require("path");
+    var fs32 = require("fs");
+    var path30 = require("path");
     var util3 = require("util");
     var mkdirp = require_mkdirp();
     var Transform5 = require("stream").Transform;
@@ -117500,11 +117500,11 @@ var require_extract2 = __commonJS({
     };
     Extract.prototype._processEntry = function(entry) {
       var self2 = this;
-      var destPath = path29.join(this.opts.path, entry.path);
-      var directory = entry.isDirectory ? destPath : path29.dirname(destPath);
+      var destPath = path30.join(this.opts.path, entry.path);
+      var directory = entry.isDirectory ? destPath : path30.dirname(destPath);
       this.unfinishedEntries++;
       var writeFileFn = function() {
-        var pipedStream = fs31.createWriteStream(destPath);
+        var pipedStream = fs32.createWriteStream(destPath);
         pipedStream.on("close", function() {
           self2.unfinishedEntries--;
           self2._notifyAwaiter();
@@ -117628,10 +117628,10 @@ var require_download_artifact = __commonJS({
       parsed.search = "";
       return parsed.toString();
     };
-    function exists(path29) {
+    function exists(path30) {
       return __awaiter2(this, void 0, void 0, function* () {
         try {
-          yield promises_1.default.access(path29);
+          yield promises_1.default.access(path30);
           return true;
         } catch (error3) {
           if (error3.code === "ENOENT") {
@@ -117863,12 +117863,12 @@ var require_dist_node11 = __commonJS({
         octokit.log.debug("request", options);
         const start = Date.now();
         const requestOptions = octokit.request.endpoint.parse(options);
-        const path29 = requestOptions.url.replace(options.baseUrl, "");
+        const path30 = requestOptions.url.replace(options.baseUrl, "");
         return request3(options).then((response) => {
-          octokit.log.info(`${requestOptions.method} ${path29} - ${response.status} in ${Date.now() - start}ms`);
+          octokit.log.info(`${requestOptions.method} ${path30} - ${response.status} in ${Date.now() - start}ms`);
           return response;
         }).catch((error3) => {
-          octokit.log.info(`${requestOptions.method} ${path29} - ${error3.status} in ${Date.now() - start}ms`);
+          octokit.log.info(`${requestOptions.method} ${path30} - ${error3.status} in ${Date.now() - start}ms`);
           throw error3;
         });
       });
@@ -118702,7 +118702,7 @@ var require_file_command2 = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.prepareKeyValueMessage = exports2.issueFileCommand = void 0;
     var crypto3 = __importStar2(require("crypto"));
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var os7 = __importStar2(require("os"));
     var utils_1 = require_utils10();
     function issueFileCommand(command, message) {
@@ -118710,10 +118710,10 @@ var require_file_command2 = __commonJS({
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
       }
-      if (!fs31.existsSync(filePath)) {
+      if (!fs32.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
       }
-      fs31.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os7.EOL}`, {
+      fs32.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os7.EOL}`, {
         encoding: "utf8"
       });
     }
@@ -119963,7 +119963,7 @@ var require_path_utils2 = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.toPlatformPath = exports2.toWin32Path = exports2.toPosixPath = void 0;
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -119973,7 +119973,7 @@ var require_path_utils2 = __commonJS({
     }
     exports2.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path29.sep);
+      return pth.replace(/[/\\]/g, path30.sep);
     }
     exports2.toPlatformPath = toPlatformPath;
   }
@@ -120036,12 +120036,12 @@ var require_io_util2 = __commonJS({
     var _a2;
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.READONLY = exports2.UV_FS_O_EXLOCK = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rm = exports2.rename = exports2.readlink = exports2.readdir = exports2.open = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
-    var fs31 = __importStar2(require("fs"));
-    var path29 = __importStar2(require("path"));
-    _a2 = fs31.promises, exports2.chmod = _a2.chmod, exports2.copyFile = _a2.copyFile, exports2.lstat = _a2.lstat, exports2.mkdir = _a2.mkdir, exports2.open = _a2.open, exports2.readdir = _a2.readdir, exports2.readlink = _a2.readlink, exports2.rename = _a2.rename, exports2.rm = _a2.rm, exports2.rmdir = _a2.rmdir, exports2.stat = _a2.stat, exports2.symlink = _a2.symlink, exports2.unlink = _a2.unlink;
+    var fs32 = __importStar2(require("fs"));
+    var path30 = __importStar2(require("path"));
+    _a2 = fs32.promises, exports2.chmod = _a2.chmod, exports2.copyFile = _a2.copyFile, exports2.lstat = _a2.lstat, exports2.mkdir = _a2.mkdir, exports2.open = _a2.open, exports2.readdir = _a2.readdir, exports2.readlink = _a2.readlink, exports2.rename = _a2.rename, exports2.rm = _a2.rm, exports2.rmdir = _a2.rmdir, exports2.stat = _a2.stat, exports2.symlink = _a2.symlink, exports2.unlink = _a2.unlink;
     exports2.IS_WINDOWS = process.platform === "win32";
     exports2.UV_FS_O_EXLOCK = 268435456;
-    exports2.READONLY = fs31.constants.O_RDONLY;
+    exports2.READONLY = fs32.constants.O_RDONLY;
     function exists(fsPath) {
       return __awaiter2(this, void 0, void 0, function* () {
         try {
@@ -120086,7 +120086,7 @@ var require_io_util2 = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path29.extname(filePath).toUpperCase();
+            const upperExt = path30.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -120110,11 +120110,11 @@ var require_io_util2 = __commonJS({
           if (stats && stats.isFile()) {
             if (exports2.IS_WINDOWS) {
               try {
-                const directory = path29.dirname(filePath);
-                const upperName = path29.basename(filePath).toUpperCase();
+                const directory = path30.dirname(filePath);
+                const upperName = path30.basename(filePath).toUpperCase();
                 for (const actualName of yield exports2.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path29.join(directory, actualName);
+                    filePath = path30.join(directory, actualName);
                     break;
                   }
                 }
@@ -120209,7 +120209,7 @@ var require_io2 = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
     var assert_1 = require("assert");
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var ioUtil = __importStar2(require_io_util2());
     function cp(source, dest, options = {}) {
       return __awaiter2(this, void 0, void 0, function* () {
@@ -120218,7 +120218,7 @@ var require_io2 = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path29.join(dest, path29.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path30.join(dest, path30.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -120230,7 +120230,7 @@ var require_io2 = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path29.relative(source, newDest) === "") {
+          if (path30.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile2(source, newDest, force);
@@ -120243,7 +120243,7 @@ var require_io2 = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path29.join(dest, path29.basename(source));
+            dest = path30.join(dest, path30.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -120254,7 +120254,7 @@ var require_io2 = __commonJS({
             }
           }
         }
-        yield mkdirP(path29.dirname(dest));
+        yield mkdirP(path30.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -120317,7 +120317,7 @@ var require_io2 = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path29.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path30.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -120330,12 +120330,12 @@ var require_io2 = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path29.sep)) {
+        if (tool.includes(path30.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path29.delimiter)) {
+          for (const p of process.env.PATH.split(path30.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -120343,7 +120343,7 @@ var require_io2 = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path29.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path30.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -120459,7 +120459,7 @@ var require_toolrunner2 = __commonJS({
     var os7 = __importStar2(require("os"));
     var events = __importStar2(require("events"));
     var child = __importStar2(require("child_process"));
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var io9 = __importStar2(require_io2());
     var ioUtil = __importStar2(require_io_util2());
     var timers_1 = require("timers");
@@ -120674,7 +120674,7 @@ var require_toolrunner2 = __commonJS({
       exec() {
         return __awaiter2(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path29.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path30.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io9.which(this.toolPath, true);
           return new Promise((resolve14, reject) => __awaiter2(this, void 0, void 0, function* () {
@@ -121174,7 +121174,7 @@ var require_core3 = __commonJS({
     var file_command_1 = require_file_command2();
     var utils_1 = require_utils10();
     var os7 = __importStar2(require("os"));
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     var oidc_utils_1 = require_oidc_utils2();
     var ExitCode;
     (function(ExitCode2) {
@@ -121202,7 +121202,7 @@ var require_core3 = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path29.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path30.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath2;
     function getInput2(name, options) {
@@ -121378,13 +121378,13 @@ These characters are not allowed in the artifact name due to limitations with ce
       (0, core_1.info)(`Artifact name is valid!`);
     }
     exports2.checkArtifactName = checkArtifactName;
-    function checkArtifactFilePath(path29) {
-      if (!path29) {
-        throw new Error(`Artifact path: ${path29}, is incorrectly provided`);
+    function checkArtifactFilePath(path30) {
+      if (!path30) {
+        throw new Error(`Artifact path: ${path30}, is incorrectly provided`);
       }
       for (const [invalidCharacterKey, errorMessageForCharacter] of invalidArtifactFilePathCharacters) {
-        if (path29.includes(invalidCharacterKey)) {
-          throw new Error(`Artifact path is not valid: ${path29}. Contains the following character: ${errorMessageForCharacter}
+        if (path30.includes(invalidCharacterKey)) {
+          throw new Error(`Artifact path is not valid: ${path30}. Contains the following character: ${errorMessageForCharacter}
           
 Invalid characters include: ${Array.from(invalidArtifactFilePathCharacters.values()).toString()}
           
@@ -121430,25 +121430,25 @@ var require_upload_specification = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getUploadSpecification = void 0;
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var core_1 = require_core3();
     var path_1 = require("path");
     var path_and_artifact_name_validation_1 = require_path_and_artifact_name_validation2();
     function getUploadSpecification(artifactName, rootDirectory, artifactFiles) {
       const specifications = [];
-      if (!fs31.existsSync(rootDirectory)) {
+      if (!fs32.existsSync(rootDirectory)) {
         throw new Error(`Provided rootDirectory ${rootDirectory} does not exist`);
       }
-      if (!fs31.statSync(rootDirectory).isDirectory()) {
+      if (!fs32.statSync(rootDirectory).isDirectory()) {
         throw new Error(`Provided rootDirectory ${rootDirectory} is not a valid directory`);
       }
       rootDirectory = (0, path_1.normalize)(rootDirectory);
       rootDirectory = (0, path_1.resolve)(rootDirectory);
       for (let file of artifactFiles) {
-        if (!fs31.existsSync(file)) {
+        if (!fs32.existsSync(file)) {
           throw new Error(`File ${file} does not exist`);
         }
-        if (!fs31.statSync(file).isDirectory()) {
+        if (!fs32.statSync(file).isDirectory()) {
           file = (0, path_1.normalize)(file);
           file = (0, path_1.resolve)(file);
           if (!file.startsWith(rootDirectory)) {
@@ -121473,11 +121473,11 @@ var require_upload_specification = __commonJS({
 // node_modules/tmp/lib/tmp.js
 var require_tmp = __commonJS({
   "node_modules/tmp/lib/tmp.js"(exports2, module2) {
-    var fs31 = require("fs");
+    var fs32 = require("fs");
     var os7 = require("os");
-    var path29 = require("path");
+    var path30 = require("path");
     var crypto3 = require("crypto");
-    var _c = { fs: fs31.constants, os: os7.constants };
+    var _c = { fs: fs32.constants, os: os7.constants };
     var RANDOM_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     var TEMPLATE_PATTERN = /XXXXXX/;
     var DEFAULT_TRIES = 3;
@@ -121489,13 +121489,13 @@ var require_tmp = __commonJS({
     var FILE_MODE = 384;
     var EXIT = "exit";
     var _removeObjects = [];
-    var FN_RMDIR_SYNC = fs31.rmdirSync.bind(fs31);
+    var FN_RMDIR_SYNC = fs32.rmdirSync.bind(fs32);
     var _gracefulCleanup = false;
     function rimraf(dirPath, callback) {
-      return fs31.rm(dirPath, { recursive: true }, callback);
+      return fs32.rm(dirPath, { recursive: true }, callback);
     }
     function FN_RIMRAF_SYNC(dirPath) {
-      return fs31.rmSync(dirPath, { recursive: true });
+      return fs32.rmSync(dirPath, { recursive: true });
     }
     function tmpName(options, callback) {
       const args = _parseArguments(options, callback), opts = args[0], cb = args[1];
@@ -121505,7 +121505,7 @@ var require_tmp = __commonJS({
         (function _getUniqueName() {
           try {
             const name = _generateTmpName(sanitizedOptions);
-            fs31.stat(name, function(err2) {
+            fs32.stat(name, function(err2) {
               if (!err2) {
                 if (tries-- > 0) return _getUniqueName();
                 return cb(new Error("Could not get a unique tmp filename, max tries reached " + name));
@@ -121525,7 +121525,7 @@ var require_tmp = __commonJS({
       do {
         const name = _generateTmpName(sanitizedOptions);
         try {
-          fs31.statSync(name);
+          fs32.statSync(name);
         } catch (e) {
           return name;
         }
@@ -121536,10 +121536,10 @@ var require_tmp = __commonJS({
       const args = _parseArguments(options, callback), opts = args[0], cb = args[1];
       tmpName(opts, function _tmpNameCreated(err, name) {
         if (err) return cb(err);
-        fs31.open(name, CREATE_FLAGS, opts.mode || FILE_MODE, function _fileCreated(err2, fd) {
+        fs32.open(name, CREATE_FLAGS, opts.mode || FILE_MODE, function _fileCreated(err2, fd) {
           if (err2) return cb(err2);
           if (opts.discardDescriptor) {
-            return fs31.close(fd, function _discardCallback(possibleErr) {
+            return fs32.close(fd, function _discardCallback(possibleErr) {
               return cb(possibleErr, name, void 0, _prepareTmpFileRemoveCallback(name, -1, opts, false));
             });
           } else {
@@ -121553,9 +121553,9 @@ var require_tmp = __commonJS({
       const args = _parseArguments(options), opts = args[0];
       const discardOrDetachDescriptor = opts.discardDescriptor || opts.detachDescriptor;
       const name = tmpNameSync(opts);
-      let fd = fs31.openSync(name, CREATE_FLAGS, opts.mode || FILE_MODE);
+      let fd = fs32.openSync(name, CREATE_FLAGS, opts.mode || FILE_MODE);
       if (opts.discardDescriptor) {
-        fs31.closeSync(fd);
+        fs32.closeSync(fd);
         fd = void 0;
       }
       return {
@@ -121568,7 +121568,7 @@ var require_tmp = __commonJS({
       const args = _parseArguments(options, callback), opts = args[0], cb = args[1];
       tmpName(opts, function _tmpNameCreated(err, name) {
         if (err) return cb(err);
-        fs31.mkdir(name, opts.mode || DIR_MODE, function _dirCreated(err2) {
+        fs32.mkdir(name, opts.mode || DIR_MODE, function _dirCreated(err2) {
           if (err2) return cb(err2);
           cb(null, name, _prepareTmpDirRemoveCallback(name, opts, false));
         });
@@ -121577,7 +121577,7 @@ var require_tmp = __commonJS({
     function dirSync(options) {
       const args = _parseArguments(options), opts = args[0];
       const name = tmpNameSync(opts);
-      fs31.mkdirSync(name, opts.mode || DIR_MODE);
+      fs32.mkdirSync(name, opts.mode || DIR_MODE);
       return {
         name,
         removeCallback: _prepareTmpDirRemoveCallback(name, opts, true)
@@ -121591,20 +121591,20 @@ var require_tmp = __commonJS({
         next();
       };
       if (0 <= fdPath[0])
-        fs31.close(fdPath[0], function() {
-          fs31.unlink(fdPath[1], _handler);
+        fs32.close(fdPath[0], function() {
+          fs32.unlink(fdPath[1], _handler);
         });
-      else fs31.unlink(fdPath[1], _handler);
+      else fs32.unlink(fdPath[1], _handler);
     }
     function _removeFileSync(fdPath) {
       let rethrownException = null;
       try {
-        if (0 <= fdPath[0]) fs31.closeSync(fdPath[0]);
+        if (0 <= fdPath[0]) fs32.closeSync(fdPath[0]);
       } catch (e) {
         if (!_isEBADF(e) && !_isENOENT(e)) throw e;
       } finally {
         try {
-          fs31.unlinkSync(fdPath[1]);
+          fs32.unlinkSync(fdPath[1]);
         } catch (e) {
           if (!_isENOENT(e)) rethrownException = e;
         }
@@ -121620,7 +121620,7 @@ var require_tmp = __commonJS({
       return sync ? removeCallbackSync : removeCallback;
     }
     function _prepareTmpDirRemoveCallback(name, opts, sync) {
-      const removeFunction = opts.unsafeCleanup ? rimraf : fs31.rmdir.bind(fs31);
+      const removeFunction = opts.unsafeCleanup ? rimraf : fs32.rmdir.bind(fs32);
       const removeFunctionSync = opts.unsafeCleanup ? FN_RIMRAF_SYNC : FN_RMDIR_SYNC;
       const removeCallbackSync = _prepareRemoveCallback(removeFunctionSync, name, sync);
       const removeCallback = _prepareRemoveCallback(removeFunction, name, sync, removeCallbackSync);
@@ -121682,35 +121682,35 @@ var require_tmp = __commonJS({
       return [actualOptions, callback];
     }
     function _resolvePath(name, tmpDir, cb) {
-      const pathToResolve = path29.isAbsolute(name) ? name : path29.join(tmpDir, name);
-      fs31.stat(pathToResolve, function(err) {
+      const pathToResolve = path30.isAbsolute(name) ? name : path30.join(tmpDir, name);
+      fs32.stat(pathToResolve, function(err) {
         if (err) {
-          fs31.realpath(path29.dirname(pathToResolve), function(err2, parentDir) {
+          fs32.realpath(path30.dirname(pathToResolve), function(err2, parentDir) {
             if (err2) return cb(err2);
-            cb(null, path29.join(parentDir, path29.basename(pathToResolve)));
+            cb(null, path30.join(parentDir, path30.basename(pathToResolve)));
           });
         } else {
-          fs31.realpath(pathToResolve, cb);
+          fs32.realpath(pathToResolve, cb);
         }
       });
     }
     function _resolvePathSync(name, tmpDir) {
-      const pathToResolve = path29.isAbsolute(name) ? name : path29.join(tmpDir, name);
+      const pathToResolve = path30.isAbsolute(name) ? name : path30.join(tmpDir, name);
       try {
-        fs31.statSync(pathToResolve);
-        return fs31.realpathSync(pathToResolve);
+        fs32.statSync(pathToResolve);
+        return fs32.realpathSync(pathToResolve);
       } catch (_err) {
-        const parentDir = fs31.realpathSync(path29.dirname(pathToResolve));
-        return path29.join(parentDir, path29.basename(pathToResolve));
+        const parentDir = fs32.realpathSync(path30.dirname(pathToResolve));
+        return path30.join(parentDir, path30.basename(pathToResolve));
       }
     }
     function _generateTmpName(opts) {
       const tmpDir = opts.tmpdir;
       if (!_isUndefined(opts.name)) {
-        return path29.join(tmpDir, opts.dir, opts.name);
+        return path30.join(tmpDir, opts.dir, opts.name);
       }
       if (!_isUndefined(opts.template)) {
-        return path29.join(tmpDir, opts.dir, opts.template).replace(TEMPLATE_PATTERN, _randomChars(6));
+        return path30.join(tmpDir, opts.dir, opts.template).replace(TEMPLATE_PATTERN, _randomChars(6));
       }
       const name = [
         opts.prefix ? opts.prefix : "tmp",
@@ -121720,7 +121720,7 @@ var require_tmp = __commonJS({
         _randomChars(12),
         opts.postfix ? "-" + opts.postfix : ""
       ].join("");
-      return path29.join(tmpDir, opts.dir, name);
+      return path30.join(tmpDir, opts.dir, name);
     }
     function _assertPath(option, value) {
       if (typeof value !== "string") {
@@ -121734,8 +121734,8 @@ var require_tmp = __commonJS({
     function _assertOptionsBase(options) {
       if (!_isUndefined(options.name)) {
         const name = options.name;
-        if (path29.isAbsolute(name)) throw new Error(`name option must not contain an absolute path, found "${name}".`);
-        const basename2 = path29.basename(name);
+        if (path30.isAbsolute(name)) throw new Error(`name option must not contain an absolute path, found "${name}".`);
+        const basename2 = path30.basename(name);
         if (basename2 === ".." || basename2 === "." || basename2 !== name) {
           throw new Error(`name option must not contain a path, found "${name}".`);
         }
@@ -121764,8 +121764,8 @@ var require_tmp = __commonJS({
       if (_isUndefined(name)) return cb(null);
       _resolvePath(name, tmpDir, function(err, resolvedPath) {
         if (err) return cb(err);
-        const relativePath2 = path29.relative(tmpDir, resolvedPath);
-        if (relativePath2.startsWith("..") || path29.isAbsolute(relativePath2)) {
+        const relativePath2 = path30.relative(tmpDir, resolvedPath);
+        if (relativePath2.startsWith("..") || path30.isAbsolute(relativePath2)) {
           return cb(new Error(`${option} option must be relative to "${tmpDir}", found "${relativePath2}".`));
         }
         cb(null, relativePath2);
@@ -121774,8 +121774,8 @@ var require_tmp = __commonJS({
     function _getRelativePathSync(option, name, tmpDir) {
       if (_isUndefined(name)) return;
       const resolvedPath = _resolvePathSync(name, tmpDir);
-      const relativePath2 = path29.relative(tmpDir, resolvedPath);
-      if (relativePath2.startsWith("..") || path29.isAbsolute(relativePath2)) {
+      const relativePath2 = path30.relative(tmpDir, resolvedPath);
+      if (relativePath2.startsWith("..") || path30.isAbsolute(relativePath2)) {
         throw new Error(`${option} option must be relative to "${tmpDir}", found "${relativePath2}".`);
       }
       return relativePath2;
@@ -121821,10 +121821,10 @@ var require_tmp = __commonJS({
       _gracefulCleanup = true;
     }
     function _getTmpDir(options, cb) {
-      return fs31.realpath(options && options.tmpdir || os7.tmpdir(), cb);
+      return fs32.realpath(options && options.tmpdir || os7.tmpdir(), cb);
     }
     function _getTmpDirSync(options) {
-      return fs31.realpathSync(options && options.tmpdir || os7.tmpdir());
+      return fs32.realpathSync(options && options.tmpdir || os7.tmpdir());
     }
     process.addListener(EXIT, _garbageCollector);
     Object.defineProperty(module2.exports, "tmpdir", {
@@ -121854,14 +121854,14 @@ var require_tmp_promise = __commonJS({
     var fileWithOptions = promisify(
       (options, cb) => tmp.file(
         options,
-        (err, path29, fd, cleanup) => err ? cb(err) : cb(void 0, { path: path29, fd, cleanup: promisify(cleanup) })
+        (err, path30, fd, cleanup) => err ? cb(err) : cb(void 0, { path: path30, fd, cleanup: promisify(cleanup) })
       )
     );
     module2.exports.file = async (options) => fileWithOptions(options);
     module2.exports.withFile = async function withFile(fn, options) {
-      const { path: path29, fd, cleanup } = await module2.exports.file(options);
+      const { path: path30, fd, cleanup } = await module2.exports.file(options);
       try {
-        return await fn({ path: path29, fd });
+        return await fn({ path: path30, fd });
       } finally {
         await cleanup();
       }
@@ -121870,14 +121870,14 @@ var require_tmp_promise = __commonJS({
     var dirWithOptions = promisify(
       (options, cb) => tmp.dir(
         options,
-        (err, path29, cleanup) => err ? cb(err) : cb(void 0, { path: path29, cleanup: promisify(cleanup) })
+        (err, path30, cleanup) => err ? cb(err) : cb(void 0, { path: path30, cleanup: promisify(cleanup) })
       )
     );
     module2.exports.dir = async (options) => dirWithOptions(options);
     module2.exports.withDir = async function withDir(fn, options) {
-      const { path: path29, cleanup } = await module2.exports.dir(options);
+      const { path: path30, cleanup } = await module2.exports.dir(options);
       try {
-        return await fn({ path: path29 });
+        return await fn({ path: path30 });
       } finally {
         await cleanup();
       }
@@ -122678,10 +122678,10 @@ var require_upload_gzip = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.createGZipFileInBuffer = exports2.createGZipFileOnDisk = void 0;
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var zlib3 = __importStar2(require("zlib"));
     var util_1 = require("util");
-    var stat2 = (0, util_1.promisify)(fs31.stat);
+    var stat2 = (0, util_1.promisify)(fs32.stat);
     var gzipExemptFileExtensions = [
       ".gz",
       ".gzip",
@@ -122714,9 +122714,9 @@ var require_upload_gzip = __commonJS({
           }
         }
         return new Promise((resolve14, reject) => {
-          const inputStream = fs31.createReadStream(originalFilePath);
+          const inputStream = fs32.createReadStream(originalFilePath);
           const gzip = zlib3.createGzip();
-          const outputStream = fs31.createWriteStream(tempFilePath);
+          const outputStream = fs32.createWriteStream(tempFilePath);
           inputStream.pipe(gzip).pipe(outputStream);
           outputStream.on("finish", () => __awaiter2(this, void 0, void 0, function* () {
             const size = (yield stat2(tempFilePath)).size;
@@ -122734,7 +122734,7 @@ var require_upload_gzip = __commonJS({
       return __awaiter2(this, void 0, void 0, function* () {
         return new Promise((resolve14) => __awaiter2(this, void 0, void 0, function* () {
           var _a2, e_1, _b, _c;
-          const inputStream = fs31.createReadStream(originalFilePath);
+          const inputStream = fs32.createReadStream(originalFilePath);
           const gzip = zlib3.createGzip();
           inputStream.pipe(gzip);
           const chunks = [];
@@ -122943,7 +122943,7 @@ var require_upload_http_client = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.UploadHttpClient = void 0;
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var core31 = __importStar2(require_core3());
     var tmp = __importStar2(require_tmp_promise());
     var stream2 = __importStar2(require("stream"));
@@ -122957,7 +122957,7 @@ var require_upload_http_client = __commonJS({
     var http_manager_1 = require_http_manager();
     var upload_gzip_1 = require_upload_gzip();
     var requestUtils_1 = require_requestUtils2();
-    var stat2 = (0, util_1.promisify)(fs31.stat);
+    var stat2 = (0, util_1.promisify)(fs32.stat);
     var UploadHttpClient = class {
       constructor() {
         this.uploadHttpManager = new http_manager_1.HttpManager((0, config_variables_1.getUploadFileConcurrency)(), "@actions/artifact-upload");
@@ -123094,7 +123094,7 @@ var require_upload_http_client = __commonJS({
             let openUploadStream;
             if (totalFileSize < buffer.byteLength) {
               core31.debug(`The gzip file created for ${parameters.file} did not help with reducing the size of the file. The original file will be uploaded as-is`);
-              openUploadStream = () => fs31.createReadStream(parameters.file);
+              openUploadStream = () => fs32.createReadStream(parameters.file);
               isGzip = false;
               uploadFileSize = totalFileSize;
             } else {
@@ -123140,7 +123140,7 @@ var require_upload_http_client = __commonJS({
                 failedChunkSizes += chunkSize;
                 continue;
               }
-              const result = yield this.uploadChunk(httpClientIndex, parameters.resourceUrl, () => fs31.createReadStream(uploadFilePath, {
+              const result = yield this.uploadChunk(httpClientIndex, parameters.resourceUrl, () => fs32.createReadStream(uploadFilePath, {
                 start: startChunkIndex,
                 end: endChunkIndex,
                 autoClose: false
@@ -123335,7 +123335,7 @@ var require_download_http_client = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.DownloadHttpClient = void 0;
-    var fs31 = __importStar2(require("fs"));
+    var fs32 = __importStar2(require("fs"));
     var core31 = __importStar2(require_core3());
     var zlib3 = __importStar2(require("zlib"));
     var utils_1 = require_utils11();
@@ -123426,7 +123426,7 @@ var require_download_http_client = __commonJS({
         return __awaiter2(this, void 0, void 0, function* () {
           let retryCount = 0;
           const retryLimit = (0, config_variables_1.getRetryLimit)();
-          let destinationStream = fs31.createWriteStream(downloadPath);
+          let destinationStream = fs32.createWriteStream(downloadPath);
           const headers = (0, utils_1.getDownloadHeaders)("application/json", true, true);
           const makeDownloadRequest = () => __awaiter2(this, void 0, void 0, function* () {
             const client = this.downloadHttpManager.getClient(httpClientIndex);
@@ -123468,7 +123468,7 @@ var require_download_http_client = __commonJS({
               }
             });
             yield (0, utils_1.rmFile)(fileDownloadPath);
-            destinationStream = fs31.createWriteStream(fileDownloadPath);
+            destinationStream = fs32.createWriteStream(fileDownloadPath);
           });
           while (retryCount <= retryLimit) {
             let response;
@@ -123585,21 +123585,21 @@ var require_download_specification = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getDownloadSpecification = void 0;
-    var path29 = __importStar2(require("path"));
+    var path30 = __importStar2(require("path"));
     function getDownloadSpecification(artifactName, artifactEntries, downloadPath, includeRootDirectory) {
       const directories = /* @__PURE__ */ new Set();
       const specifications = {
-        rootDownloadLocation: includeRootDirectory ? path29.join(downloadPath, artifactName) : downloadPath,
+        rootDownloadLocation: includeRootDirectory ? path30.join(downloadPath, artifactName) : downloadPath,
         directoryStructure: [],
         emptyFilesToCreate: [],
         filesToDownload: []
       };
       for (const entry of artifactEntries) {
         if (entry.path.startsWith(`${artifactName}/`) || entry.path.startsWith(`${artifactName}\\`)) {
-          const normalizedPathEntry = path29.normalize(entry.path);
-          const filePath = path29.join(downloadPath, includeRootDirectory ? normalizedPathEntry : normalizedPathEntry.replace(artifactName, ""));
+          const normalizedPathEntry = path30.normalize(entry.path);
+          const filePath = path30.join(downloadPath, includeRootDirectory ? normalizedPathEntry : normalizedPathEntry.replace(artifactName, ""));
           if (entry.itemType === "file") {
-            directories.add(path29.dirname(filePath));
+            directories.add(path30.dirname(filePath));
             if (entry.fileLength === 0) {
               specifications.emptyFilesToCreate.push(filePath);
             } else {
@@ -123741,7 +123741,7 @@ Note: The size of downloaded zips can differ significantly from the reported siz
           return uploadResponse;
         });
       }
-      downloadArtifact(name, path29, options) {
+      downloadArtifact(name, path30, options) {
         return __awaiter2(this, void 0, void 0, function* () {
           const downloadHttpClient = new download_http_client_1.DownloadHttpClient();
           const artifacts = yield downloadHttpClient.listArtifacts();
@@ -123755,12 +123755,12 @@ Note: The size of downloaded zips can differ significantly from the reported siz
             throw new Error(`Unable to find an artifact with the name: ${name}`);
           }
           const items = yield downloadHttpClient.getContainerItems(artifactToDownload.name, artifactToDownload.fileContainerResourceUrl);
-          if (!path29) {
-            path29 = (0, config_variables_1.getWorkSpaceDirectory)();
+          if (!path30) {
+            path30 = (0, config_variables_1.getWorkSpaceDirectory)();
           }
-          path29 = (0, path_1.normalize)(path29);
-          path29 = (0, path_1.resolve)(path29);
-          const downloadSpecification = (0, download_specification_1.getDownloadSpecification)(name, items.value, path29, (options === null || options === void 0 ? void 0 : options.createArtifactFolder) || false);
+          path30 = (0, path_1.normalize)(path30);
+          path30 = (0, path_1.resolve)(path30);
+          const downloadSpecification = (0, download_specification_1.getDownloadSpecification)(name, items.value, path30, (options === null || options === void 0 ? void 0 : options.createArtifactFolder) || false);
           if (downloadSpecification.filesToDownload.length === 0) {
             core31.info(`No downloadable files were found for the artifact: ${artifactToDownload.name}`);
           } else {
@@ -123775,7 +123775,7 @@ Note: The size of downloaded zips can differ significantly from the reported siz
           };
         });
       }
-      downloadAllArtifacts(path29) {
+      downloadAllArtifacts(path30) {
         return __awaiter2(this, void 0, void 0, function* () {
           const downloadHttpClient = new download_http_client_1.DownloadHttpClient();
           const response = [];
@@ -123784,18 +123784,18 @@ Note: The size of downloaded zips can differ significantly from the reported siz
             core31.info("Unable to find any artifacts for the associated workflow");
             return response;
           }
-          if (!path29) {
-            path29 = (0, config_variables_1.getWorkSpaceDirectory)();
+          if (!path30) {
+            path30 = (0, config_variables_1.getWorkSpaceDirectory)();
           }
-          path29 = (0, path_1.normalize)(path29);
-          path29 = (0, path_1.resolve)(path29);
+          path30 = (0, path_1.normalize)(path30);
+          path30 = (0, path_1.resolve)(path30);
           let downloadedArtifacts = 0;
           while (downloadedArtifacts < artifacts.count) {
             const currentArtifactToDownload = artifacts.value[downloadedArtifacts];
             downloadedArtifacts += 1;
             core31.info(`starting download of artifact ${currentArtifactToDownload.name} : ${downloadedArtifacts}/${artifacts.count}`);
             const items = yield downloadHttpClient.getContainerItems(currentArtifactToDownload.name, currentArtifactToDownload.fileContainerResourceUrl);
-            const downloadSpecification = (0, download_specification_1.getDownloadSpecification)(currentArtifactToDownload.name, items.value, path29, true);
+            const downloadSpecification = (0, download_specification_1.getDownloadSpecification)(currentArtifactToDownload.name, items.value, path30, true);
             if (downloadSpecification.filesToDownload.length === 0) {
               core31.info(`No downloadable files were found for any artifact ${currentArtifactToDownload.name}`);
             } else {
@@ -141674,8 +141674,8 @@ __export(entry_points_exports, {
 module.exports = __toCommonJS(entry_points_exports);
 
 // src/analyze-action.ts
-var fs22 = __toESM(require("fs"));
-var import_path4 = __toESM(require("path"));
+var fs23 = __toESM(require("fs"));
+var import_path5 = __toESM(require("path"));
 var import_perf_hooks4 = require("perf_hooks");
 var core16 = __toESM(require_core());
 
@@ -141769,21 +141769,21 @@ async function getFolderSize(itemPath, options) {
 getFolderSize.loose = async (itemPath, options) => await core(itemPath, options);
 getFolderSize.strict = async (itemPath, options) => await core(itemPath, options, { strict: true });
 async function core(rootItemPath, options = {}, returnType = {}) {
-  const fs31 = options.fs || await import("node:fs/promises");
+  const fs32 = options.fs || await import("node:fs/promises");
   let folderSize = 0n;
   const foundInos = /* @__PURE__ */ new Set();
   const errors = [];
   await processItem(rootItemPath);
   async function processItem(itemPath) {
     if (options.ignore?.test(itemPath)) return;
-    const stats = returnType.strict ? await fs31.lstat(itemPath, { bigint: true }) : await fs31.lstat(itemPath, { bigint: true }).catch((error3) => errors.push(error3));
+    const stats = returnType.strict ? await fs32.lstat(itemPath, { bigint: true }) : await fs32.lstat(itemPath, { bigint: true }).catch((error3) => errors.push(error3));
     if (typeof stats !== "object") return;
     if (!foundInos.has(stats.ino)) {
       foundInos.add(stats.ino);
       folderSize += stats.size;
     }
     if (stats.isDirectory()) {
-      const directoryItems = returnType.strict ? await fs31.readdir(itemPath) : await fs31.readdir(itemPath).catch((error3) => errors.push(error3));
+      const directoryItems = returnType.strict ? await fs32.readdir(itemPath) : await fs32.readdir(itemPath).catch((error3) => errors.push(error3));
       if (typeof directoryItems !== "object") return;
       await Promise.all(
         directoryItems.map(
@@ -144782,7 +144782,7 @@ function array(validator) {
   };
   return {
     validate: validate2,
-    check: (val, opts, path29) => {
+    check: (val, opts, path30) => {
       const result = successfulCheckSchema();
       if (!isArray(val)) {
         result.valid = false;
@@ -144790,7 +144790,7 @@ function array(validator) {
       }
       let index2 = 0;
       for (const e of val) {
-        const elementPath = `${path29}[${index2}]`;
+        const elementPath = `${path30}[${index2}]`;
         const eResult = validator.check(e, opts, `${elementPath}`);
         result.invalidKeys.push(...eResult.invalidKeys);
         result.unknownKeys.push(...eResult.unknownKeys);
@@ -144816,11 +144816,11 @@ function object(schema) {
     validate: (val) => {
       return isObject(val) && validateSchema(schema, val);
     },
-    check: (val, opts, path29) => {
+    check: (val, opts, path30) => {
       if (!isObject(val)) {
         return invalidCheckSchema();
       }
-      return checkSchema(schema, val, opts, path29);
+      return checkSchema(schema, val, opts, path30);
     },
     required: true
   };
@@ -144830,11 +144830,11 @@ function optionalOrNull(validator) {
     validate: (val) => {
       return val === void 0 || val === null || validator.validate(val);
     },
-    check: (val, opts, path29) => {
+    check: (val, opts, path30) => {
       if (val === void 0 || val === null) {
         return successfulCheckSchema();
       }
-      return validator.check(val, opts, path29);
+      return validator.check(val, opts, path30);
     },
     required: false
   };
@@ -144844,11 +144844,11 @@ function optional(validator) {
     validate: (val) => {
       return val === void 0 || validator.validate(val);
     },
-    check: (val, opts, path29) => {
+    check: (val, opts, path30) => {
       if (val === void 0) {
         return successfulCheckSchema();
       }
-      return validator.check(val, opts, path29);
+      return validator.check(val, opts, path30);
     },
     required: false
   };
@@ -144875,7 +144875,7 @@ function invalidCheckSchema() {
     invalidKeys: []
   };
 }
-function checkSchema(schema, obj, options = {}, path29 = "") {
+function checkSchema(schema, obj, options = {}, path30 = "") {
   const result = successfulCheckSchema();
   const inputKeys = new Set(Object.keys(obj));
   const invalidKeys = /* @__PURE__ */ new Set();
@@ -144898,7 +144898,7 @@ function checkSchema(schema, obj, options = {}, path29 = "") {
       continue;
     }
     if (hasKey) {
-      const checkResult = validator.check(obj[key], options, `${path29}.${key}`);
+      const checkResult = validator.check(obj[key], options, `${path30}.${key}`);
       result.unknownKeys.push(...checkResult.unknownKeys);
       result.invalidKeys.push(...checkResult.invalidKeys);
       if (checkResult.invalidKeys.length > 0) {
@@ -144915,10 +144915,10 @@ function checkSchema(schema, obj, options = {}, path29 = "") {
     invalidKeys.delete(key);
   }
   for (const remainingKey of inputKeys) {
-    result.unknownKeys.push(`${path29}.${remainingKey}`);
+    result.unknownKeys.push(`${path30}.${remainingKey}`);
   }
   for (const invalidKey of invalidKeys) {
-    result.invalidKeys.push(`${path29}.${invalidKey}`);
+    result.invalidKeys.push(`${path30}.${invalidKey}`);
   }
   return result;
 }
@@ -145241,7 +145241,6 @@ function asHTTPError(arg) {
   }
   return void 0;
 }
-var cachedCodeQlVersion = void 0;
 function isVersionInfo(x) {
   const candidate = x;
   return typeof candidate === "object" && candidate !== null && typeof candidate.version === "string" && (candidate.features === void 0 || typeof candidate.features === "object" && candidate.features !== null) && (candidate.overlayVersion === void 0 || typeof candidate.overlayVersion === "number");
@@ -145249,42 +145248,6 @@ function isVersionInfo(x) {
 function isPersistedVersionInfo(x) {
   const candidate = x;
   return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && isVersionInfo(candidate.version);
-}
-function getPathToCodeQLVersionCacheFile(env) {
-  return path.join(getTemporaryDirectory(env), "version.json");
-}
-function cacheCodeQlVersion(cmd, version, env = getEnv()) {
-  if (cachedCodeQlVersion !== void 0) {
-    throw new Error("cacheCodeQlVersion() should be called only once");
-  }
-  cachedCodeQlVersion = version;
-  fs.writeFileSync(
-    getPathToCodeQLVersionCacheFile(env),
-    JSON.stringify({ cmd, version }),
-    "utf8"
-  );
-}
-function getCachedCodeQlVersion(cmd, env = getEnv()) {
-  if (cachedCodeQlVersion !== void 0) {
-    return cachedCodeQlVersion;
-  }
-  let serialized;
-  try {
-    serialized = fs.readFileSync(getPathToCodeQLVersionCacheFile(env), "utf8");
-  } catch {
-    return void 0;
-  }
-  let persisted;
-  try {
-    persisted = JSON.parse(serialized);
-  } catch {
-    return void 0;
-  }
-  if (!isPersistedVersionInfo(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
-    return void 0;
-  }
-  cachedCodeQlVersion = persisted.version;
-  return cachedCodeQlVersion;
 }
 async function codeQlVersionAtLeast(codeql, requiredVersion) {
   return semver.gte((await codeql.getVersion()).version, requiredVersion);
@@ -146288,6 +146251,48 @@ function wrapApiConfigurationError(e) {
   return e;
 }
 
+// src/cli/output-cache.ts
+var fs3 = __toESM(require("fs"));
+var import_path = __toESM(require("path"));
+var COMMAND_CACHE_FILENAME = "codeql-action-command-cache.json";
+var cachedCodeQlVersion = void 0;
+function getCommandCacheFilePath(env) {
+  return import_path.default.join(getTemporaryDirectory(env), COMMAND_CACHE_FILENAME);
+}
+function cacheCodeQlVersion(cmd, version, env = getEnv()) {
+  if (cachedCodeQlVersion !== void 0) {
+    throw new Error("cacheCodeQlVersion() should be called only once");
+  }
+  cachedCodeQlVersion = version;
+  fs3.writeFileSync(
+    getCommandCacheFilePath(env),
+    JSON.stringify({ cmd, version }),
+    "utf8"
+  );
+}
+function getCachedCodeQlVersion(cmd, env = getEnv()) {
+  if (cachedCodeQlVersion !== void 0) {
+    return cachedCodeQlVersion;
+  }
+  let serialized;
+  try {
+    serialized = fs3.readFileSync(getCommandCacheFilePath(env), "utf8");
+  } catch {
+    return void 0;
+  }
+  let persisted;
+  try {
+    persisted = JSON.parse(serialized);
+  } catch {
+    return void 0;
+  }
+  if (!isPersistedVersionInfo(persisted) || cmd !== void 0 && persisted.cmd !== cmd) {
+    return void 0;
+  }
+  cachedCodeQlVersion = persisted.version;
+  return cachedCodeQlVersion;
+}
+
 // src/config/pack-registries.ts
 function parseRegistries(registriesInput) {
   try {
@@ -146306,9 +146311,9 @@ function parseRegistriesWithoutCredentials(registriesInput) {
 }
 
 // src/git-utils.ts
-var fs3 = __toESM(require("fs"));
+var fs4 = __toESM(require("fs"));
 var os2 = __toESM(require("os"));
-var path3 = __toESM(require("path"));
+var path4 = __toESM(require("path"));
 var core6 = __toESM(require_core());
 var toolrunner2 = __toESM(require_toolrunner());
 var io3 = __toESM(require_io());
@@ -146457,7 +146462,7 @@ var getGitRoot = async function(sourceRoot) {
   }
 };
 function hasSubmodules(gitRoot) {
-  return fs3.existsSync(path3.join(gitRoot, ".gitmodules"));
+  return fs4.existsSync(path4.join(gitRoot, ".gitmodules"));
 }
 var getFileOidsUnderPath = async function(basePath) {
   const gitRoot = await getGitRoot(basePath);
@@ -147070,8 +147075,8 @@ async function runInActions(action) {
 }
 
 // src/feature-flags.ts
-var fs5 = __toESM(require("fs"));
-var path5 = __toESM(require("path"));
+var fs6 = __toESM(require("fs"));
+var path6 = __toESM(require("path"));
 var semver4 = __toESM(require_semver2());
 
 // src/defaults.json
@@ -147079,8 +147084,8 @@ var bundleVersion = "codeql-bundle-v2.26.2";
 var cliVersion = "2.26.2";
 
 // src/overlay/index.ts
-var fs4 = __toESM(require("fs"));
-var path4 = __toESM(require("path"));
+var fs5 = __toESM(require("fs"));
+var path5 = __toESM(require("path"));
 var CODEQL_OVERLAY_MINIMUM_VERSION = "2.23.8";
 var CODEQL_OVERLAY_MINIMUM_VERSION_CPP = "2.25.0";
 var CODEQL_OVERLAY_MINIMUM_VERSION_CSHARP = "2.24.1";
@@ -147093,12 +147098,12 @@ async function writeBaseDatabaseOidsFile(config, sourceRoot) {
   const gitFileOids = await getFileOidsUnderPath(sourceRoot);
   const gitFileOidsJson = JSON.stringify(gitFileOids);
   const baseDatabaseOidsFilePath = getBaseDatabaseOidsFilePath(config);
-  await fs4.promises.writeFile(baseDatabaseOidsFilePath, gitFileOidsJson);
+  await fs5.promises.writeFile(baseDatabaseOidsFilePath, gitFileOidsJson);
 }
 async function readBaseDatabaseOidsFile(config, logger) {
   const baseDatabaseOidsFilePath = getBaseDatabaseOidsFilePath(config);
   try {
-    const contents = await fs4.promises.readFile(
+    const contents = await fs5.promises.readFile(
       baseDatabaseOidsFilePath,
       "utf-8"
     );
@@ -147120,14 +147125,14 @@ async function writeOverlayChangesFile(config, sourceRoot, logger) {
   const diffRangeFiles = await getDiffRangeFilePaths(sourceRoot, logger);
   const changedFiles = [.../* @__PURE__ */ new Set([...oidChangedFiles, ...diffRangeFiles])];
   const changedFilesJson = JSON.stringify({ changes: changedFiles });
-  const overlayChangesFile = path4.join(
+  const overlayChangesFile = path5.join(
     getTemporaryDirectory(),
     "overlay-changes.json"
   );
   logger.debug(
     `Writing overlay changed files to ${overlayChangesFile}: ${changedFilesJson}`
   );
-  await fs4.promises.writeFile(overlayChangesFile, changedFilesJson);
+  await fs5.promises.writeFile(overlayChangesFile, changedFilesJson);
   return overlayChangesFile;
 }
 function computeChangedFiles(baseFileOids, overlayFileOids) {
@@ -147146,7 +147151,7 @@ function computeChangedFiles(baseFileOids, overlayFileOids) {
 }
 async function getDiffRangeFilePaths(sourceRoot, logger) {
   const jsonFilePath = getDiffRangesJsonFilePath();
-  if (!fs4.existsSync(jsonFilePath)) {
+  if (!fs5.existsSync(jsonFilePath)) {
     logger.debug(
       `No diff ranges JSON file found at ${jsonFilePath}; skipping.`
     );
@@ -147154,7 +147159,7 @@ async function getDiffRangeFilePaths(sourceRoot, logger) {
   }
   let contents;
   try {
-    contents = await fs4.promises.readFile(jsonFilePath, "utf8");
+    contents = await fs5.promises.readFile(jsonFilePath, "utf8");
   } catch (e) {
     logger.warning(
       `Failed to read diff ranges JSON file at ${jsonFilePath}: ${e}`
@@ -147186,7 +147191,7 @@ async function getDiffRangeFilePaths(sourceRoot, logger) {
     return [...new Set(diffRanges.map((r) => r.path))];
   }
   const relativePaths = diffRanges.map(
-    (r) => path4.relative(sourceRoot, path4.join(repoRoot, r.path)).replaceAll(path4.sep, "/")
+    (r) => path5.relative(sourceRoot, path5.join(repoRoot, r.path)).replaceAll(path5.sep, "/")
   ).filter((rel) => !rel.startsWith(".."));
   return [...new Set(relativePaths)];
 }
@@ -147556,7 +147561,7 @@ var Features = class extends OfflineFeatures {
     super(logger);
     this.gitHubFeatureFlags = new GitHubFeatureFlags(
       repositoryNwo,
-      path5.join(tempDir, FEATURE_FLAGS_FILE_NAME),
+      path6.join(tempDir, FEATURE_FLAGS_FILE_NAME),
       logger
     );
   }
@@ -147688,12 +147693,12 @@ var GitHubFeatureFlags = class {
   }
   async readLocalFlags() {
     try {
-      if (fs5.existsSync(this.featureFlagsFile)) {
+      if (fs6.existsSync(this.featureFlagsFile)) {
         this.logger.debug(
           `Loading feature flags from ${this.featureFlagsFile}`
         );
         return JSON.parse(
-          fs5.readFileSync(this.featureFlagsFile, "utf8")
+          fs6.readFileSync(this.featureFlagsFile, "utf8")
         );
       }
     } catch (e) {
@@ -147706,7 +147711,7 @@ var GitHubFeatureFlags = class {
   async writeLocalFlags(flags) {
     try {
       this.logger.debug(`Writing feature flags to ${this.featureFlagsFile}`);
-      fs5.writeFileSync(this.featureFlagsFile, JSON.stringify(flags));
+      fs6.writeFileSync(this.featureFlagsFile, JSON.stringify(flags));
     } catch (e) {
       this.logger.warning(
         `Error writing cached feature flags file ${this.featureFlagsFile}: ${e}.`
@@ -147921,8 +147926,8 @@ var SarifScanOrder = [
 ];
 
 // src/analyze.ts
-var fs16 = __toESM(require("fs"));
-var path15 = __toESM(require("path"));
+var fs17 = __toESM(require("fs"));
+var path16 = __toESM(require("path"));
 var import_perf_hooks3 = require("perf_hooks");
 var io5 = __toESM(require_io());
 
@@ -147930,8 +147935,8 @@ var io5 = __toESM(require_io());
 var core13 = __toESM(require_core());
 
 // src/codeql.ts
-var fs15 = __toESM(require("fs"));
-var path14 = __toESM(require("path"));
+var fs16 = __toESM(require("fs"));
+var path15 = __toESM(require("path"));
 var core12 = __toESM(require_core());
 var toolrunner3 = __toESM(require_toolrunner());
 
@@ -148184,8 +148189,8 @@ function wrapCliConfigurationError(cliError) {
 }
 
 // src/config-utils.ts
-var fs9 = __toESM(require("fs"));
-var path10 = __toESM(require("path"));
+var fs10 = __toESM(require("fs"));
+var path11 = __toESM(require("path"));
 var import_perf_hooks = require("perf_hooks");
 var core10 = __toESM(require_core());
 
@@ -148240,13 +148245,13 @@ function getDependencyCachingEnabled() {
 }
 
 // src/config/db-config.ts
-var path7 = __toESM(require("path"));
+var path8 = __toESM(require("path"));
 var jsonschema = __toESM(require_lib2());
 var semver5 = __toESM(require_semver2());
 
 // src/diagnostics.ts
 var import_fs = require("fs");
-var import_path = __toESM(require("path"));
+var import_path2 = __toESM(require("path"));
 var unwrittenDiagnostics = [];
 var unwrittenDefaultLanguageDiagnostics = [];
 var diagnosticCounter = 0;
@@ -148285,7 +148290,7 @@ function addNoLanguageDiagnostic(config, diagnostic) {
 function writeDiagnostic(config, language, diagnostic) {
   const logger = getActionsLogger();
   const databasePath = language ? getCodeQLDatabasePath(config, language) : config.dbLocation;
-  const diagnosticsPath = import_path.default.resolve(
+  const diagnosticsPath = import_path2.default.resolve(
     databasePath,
     "diagnostic",
     "codeql-action"
@@ -148297,7 +148302,7 @@ function writeDiagnostic(config, language, diagnostic) {
       /[^a-zA-Z0-9.-]/g,
       ""
     );
-    const jsonPath = import_path.default.resolve(
+    const jsonPath = import_path2.default.resolve(
       diagnosticsPath,
       `codeql-action-${sanitizedTimestamp}-${uniqueSuffix}.json`
     );
@@ -148645,11 +148650,11 @@ function parsePacksSpecification(packStr) {
       throw new ConfigurationError(getPacksStrInvalid(packStr));
     }
   }
-  if (packPath && (path7.isAbsolute(packPath) || // Permit using "/" instead of "\" on Windows
+  if (packPath && (path8.isAbsolute(packPath) || // Permit using "/" instead of "\" on Windows
   // Use `x.split(y).join(z)` as a polyfill for `x.replaceAll(y, z)` since
   // if we used a regex we'd need to escape the path separator on Windows
   // which seems more awkward.
-  path7.normalize(packPath).split(path7.sep).join("/") !== packPath.split(path7.sep).join("/"))) {
+  path8.normalize(packPath).split(path8.sep).join("/") !== packPath.split(path8.sep).join("/"))) {
     throw new ConfigurationError(getPacksStrInvalid(packStr));
   }
   if (!packPath && pathStart) {
@@ -148882,12 +148887,12 @@ function parseNewRemoteFileAddress(env, configFile) {
     return new Failure(void 0);
   }
   const owner = pieces.groups.owner?.trim();
-  const path29 = pieces.groups.path?.trim();
+  const path30 = pieces.groups.path?.trim();
   const ref = pieces.groups.ref?.trim();
   return new Success({
     owner: owner || getDefaultOwner(env),
     repo,
-    path: path29 || DEFAULT_CONFIG_FILE_NAME,
+    path: path30 || DEFAULT_CONFIG_FILE_NAME,
     ref: ref || DEFAULT_CONFIG_FILE_REF
   });
 }
@@ -148986,7 +148991,7 @@ async function getRemoteConfig(actionState, configFile, apiDetails) {
 }
 
 // src/diff-informed-analysis-utils.ts
-var fs6 = __toESM(require("fs"));
+var fs7 = __toESM(require("fs"));
 async function getDiffInformedAnalysisBranches(codeql, features, logger) {
   if (!await features.getValue("diff_informed_queries" /* DiffInformedQueries */, codeql)) {
     return void 0;
@@ -149028,7 +149033,7 @@ async function prepareDiffInformedAnalysis(codeql, features, logger) {
 function writeDiffRangesJsonFile(logger, ranges) {
   const jsonContents = JSON.stringify(ranges, null, 2);
   const jsonFilePath = getDiffRangesJsonFilePath();
-  fs6.writeFileSync(jsonFilePath, jsonContents);
+  fs7.writeFileSync(jsonFilePath, jsonContents);
   logger.debug(
     `Wrote pr-diff-range JSON file to ${jsonFilePath}:
 ${jsonContents}`
@@ -149036,11 +149041,11 @@ ${jsonContents}`
 }
 function readDiffRangesJsonFile(logger) {
   const jsonFilePath = getDiffRangesJsonFilePath();
-  if (!fs6.existsSync(jsonFilePath)) {
+  if (!fs7.existsSync(jsonFilePath)) {
     logger.debug(`Diff ranges JSON file does not exist at ${jsonFilePath}`);
     return void 0;
   }
-  const jsonContents = fs6.readFileSync(jsonFilePath, "utf8");
+  const jsonContents = fs7.readFileSync(jsonFilePath, "utf8");
   logger.debug(
     `Read pr-diff-range JSON file from ${jsonFilePath}:
 ${jsonContents}`
@@ -149291,13 +149296,13 @@ Improved incremental analysis will be automatically retried when the next versio
 }
 
 // src/overlay/status.ts
-var fs7 = __toESM(require("fs"));
-var path8 = __toESM(require("path"));
+var fs8 = __toESM(require("fs"));
+var path9 = __toESM(require("path"));
 var actionsCache = __toESM(require_cache4());
 var MAX_CACHE_OPERATION_MS = 3e4;
 var STATUS_FILE_NAME = "overlay-status.json";
 function getStatusFilePath(languages) {
-  return path8.join(
+  return path9.join(
     getTemporaryDirectory(),
     "overlay-status",
     [...languages].sort().join("+"),
@@ -149336,7 +149341,7 @@ async function getOverlayStatus(codeql, languages, diskUsage, logger) {
   const cacheKey3 = await getCacheKey(codeql, languages, diskUsage);
   const statusFile = getStatusFilePath(languages);
   try {
-    await fs7.promises.mkdir(path8.dirname(statusFile), { recursive: true });
+    await fs8.promises.mkdir(path9.dirname(statusFile), { recursive: true });
     const foundKey = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.restoreCache([statusFile], cacheKey3),
@@ -149348,13 +149353,13 @@ async function getOverlayStatus(codeql, languages, diskUsage, logger) {
       logger.debug("No overlay status found in Actions cache.");
       return void 0;
     }
-    if (!fs7.existsSync(statusFile)) {
+    if (!fs8.existsSync(statusFile)) {
       logger.debug(
         "Overlay status cache entry found but status file is missing."
       );
       return void 0;
     }
-    const contents = await fs7.promises.readFile(statusFile, "utf-8");
+    const contents = await fs8.promises.readFile(statusFile, "utf-8");
     const parsed = JSON.parse(contents);
     if (!isObject(parsed) || typeof parsed["attemptedToBuildOverlayBaseDatabase"] !== "boolean" || typeof parsed["builtOverlayBaseDatabase"] !== "boolean") {
       logger.debug(
@@ -149374,8 +149379,8 @@ async function saveOverlayStatus(codeql, languages, diskUsage, status, logger) {
   const cacheKey3 = await getCacheKey(codeql, languages, diskUsage);
   const statusFile = getStatusFilePath(languages);
   try {
-    await fs7.promises.mkdir(path8.dirname(statusFile), { recursive: true });
-    await fs7.promises.writeFile(statusFile, JSON.stringify(status));
+    await fs8.promises.mkdir(path9.dirname(statusFile), { recursive: true });
+    await fs8.promises.writeFile(statusFile, JSON.stringify(status));
     const cacheId = await waitForResultWithTimeLimit(
       MAX_CACHE_OPERATION_MS,
       actionsCache.saveCache([statusFile], cacheKey3),
@@ -149401,8 +149406,8 @@ async function getCacheKey(codeql, languages, diskUsage) {
 }
 
 // src/trap-caching.ts
-var fs8 = __toESM(require("fs"));
-var path9 = __toESM(require("path"));
+var fs9 = __toESM(require("fs"));
+var path10 = __toESM(require("path"));
 var actionsCache2 = __toESM(require_cache4());
 var CACHE_VERSION = 1;
 var CODEQL_TRAP_CACHE_PREFIX = "codeql-trap";
@@ -149419,13 +149424,13 @@ async function downloadTrapCaches(codeql, languages, logger) {
     `Found ${languagesSupportingCaching.length} languages that support TRAP caching`
   );
   if (languagesSupportingCaching.length === 0) return result;
-  const cachesDir = path9.join(
+  const cachesDir = path10.join(
     getTemporaryDirectory(),
     "trapCaches"
   );
   for (const language of languagesSupportingCaching) {
-    const cacheDir2 = path9.join(cachesDir, language);
-    fs8.mkdirSync(cacheDir2, { recursive: true });
+    const cacheDir2 = path10.join(cachesDir, language);
+    fs9.mkdirSync(cacheDir2, { recursive: true });
     result[language] = cacheDir2;
   }
   if (await isAnalyzingDefaultBranch()) {
@@ -149437,7 +149442,7 @@ async function downloadTrapCaches(codeql, languages, logger) {
   let baseSha = "unknown";
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (getWorkflowEventName() === "pull_request" && eventPath !== void 0) {
-    const event = JSON.parse(fs8.readFileSync(path9.resolve(eventPath), "utf-8"));
+    const event = JSON.parse(fs9.readFileSync(path10.resolve(eventPath), "utf-8"));
     baseSha = event.pull_request?.base?.sha || baseSha;
   }
   for (const language of languages) {
@@ -149656,9 +149661,9 @@ async function getSupportedLanguageMap(codeql, logger) {
 }
 var baseWorkflowsPath = ".github/workflows";
 function hasActionsWorkflows(sourceRoot) {
-  const workflowsPath = path10.resolve(sourceRoot, baseWorkflowsPath);
-  const stats = fs9.lstatSync(workflowsPath, { throwIfNoEntry: false });
-  return stats !== void 0 && stats.isDirectory() && fs9.readdirSync(workflowsPath).length > 0;
+  const workflowsPath = path11.resolve(sourceRoot, baseWorkflowsPath);
+  const stats = fs10.lstatSync(workflowsPath, { throwIfNoEntry: false });
+  return stats !== void 0 && stats.isDirectory() && fs10.readdirSync(workflowsPath).length > 0;
 }
 async function getRawLanguagesInRepo(repository, sourceRoot, logger) {
   logger.debug(
@@ -149815,8 +149820,8 @@ async function downloadCacheWithTime(codeQL, languages, logger) {
 async function loadUserConfig(actionState, configFile, workspacePath, apiDetails, tempDir) {
   if (isLocal(configFile)) {
     if (configFile !== userConfigFromActionPath(tempDir)) {
-      configFile = path10.resolve(workspacePath, configFile);
-      if (!(configFile + path10.sep).startsWith(workspacePath + path10.sep)) {
+      configFile = path11.resolve(workspacePath, configFile);
+      if (!(configFile + path11.sep).startsWith(workspacePath + path11.sep)) {
         throw new ConfigurationError(
           getConfigFileOutsideWorkspaceErrorMessage(configFile)
         );
@@ -150089,10 +150094,10 @@ async function setCppTrapCachingEnvironmentVariables(config, logger) {
   }
 }
 function dbLocationOrDefault(dbLocation, tempDir) {
-  return dbLocation || path10.resolve(tempDir, "codeql_databases");
+  return dbLocation || path11.resolve(tempDir, "codeql_databases");
 }
 function userConfigFromActionPath(tempDir) {
-  return path10.resolve(tempDir, "user-config-from-action.yml");
+  return path11.resolve(tempDir, "user-config-from-action.yml");
 }
 function hasQueryCustomisation(userConfig) {
   return isDefined2(userConfig["disable-default-queries"]) || isDefined2(userConfig.queries) || isDefined2(userConfig["query-filters"]);
@@ -150142,7 +150147,7 @@ async function determineUserConfig(action, tempDir, inputs) {
         fromConfigInput,
         fromConfigFile
       );
-      fs9.writeFileSync(computedConfigPath, dump(mergedConfig));
+      fs10.writeFileSync(computedConfigPath, dump(mergedConfig));
       action.logger.debug(
         `Using merged configurations from 'config' input with configuration from '${inputs.configFile}': ${computedConfigPath}`
       );
@@ -150154,7 +150159,7 @@ async function determineUserConfig(action, tempDir, inputs) {
           `Both a config file and config input were provided. Ignoring config file.`
         );
       }
-      fs9.writeFileSync(computedConfigPath, inputs.configInput);
+      fs10.writeFileSync(computedConfigPath, inputs.configInput);
       inputs.configFile = computedConfigPath;
       action.logger.debug(
         `Using config from action input: ${inputs.configFile}`
@@ -150307,7 +150312,7 @@ function isLocal(configPath) {
   return !containsAtRef(configPath);
 }
 function getLocalConfig(logger, configFile, validateConfig) {
-  if (!fs9.existsSync(configFile)) {
+  if (!fs10.existsSync(configFile)) {
     throw new ConfigurationError(
       getConfigFileDoesNotExistErrorMessage(configFile)
     );
@@ -150315,27 +150320,27 @@ function getLocalConfig(logger, configFile, validateConfig) {
   return parseUserConfig(
     logger,
     configFile,
-    fs9.readFileSync(configFile, "utf-8"),
+    fs10.readFileSync(configFile, "utf-8"),
     validateConfig
   );
 }
 function getPathToParsedConfigFile(tempDir) {
-  return path10.join(tempDir, "config");
+  return path11.join(tempDir, "config");
 }
 async function saveConfig(config, logger) {
   const configString = JSON.stringify(config);
   const configFile = getPathToParsedConfigFile(config.tempDir);
-  fs9.mkdirSync(path10.dirname(configFile), { recursive: true });
-  fs9.writeFileSync(configFile, configString, "utf8");
+  fs10.mkdirSync(path11.dirname(configFile), { recursive: true });
+  fs10.writeFileSync(configFile, configString, "utf8");
   logger.debug("Saved config:");
   logger.debug(configString);
 }
 async function getConfig(tempDir, logger) {
   const configFile = getPathToParsedConfigFile(tempDir);
-  if (!fs9.existsSync(configFile)) {
+  if (!fs10.existsSync(configFile)) {
     return void 0;
   }
-  const configString = fs9.readFileSync(configFile, "utf8");
+  const configString = fs10.readFileSync(configFile, "utf8");
   logger.debug("Loaded config:");
   logger.debug(configString);
   const config = JSON.parse(configString);
@@ -150357,9 +150362,9 @@ async function generateRegistries(registriesInput, tempDir, logger) {
   let qlconfigFile;
   if (registries) {
     const qlconfig = createRegistriesBlock(registries);
-    qlconfigFile = path10.join(tempDir, "qlconfig.yml");
+    qlconfigFile = path11.join(tempDir, "qlconfig.yml");
     const qlconfigContents = dump(qlconfig);
-    fs9.writeFileSync(qlconfigFile, qlconfigContents, "utf8");
+    fs10.writeFileSync(qlconfigFile, qlconfigContents, "utf8");
     logger.debug("Generated qlconfig.yml:");
     logger.debug(qlconfigContents);
     registriesAuthTokens = registries.map((registry) => `${registry.url}=${registry.token}`).join(",");
@@ -150488,14 +150493,14 @@ async function logGeneratedFilesTelemetry(config, duration, generatedFilesCount)
 }
 
 // src/setup-codeql.ts
-var fs13 = __toESM(require("fs"));
-var path12 = __toESM(require("path"));
+var fs14 = __toESM(require("fs"));
+var path13 = __toESM(require("path"));
 var toolcache3 = __toESM(require_tool_cache());
 var import_fast_deep_equal = __toESM(require_fast_deep_equal());
 var semver9 = __toESM(require_semver2());
 
 // src/overlay/caching.ts
-var fs10 = __toESM(require("fs"));
+var fs11 = __toESM(require("fs"));
 var actionsCache3 = __toESM(require_cache4());
 var semver6 = __toESM(require_semver2());
 var OVERLAY_BASE_DATABASE_MAX_UPLOAD_SIZE_MB = 7500;
@@ -150505,7 +150510,7 @@ var CACHE_PREFIX = "codeql-overlay-base-database";
 var MAX_CACHE_OPERATION_MS3 = 6e5;
 async function checkOverlayBaseDatabase(codeql, config, logger, warningPrefix) {
   const baseDatabaseOidsFilePath = getBaseDatabaseOidsFilePath(config);
-  if (!fs10.existsSync(baseDatabaseOidsFilePath)) {
+  if (!fs11.existsSync(baseDatabaseOidsFilePath)) {
     logger.warning(
       `${warningPrefix}: ${baseDatabaseOidsFilePath} does not exist`
     );
@@ -150794,7 +150799,7 @@ async function getCodeQlVersionsForOverlayBaseDatabases(rawLanguages, logger) {
 
 // src/tar.ts
 var import_child_process = require("child_process");
-var fs11 = __toESM(require("fs"));
+var fs12 = __toESM(require("fs"));
 var stream = __toESM(require("stream"));
 var import_toolrunner = __toESM(require_toolrunner());
 var io4 = __toESM(require_io());
@@ -150867,7 +150872,7 @@ async function isZstdAvailable(logger) {
   }
 }
 async function extract(tarPath, dest, compressionMethod, tarVersion, logger) {
-  fs11.mkdirSync(dest, { recursive: true });
+  fs12.mkdirSync(dest, { recursive: true });
   switch (compressionMethod) {
     case "gzip":
       return await toolcache.extractTar(tarPath, dest);
@@ -150953,9 +150958,9 @@ function inferCompressionMethod(tarPath) {
 }
 
 // src/tools-download.ts
-var fs12 = __toESM(require("fs"));
+var fs13 = __toESM(require("fs"));
 var os4 = __toESM(require("os"));
-var path11 = __toESM(require("path"));
+var path12 = __toESM(require("path"));
 var import_perf_hooks2 = require("perf_hooks");
 var core11 = __toESM(require_core());
 var import_http_client = __toESM(require_lib());
@@ -151034,7 +151039,7 @@ async function downloadAndExtract(codeqlURL, compressionMethod, dest, authorizat
   return { downloadDurationMs };
 }
 async function downloadAndExtractZstdWithStreaming(codeqlURL, dest, authorization, headers, tarVersion, logger) {
-  fs12.mkdirSync(dest, { recursive: true });
+  fs13.mkdirSync(dest, { recursive: true });
   const agent = new import_http_client.HttpClient().getAgent(codeqlURL);
   headers = Object.assign(
     { "User-Agent": "CodeQL Action" },
@@ -151071,7 +151076,7 @@ async function downloadAndExtractZstdWithStreaming(codeqlURL, dest, authorizatio
   await extractTarZst(response, dest, tarVersion, logger);
 }
 function getToolcacheDirectory(version) {
-  return path11.join(
+  return path12.join(
     getRequiredEnvParam("RUNNER_TOOL_CACHE"),
     TOOLCACHE_TOOL_NAME,
     semver8.clean(version) || version,
@@ -151080,7 +151085,7 @@ function getToolcacheDirectory(version) {
 }
 function writeToolcacheMarkerFile(extractedPath, logger) {
   const markerFilePath = `${extractedPath}.complete`;
-  fs12.writeFileSync(markerFilePath, "");
+  fs13.writeFileSync(markerFilePath, "");
   logger.info(`Created toolcache marker file ${markerFilePath}`);
 }
 
@@ -151210,7 +151215,7 @@ async function findOverridingToolsInCache(humanReadableVersion, logger) {
   const candidates = toolcache3.findAllVersions("CodeQL").filter(isGoodVersion).map((version) => ({
     folder: toolcache3.find("CodeQL", version),
     version
-  })).filter(({ folder }) => fs13.existsSync(path12.join(folder, "pinned-version")));
+  })).filter(({ folder }) => fs14.existsSync(path13.join(folder, "pinned-version")));
   if (candidates.length === 1) {
     const candidate = candidates[0];
     logger.debug(
@@ -151692,7 +151697,7 @@ async function useZstdBundle(cliVersion2, tarSupportsZstd) {
   );
 }
 function getTempExtractionDir(tempDir) {
-  return path12.join(tempDir, v4_default());
+  return path13.join(tempDir, v4_default());
 }
 async function getNightlyToolsUrl(logger) {
   const zstdAvailability = await isZstdAvailable(logger);
@@ -151740,8 +151745,8 @@ function isReservedToolsValue(tools) {
 }
 
 // src/tracer-config.ts
-var fs14 = __toESM(require("fs"));
-var path13 = __toESM(require("path"));
+var fs15 = __toESM(require("fs"));
+var path14 = __toESM(require("path"));
 async function shouldEnableIndirectTracing(codeql, config) {
   if (config.buildMode === "none" /* None */) {
     return false;
@@ -151756,18 +151761,18 @@ async function endTracingForCluster(codeql, config, logger) {
   logger.info(
     "Unsetting build tracing environment variables. Subsequent steps of this job will not be traced."
   );
-  const envVariablesFile = path13.resolve(
+  const envVariablesFile = path14.resolve(
     config.dbLocation,
     "temp/tracingEnvironment/end-tracing.json"
   );
-  if (!fs14.existsSync(envVariablesFile)) {
+  if (!fs15.existsSync(envVariablesFile)) {
     throw new Error(
       `Environment file for ending tracing not found: ${envVariablesFile}`
     );
   }
   try {
     const endTracingEnvVariables = JSON.parse(
-      fs14.readFileSync(envVariablesFile, "utf8")
+      fs15.readFileSync(envVariablesFile, "utf8")
     );
     for (const [key, value] of Object.entries(endTracingEnvVariables)) {
       if (value !== null) {
@@ -151784,8 +151789,8 @@ async function endTracingForCluster(codeql, config, logger) {
 }
 async function getTracerConfigForCluster(config) {
   const tracingEnvVariables = JSON.parse(
-    fs14.readFileSync(
-      path13.resolve(
+    fs15.readFileSync(
+      path14.resolve(
         config.dbLocation,
         "temp/tracingEnvironment/start-tracing.json"
       ),
@@ -151828,7 +151833,7 @@ async function setupCodeQL(toolsInput, apiDetails, tempDir, variant, defaultCliV
       features,
       logger
     );
-    let codeqlCmd = path14.join(codeqlFolder, "codeql", "codeql");
+    let codeqlCmd = path15.join(codeqlFolder, "codeql", "codeql");
     if (process.platform === "win32") {
       codeqlCmd += ".exe";
     } else if (process.platform !== "linux" && process.platform !== "darwin") {
@@ -151886,12 +151891,12 @@ async function getCodeQLForCmd(cmd, checkVersion) {
     },
     async isTracedLanguage(language) {
       const extractorPath = await this.resolveExtractor(language);
-      const tracingConfigPath = path14.join(
+      const tracingConfigPath = path15.join(
         extractorPath,
         "tools",
         "tracing-config.lua"
       );
-      return fs15.existsSync(tracingConfigPath);
+      return fs16.existsSync(tracingConfigPath);
     },
     async isScannedLanguage(language) {
       return !await this.isTracedLanguage(language);
@@ -151971,7 +151976,7 @@ async function getCodeQLForCmd(cmd, checkVersion) {
     },
     async runAutobuild(config, language) {
       applyAutobuildAzurePipelinesTimeoutFix();
-      const autobuildCmd = path14.join(
+      const autobuildCmd = path15.join(
         await this.resolveExtractor(language),
         "tools",
         process.platform === "win32" ? "autobuild.cmd" : "autobuild.sh"
@@ -152341,7 +152346,7 @@ async function writeCodeScanningConfigFile(config, logger) {
   logger.startGroup("Augmented user configuration file contents");
   logger.info(dump(augmentedConfig));
   logger.endGroup();
-  fs15.writeFileSync(codeScanningConfigFile, dump(augmentedConfig));
+  fs16.writeFileSync(codeScanningConfigFile, dump(augmentedConfig));
   return codeScanningConfigFile;
 }
 var TRAP_CACHE_SIZE_MB = 1024;
@@ -152364,7 +152369,7 @@ async function getTrapCachingExtractorConfigArgsForLang(config, language) {
   ];
 }
 function getGeneratedCodeScanningConfigPath(config) {
-  return path14.resolve(config.tempDir, "user-config.yaml");
+  return path15.resolve(config.tempDir, "user-config.yaml");
 }
 function getExtractionVerbosityArguments(enableDebugLogging) {
   return enableDebugLogging ? [`--verbosity=${EXTRACTION_DEBUG_MODE_VERBOSITY}`] : [];
@@ -152469,31 +152474,31 @@ async function runAutobuild(config, language, logger) {
 
 // src/dependency-caching.ts
 var os5 = __toESM(require("os"));
-var import_path2 = require("path");
+var import_path3 = require("path");
 var actionsCache4 = __toESM(require_cache4());
 var glob = __toESM(require_glob());
 var CODEQL_DEPENDENCY_CACHE_PREFIX = "codeql-dependencies";
 var CODEQL_DEPENDENCY_CACHE_VERSION = 1;
 function getJavaTempDependencyDir() {
-  return (0, import_path2.join)(getTemporaryDirectory(), "codeql_java", "repository");
+  return (0, import_path3.join)(getTemporaryDirectory(), "codeql_java", "repository");
 }
 async function getJavaDependencyDirs() {
   return [
     // Maven
-    (0, import_path2.join)(os5.homedir(), ".m2", "repository"),
+    (0, import_path3.join)(os5.homedir(), ".m2", "repository"),
     // Gradle
-    (0, import_path2.join)(os5.homedir(), ".gradle", "caches"),
+    (0, import_path3.join)(os5.homedir(), ".gradle", "caches"),
     // CodeQL Java build-mode: none
     getJavaTempDependencyDir()
   ];
 }
 function getCsharpTempDependencyDir() {
-  return (0, import_path2.join)(getTemporaryDirectory(), "codeql_csharp", "repository");
+  return (0, import_path3.join)(getTemporaryDirectory(), "codeql_csharp", "repository");
 }
 async function getCsharpDependencyDirs(codeql, features) {
   const dirs = [
     // Nuget
-    (0, import_path2.join)(os5.homedir(), ".nuget", "packages")
+    (0, import_path3.join)(os5.homedir(), ".nuget", "packages")
   ];
   if (await features.getValue("csharp_cache_bmn" /* CsharpCacheBuildModeNone */, codeql)) {
     dirs.push(getCsharpTempDependencyDir());
@@ -152548,7 +152553,7 @@ var defaultCacheConfigs = {
     getHashPatterns: getCsharpHashPatterns
   },
   go: {
-    getDependencyPaths: async () => [(0, import_path2.join)(os5.homedir(), "go", "pkg", "mod")],
+    getDependencyPaths: async () => [(0, import_path3.join)(os5.homedir(), "go", "pkg", "mod")],
     getHashPatterns: async () => internal.makePatternCheck(["**/go.sum"])
   }
 };
@@ -152801,7 +152806,7 @@ function dbIsFinalized(config, language, logger) {
   const dbPath = getCodeQLDatabasePath(config, language);
   try {
     const dbInfo = load(
-      fs16.readFileSync(path15.resolve(dbPath, "codeql-database.yml"), "utf8")
+      fs17.readFileSync(path16.resolve(dbPath, "codeql-database.yml"), "utf8")
     );
     return !("inProgress" in dbInfo);
   } catch {
@@ -152872,7 +152877,7 @@ extensions:
     data:
 `;
   let data = ranges.map((range2) => {
-    const filename = path15.join(checkoutPath, range2.path).replaceAll(path15.sep, "/");
+    const filename = path16.join(checkoutPath, range2.path).replaceAll(path16.sep, "/");
     return `      - [${dump(filename, { forceQuotes: true, quoteStyle: "single" }).trim()}, ${range2.startLine}, ${range2.endLine}]
 `;
   }).join("");
@@ -152885,10 +152890,10 @@ function writeDiffRangeDataExtensionPack(logger, ranges, checkoutPath) {
   if (ranges.length === 0) {
     ranges = [{ path: "", startLine: 0, endLine: 0 }];
   }
-  const diffRangeDir = path15.join(getTemporaryDirectory(), "pr-diff-range");
-  fs16.mkdirSync(diffRangeDir, { recursive: true });
-  fs16.writeFileSync(
-    path15.join(diffRangeDir, "qlpack.yml"),
+  const diffRangeDir = path16.join(getTemporaryDirectory(), "pr-diff-range");
+  fs17.mkdirSync(diffRangeDir, { recursive: true });
+  fs17.writeFileSync(
+    path16.join(diffRangeDir, "qlpack.yml"),
     `
 name: codeql-action/pr-diff-range
 version: 0.0.0
@@ -152903,8 +152908,8 @@ dataExtensions:
     ranges,
     checkoutPath
   );
-  const extensionFilePath = path15.join(diffRangeDir, "pr-diff-range.yml");
-  fs16.writeFileSync(extensionFilePath, extensionContents);
+  const extensionFilePath = path16.join(diffRangeDir, "pr-diff-range.yml");
+  fs17.writeFileSync(extensionFilePath, extensionContents);
   logger.debug(
     `Wrote pr-diff-range extension pack to ${extensionFilePath}:
 ${extensionContents}`
@@ -153027,7 +153032,7 @@ async function runQueries(sarifFolder, memoryFlag, threadsFlag, diffRangePackDir
   async function runInterpretResultsFor(analysis, language, queries, enableDebugLogging) {
     logger.info(`Interpreting ${analysis.name} results for ${language}`);
     const category = analysis.fixCategory(logger, automationDetailsId);
-    const sarifFile = path15.join(
+    const sarifFile = path16.join(
       sarifFolder,
       addSarifExtension(analysis, language)
     );
@@ -153056,7 +153061,7 @@ async function runQueries(sarifFolder, memoryFlag, threadsFlag, diffRangePackDir
   }
   function getPerQueryAlertCounts(sarifPath) {
     const sarifObject = JSON.parse(
-      fs16.readFileSync(sarifPath, "utf8")
+      fs17.readFileSync(sarifPath, "utf8")
     );
     const perQueryAlertCounts = {};
     for (const sarifRun of sarifObject.runs) {
@@ -153074,13 +153079,13 @@ async function runQueries(sarifFolder, memoryFlag, threadsFlag, diffRangePackDir
 }
 async function runFinalize(features, outputDir, threadsFlag, memoryFlag, codeql, config, logger) {
   try {
-    await fs16.promises.rm(outputDir, { force: true, recursive: true });
+    await fs17.promises.rm(outputDir, { force: true, recursive: true });
   } catch (error3) {
     if (error3?.code !== "ENOENT") {
       throw error3;
     }
   }
-  await fs16.promises.mkdir(outputDir, { recursive: true });
+  await fs17.promises.mkdir(outputDir, { recursive: true });
   const timings = await finalizeDatabaseCreation(
     codeql,
     features,
@@ -153124,7 +153129,7 @@ async function warnIfGoInstalledAfterInit(config, logger) {
 }
 
 // src/database-upload.ts
-var fs17 = __toESM(require("fs"));
+var fs18 = __toESM(require("fs"));
 async function cleanupAndUploadDatabases(repositoryNwo, codeql, config, apiDetails, features, logger) {
   if (getRequiredInput("upload-database") !== "true") {
     logger.debug("Database upload disabled in workflow. Skipping upload.");
@@ -153160,7 +153165,7 @@ async function cleanupAndUploadDatabases(repositoryNwo, codeql, config, apiDetai
       const bundledDb = await bundleDb(config, language, codeql, language, {
         includeDiagnostics: false
       });
-      bundledDbSize = fs17.statSync(bundledDb).size;
+      bundledDbSize = fs18.statSync(bundledDb).size;
       const commitOid = await getCommitOid(
         getRequiredInput("checkout_path")
       );
@@ -153240,7 +153245,7 @@ async function recordClearCleanupSizes(codeql, config, reports, logger) {
       const bundledDb = await bundleDb(config, language, codeql, language, {
         includeDiagnostics: false
       });
-      report.clear_cleanup_zipped_size_bytes = fs17.statSync(bundledDb).size;
+      report.clear_cleanup_zipped_size_bytes = fs18.statSync(bundledDb).size;
       logger.debug(
         `Database for ${language} is ${report.clear_cleanup_zipped_size_bytes} bytes zipped at the '${"clear" /* Clear */}' cleanup level (vs. ${report.zipped_upload_size_bytes ?? "unknown"} bytes at the '${"overlay" /* Overlay */}' level).`
       );
@@ -153263,7 +153268,7 @@ async function uploadBundledDatabase(repositoryNwo, language, commitOid, bundled
   if (uploadsBaseUrl.endsWith("/")) {
     uploadsBaseUrl = uploadsBaseUrl.slice(0, -1);
   }
-  const bundledDbReadStream = fs17.createReadStream(bundledDb);
+  const bundledDbReadStream = fs18.createReadStream(bundledDb);
   try {
     const startTime = performance.now();
     await client.request(
@@ -153315,16 +153320,16 @@ __export(upload_lib_exports, {
   waitForProcessing: () => waitForProcessing,
   writePostProcessedFiles: () => writePostProcessedFiles
 });
-var fs21 = __toESM(require("fs"));
-var path18 = __toESM(require("path"));
+var fs22 = __toESM(require("fs"));
+var path19 = __toESM(require("path"));
 var url = __toESM(require("url"));
 var import_zlib = __toESM(require("zlib"));
 var core15 = __toESM(require_core());
 var jsonschema2 = __toESM(require_lib2());
 
 // src/fingerprints.ts
-var fs18 = __toESM(require("fs"));
-var import_path3 = __toESM(require("path"));
+var fs19 = __toESM(require("fs"));
+var import_path4 = __toESM(require("path"));
 
 // node_modules/long/index.js
 var wasm = null;
@@ -154311,7 +154316,7 @@ async function hash(callback, filepath) {
     }
     updateHash(current);
   };
-  const readStream = fs18.createReadStream(filepath, "utf8");
+  const readStream = fs19.createReadStream(filepath, "utf8");
   for await (const data of readStream) {
     for (let i = 0; i < data.length; ++i) {
       processCharacter(data.charCodeAt(i));
@@ -154383,14 +154388,14 @@ function resolveUriToFile(location, artifacts, sourceRoot, logger) {
     );
     return void 0;
   }
-  if (!import_path3.default.isAbsolute(uri)) {
+  if (!import_path4.default.isAbsolute(uri)) {
     uri = srcRootPrefix + uri;
   }
-  if (!fs18.existsSync(uri)) {
+  if (!fs19.existsSync(uri)) {
     logger.debug(`Unable to compute fingerprint for non-existent file: ${uri}`);
     return void 0;
   }
-  if (fs18.statSync(uri).isDirectory()) {
+  if (fs19.statSync(uri).isDirectory()) {
     logger.debug(`Unable to compute fingerprint for directory: ${uri}`);
     return void 0;
   }
@@ -154445,8 +154450,8 @@ async function addFingerprints(sarifLog, sourceRoot, logger) {
 }
 
 // src/init.ts
-var fs19 = __toESM(require("fs"));
-var path17 = __toESM(require("path"));
+var fs20 = __toESM(require("fs"));
+var path18 = __toESM(require("path"));
 var core14 = __toESM(require_core());
 var toolrunner4 = __toESM(require_toolrunner());
 var github3 = __toESM(require_github());
@@ -154480,7 +154485,7 @@ async function initConfig2(actionState, inputs) {
   });
 }
 async function runDatabaseInitCluster(databaseInitEnvironment, codeql, config, sourceRoot, processName, qlconfigFile, logger) {
-  fs19.mkdirSync(config.dbLocation, { recursive: true });
+  fs20.mkdirSync(config.dbLocation, { recursive: true });
   await wrapEnvironment(
     databaseInitEnvironment,
     async () => await codeql.databaseInitCluster(
@@ -154515,25 +154520,25 @@ async function checkPacksForOverlayCompatibility(codeql, config, logger) {
 }
 function checkPackForOverlayCompatibility(packDir, codeQlOverlayVersion, logger) {
   try {
-    let qlpackPath = path17.join(packDir, "qlpack.yml");
-    if (!fs19.existsSync(qlpackPath)) {
-      qlpackPath = path17.join(packDir, "codeql-pack.yml");
+    let qlpackPath = path18.join(packDir, "qlpack.yml");
+    if (!fs20.existsSync(qlpackPath)) {
+      qlpackPath = path18.join(packDir, "codeql-pack.yml");
     }
     const qlpackContents = load(
-      fs19.readFileSync(qlpackPath, "utf8")
+      fs20.readFileSync(qlpackPath, "utf8")
     );
     if (!qlpackContents.buildMetadata) {
       return true;
     }
-    const packInfoPath = path17.join(packDir, ".packinfo");
-    if (!fs19.existsSync(packInfoPath)) {
+    const packInfoPath = path18.join(packDir, ".packinfo");
+    if (!fs20.existsSync(packInfoPath)) {
       logger.warning(
         `The query pack at ${packDir} does not have a .packinfo file, so it cannot support overlay analysis. Recompiling the query pack with the latest CodeQL CLI should solve this problem.`
       );
       return false;
     }
     const packInfoFileContents = JSON.parse(
-      fs19.readFileSync(packInfoPath, "utf8")
+      fs20.readFileSync(packInfoPath, "utf8")
     );
     const packOverlayVersion = packInfoFileContents.overlayVersion;
     if (typeof packOverlayVersion !== "number") {
@@ -154558,7 +154563,7 @@ function checkPackForOverlayCompatibility(packDir, codeQlOverlayVersion, logger)
 }
 async function checkInstallPython311(languages, codeql) {
   if (languages.includes("python" /* python */) && process.platform === "win32" && !(await codeql.getVersion()).features?.supportsPython312) {
-    const script = path17.resolve(
+    const script = path18.resolve(
       __dirname,
       "../python-setup",
       "check_python12.ps1"
@@ -154568,8 +154573,8 @@ async function checkInstallPython311(languages, codeql) {
     ]).exec();
   }
 }
-function cleanupDatabaseClusterDirectory(config, logger, options = {}, rmSync5 = fs19.rmSync) {
-  if (fs19.existsSync(config.dbLocation) && (fs19.statSync(config.dbLocation).isFile() || fs19.readdirSync(config.dbLocation).length > 0)) {
+function cleanupDatabaseClusterDirectory(config, logger, options = {}, rmSync5 = fs20.rmSync) {
+  if (fs20.existsSync(config.dbLocation) && (fs20.statSync(config.dbLocation).isFile() || fs20.readdirSync(config.dbLocation).length > 0)) {
     if (!options.disableExistingDirectoryWarning) {
       logger.warning(
         `The database cluster directory ${config.dbLocation} must be empty. Attempting to clean it up.`
@@ -154674,7 +154679,7 @@ To opt out of this change, ${envVarOptOut}`;
 }
 
 // src/sarif/index.ts
-var fs20 = __toESM(require("fs"));
+var fs21 = __toESM(require("fs"));
 var InvalidSarifUploadError = class extends Error {
 };
 function getToolNames(sarifFile) {
@@ -154689,7 +154694,7 @@ function getToolNames(sarifFile) {
   return Object.keys(toolNames);
 }
 function readSarifFile(sarifFilePath) {
-  return JSON.parse(fs20.readFileSync(sarifFilePath, "utf8"));
+  return JSON.parse(fs21.readFileSync(sarifFilePath, "utf8"));
 }
 function combineSarifFiles(sarifFiles, logger) {
   logger.info(`Loading SARIF file(s)`);
@@ -154823,10 +154828,10 @@ async function combineSarifFilesUsingCLI(sarifFiles, gitHubVersion, features, lo
     );
     codeQL = initCodeQLResult.codeql;
   }
-  const baseTempDir = path18.resolve(tempDir, "combined-sarif");
-  fs21.mkdirSync(baseTempDir, { recursive: true });
-  const outputDirectory = fs21.mkdtempSync(path18.resolve(baseTempDir, "output-"));
-  const outputFile = path18.resolve(outputDirectory, "combined-sarif.sarif");
+  const baseTempDir = path19.resolve(tempDir, "combined-sarif");
+  fs22.mkdirSync(baseTempDir, { recursive: true });
+  const outputDirectory = fs22.mkdtempSync(path19.resolve(baseTempDir, "output-"));
+  const outputFile = path19.resolve(outputDirectory, "combined-sarif.sarif");
   await codeQL.mergeResults(sarifFiles, outputFile, {
     mergeRunsFromEqualCategory: true
   });
@@ -154859,7 +154864,7 @@ function getAutomationID2(category, analysis_key, environment) {
 async function uploadPayload(payload, repositoryNwo, logger, analysis) {
   logger.info("Uploading results");
   if (shouldSkipSarifUpload()) {
-    const payloadSaveFile = path18.join(
+    const payloadSaveFile = path19.join(
       getTemporaryDirectory(),
       `payload-${analysis.kind}.json`
     );
@@ -154867,7 +154872,7 @@ async function uploadPayload(payload, repositoryNwo, logger, analysis) {
       `SARIF upload disabled by an environment variable. Saving to ${payloadSaveFile}`
     );
     logger.info(`Payload: ${JSON.stringify(payload, null, 2)}`);
-    fs21.writeFileSync(payloadSaveFile, JSON.stringify(payload, null, 2));
+    fs22.writeFileSync(payloadSaveFile, JSON.stringify(payload, null, 2));
     return "dummy-sarif-id";
   }
   const client = getApiClient();
@@ -154901,12 +154906,12 @@ async function uploadPayload(payload, repositoryNwo, logger, analysis) {
 function findSarifFilesInDir(sarifPath, isSarif) {
   const sarifFiles = [];
   const walkSarifFiles = (dir) => {
-    const entries = fs21.readdirSync(dir, { withFileTypes: true });
+    const entries = fs22.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.isFile() && isSarif(entry.name)) {
-        sarifFiles.push(path18.resolve(dir, entry.name));
+        sarifFiles.push(path19.resolve(dir, entry.name));
       } else if (entry.isDirectory()) {
-        walkSarifFiles(path18.resolve(dir, entry.name));
+        walkSarifFiles(path19.resolve(dir, entry.name));
       }
     }
   };
@@ -154914,11 +154919,11 @@ function findSarifFilesInDir(sarifPath, isSarif) {
   return sarifFiles;
 }
 function getSarifFilePaths(sarifPath, isSarif) {
-  if (!fs21.existsSync(sarifPath)) {
+  if (!fs22.existsSync(sarifPath)) {
     throw new ConfigurationError(`Path does not exist: ${sarifPath}`);
   }
   let sarifFiles;
-  if (fs21.lstatSync(sarifPath).isDirectory()) {
+  if (fs22.lstatSync(sarifPath).isDirectory()) {
     sarifFiles = findSarifFilesInDir(sarifPath, isSarif);
     if (sarifFiles.length === 0) {
       throw new ConfigurationError(
@@ -154931,7 +154936,7 @@ function getSarifFilePaths(sarifPath, isSarif) {
   return sarifFiles;
 }
 async function getGroupedSarifFilePaths(logger, sarifPath) {
-  const stats = fs21.statSync(sarifPath, { throwIfNoEntry: false });
+  const stats = fs22.statSync(sarifPath, { throwIfNoEntry: false });
   if (stats === void 0) {
     throw new ConfigurationError(`Path does not exist: ${sarifPath}`);
   }
@@ -154939,7 +154944,7 @@ async function getGroupedSarifFilePaths(logger, sarifPath) {
   if (stats.isDirectory()) {
     let unassignedSarifFiles = findSarifFilesInDir(
       sarifPath,
-      (name) => path18.extname(name) === ".sarif"
+      (name) => path19.extname(name) === ".sarif"
     );
     logger.debug(
       `Found the following .sarif files in ${sarifPath}: ${unassignedSarifFiles.join(", ")}`
@@ -155066,7 +155071,7 @@ function buildPayload(commitOid, ref, analysisKey, analysisName, zippedSarif, wo
       payloadObj.base_sha = mergeBaseCommitOid;
     } else if (process.env.GITHUB_EVENT_PATH) {
       const githubEvent = JSON.parse(
-        fs21.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8")
+        fs22.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8")
       );
       payloadObj.base_ref = `refs/heads/${githubEvent.pull_request.base.ref}`;
       payloadObj.base_sha = githubEvent.pull_request.base.sha;
@@ -155200,19 +155205,19 @@ async function uploadPostProcessedFiles(logger, checkoutPath, uploadTarget, post
   };
 }
 function dumpSarifFile(sarifPayload, outputDir, logger, uploadTarget) {
-  if (!fs21.existsSync(outputDir)) {
-    fs21.mkdirSync(outputDir, { recursive: true });
-  } else if (!fs21.lstatSync(outputDir).isDirectory()) {
+  if (!fs22.existsSync(outputDir)) {
+    fs22.mkdirSync(outputDir, { recursive: true });
+  } else if (!fs22.lstatSync(outputDir).isDirectory()) {
     throw new ConfigurationError(
       `The path that processed SARIF files should be written to exists, but is not a directory: ${outputDir}`
     );
   }
-  const outputFile = path18.resolve(
+  const outputFile = path19.resolve(
     outputDir,
     `upload${uploadTarget.sarifExtension}`
   );
   logger.info(`Writing processed SARIF file to ${outputFile}`);
-  fs21.writeFileSync(outputFile, sarifPayload);
+  fs22.writeFileSync(outputFile, sarifPayload);
 }
 var STATUS_CHECK_INITIAL_BACKOFF_MILLISECONDS = 5 * 1e3;
 var STATUS_CHECK_BACKOFF_MULTIPLIER = 2;
@@ -155447,12 +155452,12 @@ function doesGoExtractionOutputExist(config) {
     config,
     "go" /* go */
   );
-  const trapDirectory = import_path4.default.join(
+  const trapDirectory = import_path5.default.join(
     golangDbDirectory,
     "trap",
     "go" /* go */
   );
-  return fs22.existsSync(trapDirectory) && fs22.readdirSync(trapDirectory).some(
+  return fs23.existsSync(trapDirectory) && fs23.readdirSync(trapDirectory).some(
     (fileName) => [
       ".trap",
       ".trap.gz",
@@ -155600,7 +155605,7 @@ async function run({ startedAt, logger }) {
       dbLocations[language] = getCodeQLDatabasePath(config, language);
     }
     core16.setOutput("db-locations", dbLocations);
-    core16.setOutput("sarif-output", import_path4.default.resolve(outputDir));
+    core16.setOutput("sarif-output", import_path5.default.resolve(outputDir));
     const uploadKind = getUploadValue(
       getOptionalInput("upload")
     );
@@ -155748,12 +155753,12 @@ async function runWrapper() {
 }
 
 // src/analyze-action-post.ts
-var fs26 = __toESM(require("fs"));
+var fs27 = __toESM(require("fs"));
 var core18 = __toESM(require_core());
 
 // src/debug-artifacts.ts
-var fs25 = __toESM(require("fs"));
-var path22 = __toESM(require("path"));
+var fs26 = __toESM(require("fs"));
+var path23 = __toESM(require("path"));
 var artifact = __toESM(require_artifact2());
 var artifactLegacy = __toESM(require_artifact_client2());
 var core17 = __toESM(require_core());
@@ -155767,7 +155772,7 @@ function isStream(stream2, { checkOpen = true } = {}) {
 }
 
 // node_modules/readdir-glob/dist/index.mjs
-var fs23 = __toESM(require("fs"), 1);
+var fs24 = __toESM(require("fs"), 1);
 var import_events = require("events");
 
 // node_modules/readdir-glob/node_modules/balanced-match/dist/esm/index.js
@@ -156875,11 +156880,11 @@ var qmarksTestNoExtDot = ([$0]) => {
   return (f) => f.length === len && f !== "." && f !== "..";
 };
 var defaultPlatform = typeof process === "object" && process ? typeof process.env === "object" && process.env && process.env.__MINIMATCH_TESTING_PLATFORM__ || process.platform : "posix";
-var path20 = {
+var path21 = {
   win32: { sep: "\\" },
   posix: { sep: "/" }
 };
-var sep6 = defaultPlatform === "win32" ? path20.win32.sep : path20.posix.sep;
+var sep6 = defaultPlatform === "win32" ? path21.win32.sep : path21.posix.sep;
 minimatch.sep = sep6;
 var GLOBSTAR = /* @__PURE__ */ Symbol("globstar **");
 minimatch.GLOBSTAR = GLOBSTAR;
@@ -157626,10 +157631,10 @@ minimatch.escape = escape2;
 minimatch.unescape = unescape2;
 
 // node_modules/readdir-glob/dist/index.mjs
-var import_path5 = require("path");
+var import_path6 = require("path");
 function readdir2(dir, strict) {
   return new Promise((resolve$1, reject) => {
-    fs23.readdir(dir, { withFileTypes: true }, (err, files) => {
+    fs24.readdir(dir, { withFileTypes: true }, (err, files) => {
       if (err) switch (err.code) {
         case "ENOTDIR":
           if (strict) reject(err);
@@ -157652,7 +157657,7 @@ function readdir2(dir, strict) {
 }
 function getStat(file, followSymlinks) {
   return new Promise((resolve$1) => {
-    const statFunc = followSymlinks ? fs23.stat : fs23.lstat;
+    const statFunc = followSymlinks ? fs24.stat : fs24.lstat;
     statFunc(file, (err, stats) => {
       if (err) switch (err.code) {
         case "ENOENT":
@@ -157667,13 +157672,13 @@ function getStat(file, followSymlinks) {
     });
   });
 }
-async function* exploreWalkAsync(dir, path29, followSymlinks, useStat, shouldSkip, strict) {
-  let files = await readdir2(path29 + dir, strict);
+async function* exploreWalkAsync(dir, path30, followSymlinks, useStat, shouldSkip, strict) {
+  let files = await readdir2(path30 + dir, strict);
   for (const file of files) {
     let name = file.name;
     const filename = dir + "/" + name;
     const relative3 = filename.slice(1);
-    const absolute = path29 + "/" + relative3;
+    const absolute = path30 + "/" + relative3;
     let stat2 = file;
     if (useStat || followSymlinks) stat2 = await getStat(absolute, followSymlinks) ?? stat2;
     if (stat2.isDirectory()) {
@@ -157683,7 +157688,7 @@ async function* exploreWalkAsync(dir, path29, followSymlinks, useStat, shouldSki
           absolute,
           stat: stat2
         };
-        yield* exploreWalkAsync(filename, path29, followSymlinks, useStat, shouldSkip, false);
+        yield* exploreWalkAsync(filename, path30, followSymlinks, useStat, shouldSkip, false);
       }
     } else yield {
       relative: relative3,
@@ -157692,8 +157697,8 @@ async function* exploreWalkAsync(dir, path29, followSymlinks, useStat, shouldSki
     };
   }
 }
-async function* explore(path29, followSymlinks, useStat, shouldSkip) {
-  yield* exploreWalkAsync("", path29, followSymlinks, useStat, shouldSkip, true);
+async function* explore(path30, followSymlinks, useStat, shouldSkip) {
+  yield* exploreWalkAsync("", path30, followSymlinks, useStat, shouldSkip, true);
 }
 function readOptions(options) {
   return {
@@ -157748,7 +157753,7 @@ var ReaddirGlob = class extends import_events.EventEmitter {
       const skipPatterns = Array.isArray(this.options.skip) ? this.options.skip : [this.options.skip];
       this.skipMatchers = skipPatterns.map((skip) => new Minimatch(skip, { dot: true }));
     }
-    this.iterator = explore((0, import_path5.resolve)(cwd || "."), this.options.follow, this.options.stat, this._shouldSkipDirectory.bind(this));
+    this.iterator = explore((0, import_path6.resolve)(cwd || "."), this.options.follow, this.options.stat, this._shouldSkipDirectory.bind(this));
     this.paused = false;
     this.inactive = false;
     this.aborted = false;
@@ -157819,10 +157824,10 @@ var src_default = readdirGlob;
 // node_modules/archiver/lib/core.js
 var import_lazystream = __toESM(require_lazystream(), 1);
 var import_async = __toESM(require_async(), 1);
-var import_path6 = require("path");
+var import_path7 = require("path");
 
 // node_modules/archiver/lib/error.js
-var import_util34 = __toESM(require("util"), 1);
+var import_util35 = __toESM(require("util"), 1);
 var ERROR_CODES = {
   ABORTED: "archive was aborted",
   DIRECTORYDIRPATHREQUIRED: "diretory dirpath argument must be a non-empty string value",
@@ -157847,7 +157852,7 @@ function ArchiverError(code, data) {
   this.code = code;
   this.data = data;
 }
-import_util34.default.inherits(ArchiverError, Error);
+import_util35.default.inherits(ArchiverError, Error);
 
 // node_modules/archiver/lib/core.js
 var import_readable_stream2 = __toESM(require_ours(), 1);
@@ -158280,11 +158285,11 @@ var Archiver = class extends import_readable_stream2.Transform {
       task.source = Buffer.concat([]);
     } else if (stats.isSymbolicLink() && this._supportsSymlink) {
       const linkPath = (0, import_fs2.readlinkSync)(task.filepath);
-      const dirName = (0, import_path6.dirname)(task.filepath);
+      const dirName = (0, import_path7.dirname)(task.filepath);
       task.data.type = "symlink";
-      task.data.linkname = (0, import_path6.relative)(
+      task.data.linkname = (0, import_path7.relative)(
         dirName,
-        (0, import_path6.resolve)(dirName, linkPath)
+        (0, import_path7.resolve)(dirName, linkPath)
       );
       task.data.sourceType = "buffer";
       task.source = Buffer.concat([]);
@@ -160122,9 +160127,9 @@ var ZipArchive = class extends Archiver {
 };
 
 // src/artifact-scanner.ts
-var fs24 = __toESM(require("fs"));
+var fs25 = __toESM(require("fs"));
 var os6 = __toESM(require("os"));
-var path21 = __toESM(require("path"));
+var path22 = __toESM(require("path"));
 var exec = __toESM(require_exec());
 var GITHUB_PAT_CLASSIC_PATTERN = {
   type: "Personal Access Token (Classic)" /* PersonalAccessClassic */,
@@ -160169,7 +160174,7 @@ function isAuthToken(value, patterns = GITHUB_TOKEN_PATTERNS) {
 function scanFileForTokens(filePath, relativePath2, logger) {
   const findings = [];
   try {
-    const content = fs24.readFileSync(filePath, "utf8");
+    const content = fs25.readFileSync(filePath, "utf8");
     for (const { type, pattern } of GITHUB_TOKEN_PATTERNS) {
       const matches = content.match(pattern);
       if (matches) {
@@ -160202,10 +160207,10 @@ async function scanArchiveFile(archivePath, relativeArchivePath, extractDir, log
     findings: []
   };
   try {
-    const tempExtractDir = fs24.mkdtempSync(
-      path21.join(extractDir, `extract-${depth}-`)
+    const tempExtractDir = fs25.mkdtempSync(
+      path22.join(extractDir, `extract-${depth}-`)
     );
-    const fileName = path21.basename(archivePath).toLowerCase();
+    const fileName = path22.basename(archivePath).toLowerCase();
     if (fileName.endsWith(".tar.gz") || fileName.endsWith(".tgz")) {
       logger.debug(`Extracting tar.gz file: ${archivePath}`);
       await exec.exec("tar", ["-xzf", archivePath, "-C", tempExtractDir], {
@@ -160222,21 +160227,21 @@ async function scanArchiveFile(archivePath, relativeArchivePath, extractDir, log
       );
     } else if (fileName.endsWith(".zst")) {
       logger.debug(`Extracting zst file: ${archivePath}`);
-      const outputFile = path21.join(
+      const outputFile = path22.join(
         tempExtractDir,
-        path21.basename(archivePath, ".zst")
+        path22.basename(archivePath, ".zst")
       );
       await exec.exec("zstd", ["-d", archivePath, "-o", outputFile], {
         silent: true
       });
     } else if (fileName.endsWith(".gz")) {
       logger.debug(`Extracting gz file: ${archivePath}`);
-      const outputFile = path21.join(
+      const outputFile = path22.join(
         tempExtractDir,
-        path21.basename(archivePath, ".gz")
+        path22.basename(archivePath, ".gz")
       );
       await exec.exec("gunzip", ["-c", archivePath], {
-        outStream: fs24.createWriteStream(outputFile),
+        outStream: fs25.createWriteStream(outputFile),
         silent: true
       });
     } else if (fileName.endsWith(".zip")) {
@@ -160257,7 +160262,7 @@ async function scanArchiveFile(archivePath, relativeArchivePath, extractDir, log
     );
     result.scannedFiles += scanResult.scannedFiles;
     result.findings.push(...scanResult.findings);
-    fs24.rmSync(tempExtractDir, { recursive: true, force: true });
+    fs25.rmSync(tempExtractDir, { recursive: true, force: true });
   } catch (e) {
     logger.debug(
       `Could not extract or scan archive file ${archivePath}: ${getErrorMessage(e)}`
@@ -160270,7 +160275,7 @@ async function scanFile(fullPath, relativePath2, extractDir, logger, depth = 0) 
     scannedFiles: 1,
     findings: []
   };
-  const fileName = path21.basename(fullPath).toLowerCase();
+  const fileName = path22.basename(fullPath).toLowerCase();
   const isArchive = fileName.endsWith(".zip") || fileName.endsWith(".tar.gz") || fileName.endsWith(".tgz") || fileName.endsWith(".tar.zst") || fileName.endsWith(".zst") || fileName.endsWith(".gz");
   if (isArchive) {
     const archiveResult = await scanArchiveFile(
@@ -160292,10 +160297,10 @@ async function scanDirectory(dirPath, baseRelativePath, logger, depth = 0) {
     scannedFiles: 0,
     findings: []
   };
-  const entries = fs24.readdirSync(dirPath, { withFileTypes: true });
+  const entries = fs25.readdirSync(dirPath, { withFileTypes: true });
   for (const entry of entries) {
-    const fullPath = path21.join(dirPath, entry.name);
-    const relativePath2 = path21.join(baseRelativePath, entry.name);
+    const fullPath = path22.join(dirPath, entry.name);
+    const relativePath2 = path22.join(baseRelativePath, entry.name);
     if (entry.isDirectory()) {
       const subResult = await scanDirectory(
         fullPath,
@@ -160309,7 +160314,7 @@ async function scanDirectory(dirPath, baseRelativePath, logger, depth = 0) {
       const fileResult = await scanFile(
         fullPath,
         relativePath2,
-        path21.dirname(fullPath),
+        path22.dirname(fullPath),
         logger,
         depth
       );
@@ -160327,11 +160332,11 @@ async function scanArtifactsForTokens(filesToScan, logger) {
     scannedFiles: 0,
     findings: []
   };
-  const tempScanDir = fs24.mkdtempSync(path21.join(os6.tmpdir(), "artifact-scan-"));
+  const tempScanDir = fs25.mkdtempSync(path22.join(os6.tmpdir(), "artifact-scan-"));
   try {
     for (const filePath of filesToScan) {
-      const stats = fs24.statSync(filePath);
-      const fileName = path21.basename(filePath);
+      const stats = fs25.statSync(filePath);
+      const fileName = path22.basename(filePath);
       if (stats.isDirectory()) {
         const dirResult = await scanDirectory(filePath, fileName, logger);
         result.scannedFiles += dirResult.scannedFiles;
@@ -160368,7 +160373,7 @@ async function scanArtifactsForTokens(filesToScan, logger) {
     }
   } finally {
     try {
-      fs24.rmSync(tempScanDir, { recursive: true, force: true });
+      fs25.rmSync(tempScanDir, { recursive: true, force: true });
     } catch (e) {
       logger.debug(
         `Could not clean up temporary scan directory: ${getErrorMessage(e)}`
@@ -160388,14 +160393,14 @@ async function uploadCombinedSarifArtifacts(logger, gitHubVariant, codeQlVersion
       logger.info(
         "Uploading available combined SARIF files as Actions debugging artifact..."
       );
-      const baseTempDir = path22.resolve(tempDir, "combined-sarif");
+      const baseTempDir = path23.resolve(tempDir, "combined-sarif");
       const toUpload = [];
-      if (fs25.existsSync(baseTempDir)) {
-        const outputDirs = fs25.readdirSync(baseTempDir);
+      if (fs26.existsSync(baseTempDir)) {
+        const outputDirs = fs26.readdirSync(baseTempDir);
         for (const outputDir of outputDirs) {
-          const sarifFiles = fs25.readdirSync(path22.resolve(baseTempDir, outputDir)).filter((f) => path22.extname(f) === ".sarif");
+          const sarifFiles = fs26.readdirSync(path23.resolve(baseTempDir, outputDir)).filter((f) => path23.extname(f) === ".sarif");
           for (const sarifFile of sarifFiles) {
-            toUpload.push(path22.resolve(baseTempDir, outputDir, sarifFile));
+            toUpload.push(path23.resolve(baseTempDir, outputDir, sarifFile));
           }
         }
       }
@@ -160421,17 +160426,17 @@ async function uploadCombinedSarifArtifacts(logger, gitHubVariant, codeQlVersion
 function tryPrepareSarifDebugArtifact(config, language, logger) {
   try {
     const analyzeActionOutputDir = process.env["CODEQL_ACTION_SARIF_RESULTS_OUTPUT_DIR" /* SARIF_RESULTS_OUTPUT_DIR */];
-    if (analyzeActionOutputDir !== void 0 && fs25.existsSync(analyzeActionOutputDir) && fs25.lstatSync(analyzeActionOutputDir).isDirectory()) {
-      const sarifFile = path22.resolve(
+    if (analyzeActionOutputDir !== void 0 && fs26.existsSync(analyzeActionOutputDir) && fs26.lstatSync(analyzeActionOutputDir).isDirectory()) {
+      const sarifFile = path23.resolve(
         analyzeActionOutputDir,
         `${language}.sarif`
       );
-      if (fs25.existsSync(sarifFile)) {
-        const sarifInDbLocation = path22.resolve(
+      if (fs26.existsSync(sarifFile)) {
+        const sarifInDbLocation = path23.resolve(
           config.dbLocation,
           `${language}.sarif`
         );
-        fs25.copyFileSync(sarifFile, sarifInDbLocation);
+        fs26.copyFileSync(sarifFile, sarifInDbLocation);
         return sarifInDbLocation;
       }
     }
@@ -160482,13 +160487,13 @@ async function tryUploadAllAvailableDebugArtifacts(codeql, config, logger, codeQ
         }
         logger.info("Preparing database logs debug artifact...");
         const databaseDirectory = getCodeQLDatabasePath(config, language);
-        const logsDirectory = path22.resolve(databaseDirectory, "log");
+        const logsDirectory = path23.resolve(databaseDirectory, "log");
         if (doesDirectoryExist(logsDirectory)) {
           filesToUpload.push(...listFolder(logsDirectory));
           logger.info("Database logs debug artifact ready for upload.");
         }
         logger.info("Preparing database cluster logs debug artifact...");
-        const multiLanguageTracingLogsDirectory = path22.resolve(
+        const multiLanguageTracingLogsDirectory = path23.resolve(
           config.dbLocation,
           "log"
         );
@@ -160575,8 +160580,8 @@ async function uploadArtifacts(logger, toUpload, rootDir, artifactName, ghVarian
   try {
     await artifactUploader.uploadArtifact(
       sanitizeArtifactName(`${artifactName}${suffix}`),
-      toUpload.map((file) => path22.normalize(file)),
-      path22.normalize(rootDir),
+      toUpload.map((file) => path23.normalize(file)),
+      path23.normalize(rootDir),
       {
         // ensure we don't keep the debug artifacts around for too long since they can be large.
         retentionDays: 7
@@ -160603,17 +160608,17 @@ async function getArtifactUploaderClient(logger, ghVariant) {
 }
 async function createPartialDatabaseBundle(config, language) {
   const databasePath = getCodeQLDatabasePath(config, language);
-  const databaseBundlePath = path22.resolve(
+  const databaseBundlePath = path23.resolve(
     config.dbLocation,
     `${config.debugDatabaseName}-${language}-partial.zip`
   );
   core17.info(
     `${config.debugDatabaseName}-${language} is not finalized. Uploading partial database bundle at ${databaseBundlePath}...`
   );
-  if (fs25.existsSync(databaseBundlePath)) {
-    await fs25.promises.rm(databaseBundlePath, { force: true });
+  if (fs26.existsSync(databaseBundlePath)) {
+    await fs26.promises.rm(databaseBundlePath, { force: true });
   }
-  const output = fs25.createWriteStream(databaseBundlePath);
+  const output = fs26.createWriteStream(databaseBundlePath);
   const zip = new ZipArchive();
   zip.on("error", (err) => {
     throw err;
@@ -160666,9 +160671,9 @@ async function runWrapper2() {
       getCsharpTempDependencyDir()
     ];
     for (const tempDependencyDir of tempDependencyDirs) {
-      if (fs26.existsSync(tempDependencyDir)) {
+      if (fs27.existsSync(tempDependencyDir)) {
         try {
-          fs26.rmSync(tempDependencyDir, { recursive: true });
+          fs27.rmSync(tempDependencyDir, { recursive: true });
         } catch (error3) {
           logger.info(
             `Failed to remove temporary dependencies directory: ${getErrorMessage(error3)}`
@@ -160775,8 +160780,8 @@ async function runWrapper3() {
 }
 
 // src/init-action.ts
-var fs28 = __toESM(require("fs"));
-var path24 = __toESM(require("path"));
+var fs29 = __toESM(require("fs"));
+var path25 = __toESM(require("path"));
 var core21 = __toESM(require_core());
 var io7 = __toESM(require_io());
 var semver10 = __toESM(require_semver2());
@@ -160816,8 +160821,8 @@ async function getToolsInput(action, repositoryProperties) {
 }
 
 // src/workflow.ts
-var fs27 = __toESM(require("fs"));
-var path23 = __toESM(require("path"));
+var fs28 = __toESM(require("fs"));
+var path24 = __toESM(require("path"));
 var import_zlib3 = __toESM(require("zlib"));
 var core20 = __toESM(require_core());
 function toCodedErrors(errors) {
@@ -160968,15 +160973,15 @@ async function getWorkflow(logger) {
     );
   }
   const workflowPath = await getWorkflowAbsolutePath(logger);
-  return load(fs27.readFileSync(workflowPath, "utf-8"));
+  return load(fs28.readFileSync(workflowPath, "utf-8"));
 }
 async function getWorkflowAbsolutePath(logger) {
   const relativePath2 = await getWorkflowRelativePath();
-  const absolutePath = path23.join(
+  const absolutePath = path24.join(
     getRequiredEnvParam("GITHUB_WORKSPACE"),
     relativePath2
   );
-  if (fs27.existsSync(absolutePath)) {
+  if (fs28.existsSync(absolutePath)) {
     logger.debug(
       `Derived the following absolute path for the currently executing workflow: ${absolutePath}.`
     );
@@ -161195,7 +161200,7 @@ async function run3(actionState) {
     );
     const repositoryProperties = repositoryPropertiesResult.orElse({});
     core21.exportVariable("CODEQL_ACTION_INIT_HAS_RUN" /* INIT_ACTION_HAS_RUN */, "true");
-    sourceRoot = path24.resolve(
+    sourceRoot = path25.resolve(
       getRequiredEnvParam("GITHUB_WORKSPACE"),
       getOptionalInput("source-root") || ""
     );
@@ -161390,21 +161395,21 @@ async function run3(actionState) {
         )) {
           try {
             logger.debug(`Applying static binary workaround for Go`);
-            const tempBinPath = path24.resolve(
+            const tempBinPath = path25.resolve(
               getTemporaryDirectory(),
               "codeql-action-go-tracing",
               "bin"
             );
-            fs28.mkdirSync(tempBinPath, { recursive: true });
+            fs29.mkdirSync(tempBinPath, { recursive: true });
             core21.addPath(tempBinPath);
-            const goWrapperPath = path24.resolve(tempBinPath, "go");
-            fs28.writeFileSync(
+            const goWrapperPath = path25.resolve(tempBinPath, "go");
+            fs29.writeFileSync(
               goWrapperPath,
               `#!/bin/bash
 
 exec ${goBinaryPath} "$@"`
             );
-            fs28.chmodSync(goWrapperPath, "755");
+            fs29.chmodSync(goWrapperPath, "755");
             core21.exportVariable("CODEQL_ACTION_GO_BINARY" /* GO_BINARY_LOCATION */, goWrapperPath);
           } catch (e) {
             logger.warning(
@@ -161589,8 +161594,8 @@ async function runWrapper4() {
 var core22 = __toESM(require_core());
 
 // src/init-action-post-helper.ts
-var fs29 = __toESM(require("fs"));
-var import_path7 = __toESM(require("path"));
+var fs30 = __toESM(require("fs"));
+var import_path8 = __toESM(require("path"));
 var github4 = __toESM(require_github());
 function createFailedUploadFailedSarifResult(error3) {
   const wrappedError = wrapError(error3);
@@ -161701,8 +161706,8 @@ async function maybeUploadFailedSarifArtifact(config, features, logger) {
   const name = sanitizeArtifactName(`sarif-artifact-${suffix}`);
   await client.uploadArtifact(
     name,
-    [import_path7.default.normalize(failedSarif.sarifFile)],
-    import_path7.default.normalize("..")
+    [import_path8.default.normalize(failedSarif.sarifFile)],
+    import_path8.default.normalize("..")
   );
   return { sarifID: name };
 }
@@ -161777,7 +161782,7 @@ async function uploadFailureInfo(uploadAllAvailableDebugArtifacts, printDebugLog
   }
   if (isSelfHostedRunner()) {
     try {
-      fs29.rmSync(config.dbLocation, {
+      fs30.rmSync(config.dbLocation, {
         recursive: true,
         force: true,
         maxRetries: 3
@@ -162269,11 +162274,11 @@ async function runWrapper7() {
 
 // src/start-proxy-action.ts
 var import_child_process2 = require("child_process");
-var path28 = __toESM(require("path"));
+var path29 = __toESM(require("path"));
 var core27 = __toESM(require_core());
 
 // src/start-proxy.ts
-var path26 = __toESM(require("path"));
+var path27 = __toESM(require("path"));
 var core26 = __toESM(require_core());
 var toolcache4 = __toESM(require_tool_cache());
 
@@ -162611,7 +162616,7 @@ async function getProxyBinaryPath(logger, features) {
       proxyInfo.version
     );
   }
-  return path26.join(proxyBin, proxyFileName);
+  return path27.join(proxyBin, proxyFileName);
 }
 
 // src/start-proxy/ca.ts
@@ -162676,8 +162681,8 @@ function generateCertificateAuthority() {
 }
 
 // src/start-proxy/environment.ts
-var fs30 = __toESM(require("fs"));
-var path27 = __toESM(require("path"));
+var fs31 = __toESM(require("fs"));
+var path28 = __toESM(require("path"));
 var toolrunner5 = __toESM(require_toolrunner());
 var io8 = __toESM(require_io());
 function checkEnvVar(logger, name) {
@@ -162742,16 +162747,16 @@ function discoverActionsJdks() {
 function checkJdkSettings(logger, jdkHome) {
   const filesToCheck = [
     // JDK 9+
-    path27.join("conf", "net.properties"),
+    path28.join("conf", "net.properties"),
     // JDK 8 and below
-    path27.join("lib", "net.properties")
+    path28.join("lib", "net.properties")
   ];
   for (const fileToCheck of filesToCheck) {
-    const file = path27.join(jdkHome, fileToCheck);
+    const file = path28.join(jdkHome, fileToCheck);
     try {
-      if (fs30.existsSync(file)) {
+      if (fs31.existsSync(file)) {
         logger.debug(`Found '${file}'.`);
-        const lines = String(fs30.readFileSync(file)).split("\n");
+        const lines = String(fs31.readFileSync(file)).split("\n");
         for (const line of lines) {
           for (const property of javaProperties) {
             if (line.startsWith(`${property}=`)) {
@@ -162933,7 +162938,7 @@ async function run7(action) {
   try {
     persistInputs();
     const tempDir = getTemporaryDirectory();
-    const proxyLogFilePath = path28.resolve(tempDir, "proxy.log");
+    const proxyLogFilePath = path29.resolve(tempDir, "proxy.log");
     core27.saveState("proxy-log-file", proxyLogFilePath);
     const repositoryNwo = getRepositoryNwo();
     const gitHubVersion = await getGitHubVersion();

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -1,0 +1,111 @@
+import * as fs from "fs";
+import path from "path";
+
+import test from "ava";
+
+import { EnvVar } from "../environment";
+import { getTestEnv, setupTests } from "../testing-utils";
+import * as util from "../util";
+
+import * as outputCache from "./output-cache";
+
+setupTests(test);
+
+test.serial(
+  "getCachedCodeQlVersion reuses a version persisted by an earlier step",
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "codeql-action-command-cache.json");
+      fs.writeFileSync(
+        cacheFile,
+        JSON.stringify({
+          cmd: "/path/to/codeql",
+          version: { version: "2.20.0" },
+        }),
+        "utf8",
+      );
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      t.deepEqual(outputCache.getCachedCodeQlVersion("/path/to/codeql", env), {
+        version: "2.20.0",
+      });
+    });
+  },
+);
+
+test.serial(
+  "getCachedCodeQlVersion ignores a persisted version from a different CLI",
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "version.json");
+      fs.writeFileSync(
+        cacheFile,
+        JSON.stringify({
+          cmd: "/path/to/other-codeql",
+          version: { version: "2.20.0" },
+        }),
+        "utf8",
+      );
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      t.is(
+        outputCache.getCachedCodeQlVersion("/path/to/codeql", env),
+        undefined,
+      );
+    });
+  },
+);
+
+test.serial(
+  "getCachedCodeQlVersion ignores a malformed persisted value",
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "version.json");
+      fs.writeFileSync(cacheFile, "not valid json", "utf8");
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      t.is(
+        outputCache.getCachedCodeQlVersion("/path/to/codeql", env),
+        undefined,
+      );
+    });
+  },
+);
+
+test.serial(
+  "getCachedCodeQlVersion ignores a persisted value with the wrong structure",
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "version.json");
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+
+      const testValues = [
+        { cmd: "/path/to/codeql" },
+        { cmd: "/path/to/codeql", version: {} },
+        { cmd: "/path/to/codeql", version: { version: 2 } },
+        { version: { version: "2.20.0" } },
+        {
+          cmd: "/path/to/codeql",
+          version: { version: "2.20.0", overlayVersion: "1" },
+        },
+        {
+          cmd: "/path/to/codeql",
+          version: { version: "2.20.0", features: "nope" },
+        },
+      ].map((v) => JSON.stringify(v));
+
+      for (const value of testValues) {
+        fs.writeFileSync(cacheFile, value, "utf8");
+        t.is(
+          outputCache.getCachedCodeQlVersion("/path/to/codeql", env),
+          undefined,
+          value,
+        );
+      }
+    });
+  },
+);
+
+test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
+  await util.withTmpDir(async (tmpDir: string) => {
+    const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+    t.is(outputCache.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
+  });
+});

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -4,12 +4,15 @@ import path from "path";
 import test from "ava";
 
 import { EnvVar } from "../environment";
+import { getRunnerLogger } from "../logging";
 import { getTestEnv, setupTests } from "../testing-utils";
 import * as util from "../util";
 
 import * as outputCache from "./output-cache";
 
 setupTests(test);
+
+const logger = getRunnerLogger(true);
 
 test.serial(
   "getCachedCodeQlVersion reuses a version persisted by an earlier step",
@@ -25,9 +28,12 @@ test.serial(
         "utf8",
       );
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      t.deepEqual(outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"), {
-        version: "2.20.0",
-      });
+      t.deepEqual(
+        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
+        {
+          version: "2.20.0",
+        },
+      );
     });
   },
 );
@@ -47,7 +53,7 @@ test.serial(
       );
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
       t.is(
-        outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
+        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
         undefined,
       );
     });
@@ -62,7 +68,7 @@ test.serial(
       fs.writeFileSync(cacheFile, "not valid json", "utf8");
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
       t.is(
-        outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
+        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
         undefined,
       );
     });
@@ -100,7 +106,7 @@ test.serial(
       for (const value of testValues) {
         fs.writeFileSync(cacheFile, value, "utf8");
         t.is(
-          outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
+          outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
           undefined,
           value,
         );
@@ -114,7 +120,7 @@ test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
     const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
     t.notThrows(() => {
       t.is(
-        outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
+        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
         undefined,
       );
     });

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -25,7 +25,7 @@ test.serial(
         "utf8",
       );
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      t.deepEqual(outputCache.getCachedCodeQlVersion("/path/to/codeql", env), {
+      t.deepEqual(outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"), {
         version: "2.20.0",
       });
     });
@@ -47,7 +47,7 @@ test.serial(
       );
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
       t.is(
-        outputCache.getCachedCodeQlVersion("/path/to/codeql", env),
+        outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
         undefined,
       );
     });
@@ -62,7 +62,7 @@ test.serial(
       fs.writeFileSync(cacheFile, "not valid json", "utf8");
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
       t.is(
-        outputCache.getCachedCodeQlVersion("/path/to/codeql", env),
+        outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
         undefined,
       );
     });
@@ -94,7 +94,7 @@ test.serial(
       for (const value of testValues) {
         fs.writeFileSync(cacheFile, value, "utf8");
         t.is(
-          outputCache.getCachedCodeQlVersion("/path/to/codeql", env),
+          outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
           undefined,
           value,
         );
@@ -106,6 +106,6 @@ test.serial(
 test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
   await util.withTmpDir(async (tmpDir: string) => {
     const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-    t.is(outputCache.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
+    t.is(outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"), undefined);
   });
 });

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -20,7 +20,7 @@ test.serial(
         cacheFile,
         JSON.stringify({
           cmd: "/path/to/codeql",
-          version: { version: "2.20.0" },
+          entries: { version: { version: "2.20.0" } },
         }),
         "utf8",
       );

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -80,6 +80,7 @@ test.serial(
         { cmd: "/path/to/codeql" },
         { entries: { version: { version: "2.20.0" } } },
         { cmd: "/path/to/codeql", entries: {} },
+        { cmd: "/path/to/codeql", entries: null },
         { cmd: "/path/to/codeql", entries: { version: {} } },
         { cmd: "/path/to/codeql", entries: { version: null } },
         { cmd: "/path/to/codeql", entries: { version: "2.20.0" } },

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -78,16 +78,21 @@ test.serial(
 
       const testValues = [
         { cmd: "/path/to/codeql" },
-        { cmd: "/path/to/codeql", version: {} },
-        { cmd: "/path/to/codeql", version: { version: 2 } },
-        { version: { version: "2.20.0" } },
+        { entries: { version: { version: "2.20.0" } } },
+        { cmd: "/path/to/codeql", entries: {} },
+        { cmd: "/path/to/codeql", entries: { version: {} } },
+        { cmd: "/path/to/codeql", entries: { version: null } },
+        { cmd: "/path/to/codeql", entries: { version: "2.20.0" } },
+        { cmd: "/path/to/codeql", entries: { version: { version: null } } },
+        { cmd: "/path/to/codeql", entries: { version: { version: 2.2 } } },
+        { cmd: "/path/to/codeql", entries: { version: { version: 2 } } },
         {
           cmd: "/path/to/codeql",
-          version: { version: "2.20.0", overlayVersion: "1" },
+          entries: { version: { version: "2.20.0", overlayVersion: "1" } },
         },
         {
           cmd: "/path/to/codeql",
-          version: { version: "2.20.0", features: "nope" },
+          entries: { version: { version: "2.20.0", features: "nope" } },
         },
       ].map((v) => JSON.stringify(v));
 

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -106,6 +106,11 @@ test.serial(
 test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
   await util.withTmpDir(async (tmpDir: string) => {
     const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-    t.is(outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"), undefined);
+    t.notThrows(() => {
+      t.is(
+        outputCache.getCachedCodeQlVersion(env, "/path/to/codeql"),
+        undefined,
+      );
+    });
   });
 });

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -9,21 +9,21 @@ import type { VersionInfo } from "./types";
 /**
  * The keys of the command cache. Each key corresponds to a command whose output we cache.
  */
-enum CommandCacheKey {
+export enum CommandCacheKey {
   Version = "version",
 }
 
 /**
  * The mapping of CLI commands to the types of the output of each command that we cache.
  */
-type CommandCacheKeyOutputMap = {
+export type CommandCacheKeyOutputMap = {
   [CommandCacheKey.Version]: VersionInfo;
 };
 
 /**
  * The type of the command cache that is persisted to disk.
  */
-interface CommandCacheRecord<K extends CommandCacheKey> {
+export interface CommandCacheRecord<K extends CommandCacheKey> {
   cmd: string;
   entries: Map<K, CommandCacheKeyOutputMap[K]>;
 }

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -23,7 +23,7 @@ export type CommandCacheKeyOutputMap = {
 /**
  * The type of the command cache that is persisted to disk.
  */
-export interface CommandCacheRecord<K extends CommandCacheKey> {
+export interface OutputCache<K extends CommandCacheKey> {
   cmd: string;
   entries: Map<K, CommandCacheKeyOutputMap[K]>;
 }
@@ -109,7 +109,7 @@ export function getCachedCodeQlVersion(
     return undefined;
   }
   if (
-    !isCommandCacheRecord(persisted) ||
+    !isOutputCache(persisted) ||
     (cmd !== undefined && persisted.cmd !== cmd)
   ) {
     return undefined;
@@ -139,15 +139,11 @@ function isVersionInfo(x: unknown): x is VersionInfo {
 }
 
 /**
- * Determines whether a value is a `CommandCacheRecord` object.
+ * Determines whether a value is a `OutputCache` object.
  * @param x The value to test
  */
-function isCommandCacheRecord(
-  x: unknown,
-): x is CommandCacheRecord<CommandCacheKey.Version> {
-  const candidate = x as Partial<
-    CommandCacheRecord<CommandCacheKey.Version>
-  > | null;
+function isOutputCache(x: unknown): x is OutputCache<CommandCacheKey.Version> {
+  const candidate = x as Partial<OutputCache<CommandCacheKey.Version>> | null;
   return (
     typeof candidate === "object" &&
     candidate !== null &&

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -59,14 +59,14 @@ function getCommandCacheFilePath(env: Env): string {
 
 /**
  * Caches the CodeQL CLI version both in-memory and on disk.
+ * @param env The environment variables to use.
  * @param cmd The path to the CodeQL CLI.
  * @param version The version information to cache.
- * @param env The environment variables to use.
  */
 export function cacheCodeQlVersion(
+  env: Env,
   cmd: string,
   version: VersionInfo,
-  env: Env,
 ): void {
   if (cachedCodeQlVersion !== undefined) {
     throw new Error("cacheCodeQlVersion() should be called only once");

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -1,0 +1,17 @@
+import path from "path";
+
+import { getTemporaryDirectory } from "../actions-util";
+
+/**
+ * The name of the temporary file that backs the on-disk cache of
+ * CLI responses between workflow steps.
+ */
+const COMMAND_CACHE_FILENAME = "codeql-action-command-cache.json";
+
+/**
+ * Returns the path to the temporary file that backs the
+ * on-disk cache of CLI responses between workflow steps.
+ */
+function getCommandCacheFilePath(): string {
+  return path.join(getTemporaryDirectory(), COMMAND_CACHE_FILENAME);
+}

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -25,7 +25,9 @@ export type CommandCacheKeyOutputMap = {
  */
 export interface OutputCache<K extends CommandCacheKey> {
   cmd: string;
-  entries: Map<K, CommandCacheKeyOutputMap[K]>;
+  entries: {
+    [P in K]: CommandCacheKeyOutputMap[K];
+  };
 }
 
 /**
@@ -70,13 +72,17 @@ export function cacheCodeQlVersion(
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
   cachedCodeQlVersion = version;
+  const outputCache = {
+    cmd,
+    entries: { [CommandCacheKey.Version]: version },
+  } satisfies OutputCache<CommandCacheKey.Version>;
   // Persist the version so that subsequent Actions steps, which run in separate
   // processes, can reuse it rather than invoking `codeql version` again. We
   // record the CLI path so that a different step using a different CodeQL bundle
   // doesn't pick up a stale version.
   fs.writeFileSync(
     getCommandCacheFilePath(env),
-    JSON.stringify({ cmd, entries: { [CommandCacheKey.Version]: version } }),
+    JSON.stringify(outputCache),
     "utf8",
   );
 }

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -9,25 +9,14 @@ import type { VersionInfo } from "./types";
 /**
  * The keys of the command cache. Each key corresponds to a command whose output we cache.
  */
-export enum CommandCacheKey {
-  Version = "version",
-}
-
-/**
- * The mapping of CLI commands to the types of the output of each command that we cache.
- */
-export type CommandCacheKeyOutputMap = {
-  [CommandCacheKey.Version]: VersionInfo;
-};
+export type CommandCacheKey = string;
 
 /**
  * The type of the command cache that is persisted to disk.
  */
-export interface OutputCache<K extends CommandCacheKey> {
+export interface OutputCache {
   cmd: string;
-  entries: {
-    [P in K]: CommandCacheKeyOutputMap[K];
-  };
+  entries: Record<CommandCacheKey, unknown>;
 }
 
 /**
@@ -74,8 +63,8 @@ export function cacheCodeQlVersion(
   cachedCodeQlVersion = version;
   const outputCache = {
     cmd,
-    entries: { [CommandCacheKey.Version]: version },
-  } satisfies OutputCache<CommandCacheKey.Version>;
+    entries: { version },
+  } satisfies OutputCache;
   // Persist the version so that subsequent Actions steps, which run in separate
   // processes, can reuse it rather than invoking `codeql version` again. We
   // record the CLI path so that a different step using a different CodeQL bundle
@@ -122,7 +111,7 @@ export function getCachedCodeQlVersion(
   }
   // Memoize the parsed value so that subsequent calls in this process don't
   // re-parse the environment variable.
-  cachedCodeQlVersion = persisted.entries[CommandCacheKey.Version];
+  cachedCodeQlVersion = persisted.entries.version as VersionInfo;
   return cachedCodeQlVersion;
 }
 
@@ -148,13 +137,13 @@ function isVersionInfo(x: unknown): x is VersionInfo {
  * Determines whether a value is a `OutputCache` object.
  * @param x The value to test
  */
-function isOutputCache(x: unknown): x is OutputCache<CommandCacheKey.Version> {
-  const candidate = x as Partial<OutputCache<CommandCacheKey.Version>> | null;
+function isOutputCache(x: unknown): x is OutputCache {
+  const candidate = x as Partial<OutputCache> | null;
   return (
     typeof candidate === "object" &&
     candidate !== null &&
     typeof candidate.cmd === "string" &&
     candidate.entries !== undefined &&
-    isVersionInfo(candidate.entries[CommandCacheKey.Version])
+    isVersionInfo(candidate.entries.version)
   );
 }

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -3,9 +3,14 @@ import path from "path";
 
 import { getTemporaryDirectory } from "../actions-util";
 import { Env, getEnv } from "../environment";
-import { isPersistedVersionInfo } from "../util";
 
 import type { VersionInfo } from "./types";
+
+/** The persisted version together with the CLI path it was obtained from. */
+interface PersistedVersionInfo {
+  cmd: string;
+  version: VersionInfo;
+}
 
 /**
  * The name of the temporary file that backs the on-disk cache of
@@ -98,4 +103,36 @@ export function getCachedCodeQlVersion(
   // re-parse the environment variable.
   cachedCodeQlVersion = persisted.version;
   return cachedCodeQlVersion;
+}
+
+/**
+ * Determines whether a value is a `VersionInfo` object.
+ * @param x The value to test
+ */
+function isVersionInfo(x: unknown): x is VersionInfo {
+  const candidate = x as Partial<VersionInfo> | null;
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    typeof candidate.version === "string" &&
+    (candidate.features === undefined ||
+      (typeof candidate.features === "object" &&
+        candidate.features !== null)) &&
+    (candidate.overlayVersion === undefined ||
+      typeof candidate.overlayVersion === "number")
+  );
+}
+
+/**
+ * Determines whether a value is a `PersistedVersionInfo` object.
+ * @param x The value to test
+ */
+function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
+  const candidate = x as Partial<PersistedVersionInfo> | null;
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    typeof candidate.cmd === "string" &&
+    isVersionInfo(candidate.version)
+  );
 }

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -66,8 +66,7 @@ export function cacheCodeQlVersion(
 }
 
 /**
- * Returns the cached CodeQL CLI version, if any. If not cached,
- * attempts to read and parse it from disk.
+ * Returns the cached CodeQL CLI version, if any.
  * @param cmd The path to the CodeQL CLI.
  * @param env The environment variables to use.
  */

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -6,10 +6,24 @@ import { Env, getEnv } from "../environment";
 
 import type { VersionInfo } from "./types";
 
+/**
+ * The keys of the command cache. Each key corresponds to a command whose output we cache.
+ */
+enum CommandCacheKey {
+  Version = "version",
+}
+
+/**
+ * The mapping of CLI commands to the types of the output of each command that we cache.
+ */
+type CommandCacheKeyOutputMap = {
+  [CommandCacheKey.Version]: VersionInfo;
+};
+
 /** The persisted version together with the CLI path it was obtained from. */
-interface PersistedVersionInfo {
+interface PersistedVersionInfo<K extends CommandCacheKey> {
   cmd: string;
-  version: VersionInfo;
+  entries: Map<K, CommandCacheKeyOutputMap[K]>;
 }
 
 /**
@@ -60,7 +74,7 @@ export function cacheCodeQlVersion(
   // doesn't pick up a stale version.
   fs.writeFileSync(
     getCommandCacheFilePath(env),
-    JSON.stringify({ cmd, version }),
+    JSON.stringify({ cmd, entries: { [CommandCacheKey.Version]: version } }),
     "utf8",
   );
 }
@@ -100,7 +114,7 @@ export function getCachedCodeQlVersion(
   }
   // Memoize the parsed value so that subsequent calls in this process don't
   // re-parse the environment variable.
-  cachedCodeQlVersion = persisted.version;
+  cachedCodeQlVersion = persisted.entries[CommandCacheKey.Version];
   return cachedCodeQlVersion;
 }
 
@@ -126,12 +140,17 @@ function isVersionInfo(x: unknown): x is VersionInfo {
  * Determines whether a value is a `PersistedVersionInfo` object.
  * @param x The value to test
  */
-function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
-  const candidate = x as Partial<PersistedVersionInfo> | null;
+function isPersistedVersionInfo(
+  x: unknown,
+): x is PersistedVersionInfo<CommandCacheKey.Version> {
+  const candidate = x as Partial<
+    PersistedVersionInfo<CommandCacheKey.Version>
+  > | null;
   return (
     typeof candidate === "object" &&
     candidate !== null &&
     typeof candidate.cmd === "string" &&
-    isVersionInfo(candidate.version)
+    candidate.entries !== undefined &&
+    isVersionInfo(candidate.entries[CommandCacheKey.Version])
   );
 }

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import path from "path";
 
 import { getTemporaryDirectory } from "../actions-util";
-import { Env, getEnv } from "../environment";
+import { Env } from "../environment";
 
 import type { VersionInfo } from "./types";
 
@@ -64,7 +64,7 @@ function getCommandCacheFilePath(env: Env): string {
 export function cacheCodeQlVersion(
   cmd: string,
   version: VersionInfo,
-  env: Env = getEnv(),
+  env: Env,
 ): void {
   if (cachedCodeQlVersion !== undefined) {
     throw new Error("cacheCodeQlVersion() should be called only once");
@@ -83,12 +83,12 @@ export function cacheCodeQlVersion(
 
 /**
  * Returns the cached CodeQL CLI version, if any.
- * @param cmd The path to the CodeQL CLI.
  * @param env The environment variables to use.
+ * @param cmd The path to the CodeQL CLI.
  */
 export function getCachedCodeQlVersion(
+  env: Env,
   cmd?: string,
-  env: Env = getEnv(),
 ): undefined | VersionInfo {
   if (cachedCodeQlVersion !== undefined) {
     return cachedCodeQlVersion;

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -1,6 +1,10 @@
+import * as fs from "fs";
 import path from "path";
 
 import { getTemporaryDirectory } from "../actions-util";
+import { VersionInfo } from "../codeql";
+import { Env, getEnv } from "../environment";
+import { isPersistedVersionInfo } from "../util";
 
 /**
  * The name of the temporary file that backs the on-disk cache of
@@ -9,9 +13,88 @@ import { getTemporaryDirectory } from "../actions-util";
 const COMMAND_CACHE_FILENAME = "codeql-action-command-cache.json";
 
 /**
+ * The module-global variable that caches the CodeQL CLI version in-memory.
+ */
+let cachedCodeQlVersion: undefined | VersionInfo = undefined;
+
+/**
+ * Resets the in-process cache of the CodeQL CLI version. Only for use in tests,
+ * which exercise multiple "steps" within a single process.
+ */
+export function resetCachedCodeQlVersion(): void {
+  cachedCodeQlVersion = undefined;
+}
+
+/**
  * Returns the path to the temporary file that backs the
  * on-disk cache of CLI responses between workflow steps.
  */
-function getCommandCacheFilePath(): string {
-  return path.join(getTemporaryDirectory(), COMMAND_CACHE_FILENAME);
+function getCommandCacheFilePath(env: Env): string {
+  return path.join(getTemporaryDirectory(env), COMMAND_CACHE_FILENAME);
+}
+
+/**
+ * Caches the CodeQL CLI version both in-memory and on disk.
+ * @param cmd The path to the CodeQL CLI.
+ * @param version The version information to cache.
+ * @param env The environment variables to use.
+ */
+export function cacheCodeQlVersion(
+  cmd: string,
+  version: VersionInfo,
+  env: Env = getEnv(),
+): void {
+  if (cachedCodeQlVersion !== undefined) {
+    throw new Error("cacheCodeQlVersion() should be called only once");
+  }
+  cachedCodeQlVersion = version;
+  // Persist the version so that subsequent Actions steps, which run in separate
+  // processes, can reuse it rather than invoking `codeql version` again. We
+  // record the CLI path so that a different step using a different CodeQL bundle
+  // doesn't pick up a stale version.
+  fs.writeFileSync(
+    getCommandCacheFilePath(env),
+    JSON.stringify({ cmd, version }),
+    "utf8",
+  );
+}
+
+/**
+ * Returns the cached CodeQL CLI version, if any. If not cached,
+ * attempts to read and parse it from disk.
+ * @param cmd The path to the CodeQL CLI.
+ * @param env The environment variables to use.
+ */
+export function getCachedCodeQlVersion(
+  cmd?: string,
+  env: Env = getEnv(),
+): undefined | VersionInfo {
+  if (cachedCodeQlVersion !== undefined) {
+    return cachedCodeQlVersion;
+  }
+  // Fall back to the value persisted by an earlier Actions step, if any. This is
+  // best-effort: any malformed or mismatched value is ignored so that the caller
+  // invokes `codeql version` instead.
+  let serialized: string;
+  try {
+    serialized = fs.readFileSync(getCommandCacheFilePath(env), "utf8");
+  } catch {
+    return undefined;
+  }
+  let persisted: unknown;
+  try {
+    persisted = JSON.parse(serialized);
+  } catch {
+    return undefined;
+  }
+  if (
+    !isPersistedVersionInfo(persisted) ||
+    (cmd !== undefined && persisted.cmd !== cmd)
+  ) {
+    return undefined;
+  }
+  // Memoize the parsed value so that subsequent calls in this process don't
+  // re-parse the environment variable.
+  cachedCodeQlVersion = persisted.version;
+  return cachedCodeQlVersion;
 }

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -2,9 +2,10 @@ import * as fs from "fs";
 import path from "path";
 
 import { getTemporaryDirectory } from "../actions-util";
-import { VersionInfo } from "../codeql";
 import { Env, getEnv } from "../environment";
 import { isPersistedVersionInfo } from "../util";
+
+import type { VersionInfo } from "./types";
 
 /**
  * The name of the temporary file that backs the on-disk cache of

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -20,8 +20,10 @@ type CommandCacheKeyOutputMap = {
   [CommandCacheKey.Version]: VersionInfo;
 };
 
-/** The persisted version together with the CLI path it was obtained from. */
-interface PersistedVersionInfo<K extends CommandCacheKey> {
+/**
+ * The type of the command cache that is persisted to disk.
+ */
+interface CommandCacheRecord<K extends CommandCacheKey> {
   cmd: string;
   entries: Map<K, CommandCacheKeyOutputMap[K]>;
 }
@@ -107,7 +109,7 @@ export function getCachedCodeQlVersion(
     return undefined;
   }
   if (
-    !isPersistedVersionInfo(persisted) ||
+    !isCommandCacheRecord(persisted) ||
     (cmd !== undefined && persisted.cmd !== cmd)
   ) {
     return undefined;
@@ -137,14 +139,14 @@ function isVersionInfo(x: unknown): x is VersionInfo {
 }
 
 /**
- * Determines whether a value is a `PersistedVersionInfo` object.
+ * Determines whether a value is a `CommandCacheRecord` object.
  * @param x The value to test
  */
-function isPersistedVersionInfo(
+function isCommandCacheRecord(
   x: unknown,
-): x is PersistedVersionInfo<CommandCacheKey.Version> {
+): x is CommandCacheRecord<CommandCacheKey.Version> {
   const candidate = x as Partial<
-    PersistedVersionInfo<CommandCacheKey.Version>
+    CommandCacheRecord<CommandCacheKey.Version>
   > | null;
   return (
     typeof candidate === "object" &&

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -3,6 +3,7 @@ import path from "path";
 
 import { getTemporaryDirectory } from "../actions-util";
 import { Env } from "../environment";
+import { Logger } from "../logging";
 
 import type { VersionInfo } from "./types";
 
@@ -78,10 +79,12 @@ export function cacheCodeQlVersion(
 
 /**
  * Returns the cached CodeQL CLI version, if any.
+ * @param logger The logger to use for logging messages.
  * @param env The environment variables to use.
  * @param cmd The path to the CodeQL CLI.
  */
 export function getCachedCodeQlVersion(
+  logger: Logger,
   env: Env,
   cmd?: string,
 ): undefined | VersionInfo {
@@ -94,13 +97,17 @@ export function getCachedCodeQlVersion(
   let serialized: string;
   try {
     serialized = fs.readFileSync(getCommandCacheFilePath(env), "utf8");
-  } catch {
+  } catch (e) {
+    logger.debug(
+      `Cannot read CLI-cache file ${getCommandCacheFilePath(env)}: ${e}`,
+    );
     return undefined;
   }
   let persisted: unknown;
   try {
     persisted = JSON.parse(serialized);
-  } catch {
+  } catch (e) {
+    logger.debug(`Cannot parse CLI-cache data as JSON: ${e}`);
     return undefined;
   }
   if (

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,13 @@
+export interface VersionInfo {
+  version: string;
+  features?: { [name: string]: boolean };
+  /**
+   * The overlay version helps deal with backward incompatible changes for
+   * overlay analysis. When a precompiled query pack reports the same overlay
+   * version as the CodeQL CLI, we can use the CodeQL CLI to perform overlay
+   * analysis with that pack. Otherwise, if the overlay versions are different,
+   * or if either the pack or the CLI does not report an overlay version,
+   * we need to revert to non-overlay analysis.
+   */
+  overlayVersion?: number;
+}

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -12,6 +12,7 @@ import {
   runTool,
 } from "./actions-util";
 import * as api from "./api-client";
+import * as outputCache from "./cli/output-cache";
 import { CliError, wrapCliConfigurationError } from "./cli-errors";
 import { appendExtraQueryExclusions, type Config } from "./config-utils";
 import { DocUrl } from "./doc-url";
@@ -502,7 +503,7 @@ async function getCodeQLForCmd(
       return cmd;
     },
     async getVersion() {
-      let result = util.getCachedCodeQlVersion(cmd);
+      let result = outputCache.getCachedCodeQlVersion(cmd);
       if (result === undefined) {
         result = await runCliJson<VersionInfo>(
           cmd,
@@ -511,7 +512,7 @@ async function getCodeQLForCmd(
             noStreamStdout: true,
           },
         );
-        util.cacheCodeQlVersion(cmd, result);
+        outputCache.cacheCodeQlVersion(cmd, result);
       }
       return result;
     },

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -499,7 +499,7 @@ async function getCodeQLForCmd(
             noStreamStdout: true,
           },
         );
-        outputCache.cacheCodeQlVersion(cmd, result, getEnv());
+        outputCache.cacheCodeQlVersion(getEnv(), cmd, result);
       }
       return result;
     },

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -13,6 +13,7 @@ import {
 } from "./actions-util";
 import * as api from "./api-client";
 import * as outputCache from "./cli/output-cache";
+import type { VersionInfo } from "./cli/types";
 import { CliError, wrapCliConfigurationError } from "./cli-errors";
 import { appendExtraQueryExclusions, type Config } from "./config-utils";
 import { DocUrl } from "./doc-url";
@@ -214,20 +215,6 @@ export interface CodeQL {
     outputFile: string,
     options: { mergeRunsFromEqualCategory?: boolean },
   ): Promise<void>;
-}
-
-export interface VersionInfo {
-  version: string;
-  features?: { [name: string]: boolean };
-  /**
-   * The overlay version helps deal with backward incompatible changes for
-   * overlay analysis. When a precompiled query pack reports the same overlay
-   * version as the CodeQL CLI, we can use the CodeQL CLI to perform overlay
-   * analysis with that pack. Otherwise, if the overlay versions are different,
-   * or if either the pack or the CLI does not report an overlay version,
-   * we need to revert to non-overlay analysis.
-   */
-  overlayVersion?: number;
 }
 
 export interface ResolveDatabaseOutput {

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -491,7 +491,7 @@ async function getCodeQLForCmd(
       return cmd;
     },
     async getVersion() {
-      let result = outputCache.getCachedCodeQlVersion(getEnv(), cmd);
+      let result = outputCache.getCachedCodeQlVersion(logger, getEnv(), cmd);
       if (result === undefined) {
         result = await runCliJson<VersionInfo>(
           cmd,

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -17,7 +17,7 @@ import type { VersionInfo } from "./cli/types";
 import { CliError, wrapCliConfigurationError } from "./cli-errors";
 import { appendExtraQueryExclusions, type Config } from "./config-utils";
 import { DocUrl } from "./doc-url";
-import { EnvVar } from "./environment";
+import { EnvVar, getEnv } from "./environment";
 import {
   CodeQLDefaultVersionInfo,
   Feature,
@@ -490,7 +490,7 @@ async function getCodeQLForCmd(
       return cmd;
     },
     async getVersion() {
-      let result = outputCache.getCachedCodeQlVersion(cmd);
+      let result = outputCache.getCachedCodeQlVersion(getEnv(), cmd);
       if (result === undefined) {
         result = await runCliJson<VersionInfo>(
           cmd,
@@ -499,7 +499,7 @@ async function getCodeQLForCmd(
             noStreamStdout: true,
           },
         );
-        outputCache.cacheCodeQlVersion(cmd, result);
+        outputCache.cacheCodeQlVersion(cmd, result, getEnv());
       }
       return result;
     },

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -39,12 +39,6 @@ export enum EnvVar {
    */
   CODE_SCANNING_REF = "CODE_SCANNING_REF",
 
-  /**
-   * `PersistedVersionInfo` for the CodeQL CLI, so later Actions steps can reuse it instead of
-   * invoking `codeql version` again.
-   */
-  CODEQL_VERSION_INFO = "CODEQL_ACTION_CLI_VERSION_INFO",
-
   /** Whether the CodeQL Action has invoked the Go autobuilder. */
   DID_AUTOBUILD_GOLANG = "CODEQL_ACTION_DID_AUTOBUILD_GOLANG",
 

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -376,7 +376,7 @@ export async function createStatusReportBase(
       core.exportVariable(EnvVar.WORKFLOW_STARTED_AT, workflowStartedAt);
     }
     const runnerOs = getRequiredEnvParam("RUNNER_OS");
-    const codeQlCliVersion = getCachedCodeQlVersion();
+    const codeQlCliVersion = getCachedCodeQlVersion(getEnv());
     const actionRef = process.env["GITHUB_ACTION_REF"] || "";
     const testingEnvironment = getTestingEnvironment();
     // re-export the testing environment variable so that it is available to subsequent steps,

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -376,7 +376,7 @@ export async function createStatusReportBase(
       core.exportVariable(EnvVar.WORKFLOW_STARTED_AT, workflowStartedAt);
     }
     const runnerOs = getRequiredEnvParam("RUNNER_OS");
-    const codeQlCliVersion = getCachedCodeQlVersion(getEnv());
+    const codeQlCliVersion = getCachedCodeQlVersion(logger, getEnv());
     const actionRef = process.env["GITHUB_ACTION_REF"] || "";
     const testingEnvironment = getTestingEnvironment();
     // re-export the testing environment variable so that it is available to subsequent steps,

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -14,6 +14,7 @@ import {
   isSelfHostedRunner,
 } from "./actions-util";
 import { getAnalysisKey, getApiClient } from "./api-client";
+import { getCachedCodeQlVersion } from "./cli/output-cache";
 import type { Config } from "./config/action-config";
 import type { ComputedInput, InputName } from "./config/inputs";
 import { parseRegistriesWithoutCredentials } from "./config/pack-registries";
@@ -30,7 +31,6 @@ import { registryBaseSchema } from "./start-proxy/types";
 import {
   ConfigurationError,
   getRequiredEnvParam,
-  getCachedCodeQlVersion,
   isInTestMode,
   GITHUB_DOTCOM_URL,
   DiskUsage,

--- a/src/testing-utils.ts
+++ b/src/testing-utils.ts
@@ -19,6 +19,7 @@ import * as apiClient from "./api-client";
 import { GitHubApiDetails } from "./api-client";
 import { CachingKind } from "./caching-utils";
 import { resetCachedCodeQlVersion } from "./cli/output-cache";
+import type { VersionInfo } from "./cli/types";
 import * as codeql from "./codeql";
 import { Config } from "./config-utils";
 import * as defaults from "./defaults.json";
@@ -872,7 +873,7 @@ export const makeVersionInfo = (
   version: string,
   features?: { [name: string]: boolean },
   overlayVersion?: number,
-): codeql.VersionInfo => ({
+): VersionInfo => ({
   version,
   features,
   overlayVersion,

--- a/src/testing-utils.ts
+++ b/src/testing-utils.ts
@@ -18,6 +18,7 @@ import { AnalysisKind } from "./analyses";
 import * as apiClient from "./api-client";
 import { GitHubApiDetails } from "./api-client";
 import { CachingKind } from "./caching-utils";
+import { resetCachedCodeQlVersion } from "./cli/output-cache";
 import * as codeql from "./codeql";
 import { Config } from "./config-utils";
 import * as defaults from "./defaults.json";
@@ -39,7 +40,6 @@ import {
   GitHubVariant,
   GitHubVersion,
   HTTPError,
-  resetCachedCodeQlVersion,
   Result,
   Success,
 } from "./util";

--- a/src/tools-features.ts
+++ b/src/tools-features.ts
@@ -1,6 +1,6 @@
 import * as semver from "semver";
 
-import type { VersionInfo } from "./codeql";
+import type { VersionInfo } from "./cli/types";
 
 export enum ToolsFeature {
   BuiltinExtractorsSpecifyDefaultQueries = "builtinExtractorsSpecifyDefaultQueries",

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -10,7 +10,7 @@ import * as sinon from "sinon";
 import * as api from "./api-client";
 import { EnvVar } from "./environment";
 import { getRunnerLogger } from "./logging";
-import { setupTests } from "./testing-utils";
+import { getTestEnv, setupTests } from "./testing-utils";
 import * as util from "./util";
 
 setupTests(test);
@@ -535,55 +535,83 @@ test("Failure.orElse returns the default value for a failure result", (t) => {
 
 test.serial(
   "getCachedCodeQlVersion reuses a version persisted by an earlier step",
-  (t) => {
-    process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
-      cmd: "/path/to/codeql",
-      version: { version: "2.20.0" },
-    });
-    t.deepEqual(util.getCachedCodeQlVersion("/path/to/codeql"), {
-      version: "2.20.0",
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "version.json");
+      fs.writeFileSync(
+        cacheFile,
+        JSON.stringify({
+          cmd: "/path/to/codeql",
+          version: { version: "2.20.0" },
+        }),
+        "utf8",
+      );
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      t.deepEqual(util.getCachedCodeQlVersion("/path/to/codeql", env), {
+        version: "2.20.0",
+      });
     });
   },
 );
 
 test.serial(
   "getCachedCodeQlVersion ignores a persisted version from a different CLI",
-  (t) => {
-    process.env[EnvVar.CODEQL_VERSION_INFO] = JSON.stringify({
-      cmd: "/path/to/other-codeql",
-      version: { version: "2.20.0" },
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "version.json");
+      fs.writeFileSync(
+        cacheFile,
+        JSON.stringify({
+          cmd: "/path/to/other-codeql",
+          version: { version: "2.20.0" },
+        }),
+        "utf8",
+      );
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      t.is(util.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
     });
-    t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
   },
 );
 
 test.serial(
   "getCachedCodeQlVersion ignores a malformed persisted value",
-  (t) => {
-    process.env[EnvVar.CODEQL_VERSION_INFO] = "not valid json";
-    t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined);
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "version.json");
+      fs.writeFileSync(cacheFile, "not valid json", "utf8");
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      t.is(util.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
+    });
   },
 );
 
 test.serial(
   "getCachedCodeQlVersion ignores a persisted value with the wrong structure",
-  (t) => {
-    for (const value of [
-      JSON.stringify({ cmd: "/path/to/codeql" }),
-      JSON.stringify({ cmd: "/path/to/codeql", version: {} }),
-      JSON.stringify({ cmd: "/path/to/codeql", version: { version: 2 } }),
-      JSON.stringify({ version: { version: "2.20.0" } }),
-      JSON.stringify({
-        cmd: "/path/to/codeql",
-        version: { version: "2.20.0", overlayVersion: "1" },
-      }),
-      JSON.stringify({
-        cmd: "/path/to/codeql",
-        version: { version: "2.20.0", features: "nope" },
-      }),
-    ]) {
-      process.env[EnvVar.CODEQL_VERSION_INFO] = value;
-      t.is(util.getCachedCodeQlVersion("/path/to/codeql"), undefined, value);
-    }
+  async (t) => {
+    await util.withTmpDir(async (tmpDir: string) => {
+      const cacheFile = path.join(tmpDir, "version.json");
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      for (const value of [
+        JSON.stringify({ cmd: "/path/to/codeql" }),
+        JSON.stringify({ cmd: "/path/to/codeql", version: {} }),
+        JSON.stringify({ cmd: "/path/to/codeql", version: { version: 2 } }),
+        JSON.stringify({ version: { version: "2.20.0" } }),
+        JSON.stringify({
+          cmd: "/path/to/codeql",
+          version: { version: "2.20.0", overlayVersion: "1" },
+        }),
+        JSON.stringify({
+          cmd: "/path/to/codeql",
+          version: { version: "2.20.0", features: "nope" },
+        }),
+      ]) {
+        fs.writeFileSync(cacheFile, value, "utf8");
+        t.is(
+          util.getCachedCodeQlVersion("/path/to/codeql", env),
+          undefined,
+          value,
+        );
+      }
+    });
   },
 );

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -618,3 +618,10 @@ test.serial(
     });
   },
 );
+
+test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
+  await util.withTmpDir(async (tmpDir: string) => {
+    const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+    t.is(util.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
+  });
+});

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -591,20 +591,23 @@ test.serial(
     await util.withTmpDir(async (tmpDir: string) => {
       const cacheFile = path.join(tmpDir, "version.json");
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      for (const value of [
-        JSON.stringify({ cmd: "/path/to/codeql" }),
-        JSON.stringify({ cmd: "/path/to/codeql", version: {} }),
-        JSON.stringify({ cmd: "/path/to/codeql", version: { version: 2 } }),
-        JSON.stringify({ version: { version: "2.20.0" } }),
-        JSON.stringify({
+
+      const testValues = [
+        { cmd: "/path/to/codeql" },
+        { cmd: "/path/to/codeql", version: {} },
+        { cmd: "/path/to/codeql", version: { version: 2 } },
+        { version: { version: "2.20.0" } },
+        {
           cmd: "/path/to/codeql",
           version: { version: "2.20.0", overlayVersion: "1" },
-        }),
-        JSON.stringify({
+        },
+        {
           cmd: "/path/to/codeql",
           version: { version: "2.20.0", features: "nope" },
-        }),
-      ]) {
+        },
+      ].map((v) => JSON.stringify(v));
+
+      for (const value of testValues) {
         fs.writeFileSync(cacheFile, value, "utf8");
         t.is(
           util.getCachedCodeQlVersion("/path/to/codeql", env),

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -10,7 +10,7 @@ import * as sinon from "sinon";
 import * as api from "./api-client";
 import { EnvVar } from "./environment";
 import { getRunnerLogger } from "./logging";
-import { getTestEnv, setupTests } from "./testing-utils";
+import { setupTests } from "./testing-utils";
 import * as util from "./util";
 
 setupTests(test);
@@ -531,97 +531,4 @@ test("Success.orElse returns the value for a success result", (t) => {
 test("Failure.orElse returns the default value for a failure result", (t) => {
   const result = new util.Failure(new Error("test error"));
   t.is(result.orElse("default value"), "default value");
-});
-
-test.serial(
-  "getCachedCodeQlVersion reuses a version persisted by an earlier step",
-  async (t) => {
-    await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "version.json");
-      fs.writeFileSync(
-        cacheFile,
-        JSON.stringify({
-          cmd: "/path/to/codeql",
-          version: { version: "2.20.0" },
-        }),
-        "utf8",
-      );
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      t.deepEqual(util.getCachedCodeQlVersion("/path/to/codeql", env), {
-        version: "2.20.0",
-      });
-    });
-  },
-);
-
-test.serial(
-  "getCachedCodeQlVersion ignores a persisted version from a different CLI",
-  async (t) => {
-    await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "version.json");
-      fs.writeFileSync(
-        cacheFile,
-        JSON.stringify({
-          cmd: "/path/to/other-codeql",
-          version: { version: "2.20.0" },
-        }),
-        "utf8",
-      );
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      t.is(util.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
-    });
-  },
-);
-
-test.serial(
-  "getCachedCodeQlVersion ignores a malformed persisted value",
-  async (t) => {
-    await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "version.json");
-      fs.writeFileSync(cacheFile, "not valid json", "utf8");
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      t.is(util.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
-    });
-  },
-);
-
-test.serial(
-  "getCachedCodeQlVersion ignores a persisted value with the wrong structure",
-  async (t) => {
-    await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "version.json");
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-
-      const testValues = [
-        { cmd: "/path/to/codeql" },
-        { cmd: "/path/to/codeql", version: {} },
-        { cmd: "/path/to/codeql", version: { version: 2 } },
-        { version: { version: "2.20.0" } },
-        {
-          cmd: "/path/to/codeql",
-          version: { version: "2.20.0", overlayVersion: "1" },
-        },
-        {
-          cmd: "/path/to/codeql",
-          version: { version: "2.20.0", features: "nope" },
-        },
-      ].map((v) => JSON.stringify(v));
-
-      for (const value of testValues) {
-        fs.writeFileSync(cacheFile, value, "utf8");
-        t.is(
-          util.getCachedCodeQlVersion("/path/to/codeql", env),
-          undefined,
-          value,
-        );
-      }
-    });
-  },
-);
-
-test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
-  await util.withTmpDir(async (tmpDir: string) => {
-    const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-    t.is(util.getCachedCodeQlVersion("/path/to/codeql", env), undefined);
-  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,11 +9,12 @@ import getFolderSize from "get-folder-size";
 import * as yaml from "js-yaml";
 import * as semver from "semver";
 
+import { getTemporaryDirectory } from "./actions-util";
 import * as apiCompatibility from "./api-compatibility.json";
 import type { CodeQL, VersionInfo } from "./codeql";
 import type { Pack } from "./config/db-config";
 import type { Config } from "./config-utils";
-import { EnvVar, getRequiredEnvParam } from "./environment";
+import { Env, EnvVar, getEnv, getRequiredEnvParam } from "./environment";
 import * as json from "./json";
 import { Language } from "./languages";
 import { Logger } from "./logging";
@@ -638,7 +639,25 @@ function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
   );
 }
 
-export function cacheCodeQlVersion(cmd: string, version: VersionInfo): void {
+/**
+ * Returns the file path to the `codeql version` output cache.
+ * @param env The environment variables to use—only necessary for testing.
+ */
+function getPathToCodeQLVersionCacheFile(env: Env): string {
+  return path.join(getTemporaryDirectory(env), "version.json");
+}
+
+/**
+ * Caches the CodeQL CLI version both in-memory and on disk.
+ * @param cmd The path to the CodeQL CLI.
+ * @param version The version information to cache.
+ * @param env The environment variables to use—only necessary for testing.
+ */
+export function cacheCodeQlVersion(
+  cmd: string,
+  version: VersionInfo,
+  env: Env = getEnv(),
+): void {
   if (cachedCodeQlVersion !== undefined) {
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
@@ -647,23 +666,33 @@ export function cacheCodeQlVersion(cmd: string, version: VersionInfo): void {
   // processes, can reuse it rather than invoking `codeql version` again. We
   // record the CLI path so that a different step using a different CodeQL bundle
   // doesn't pick up a stale version.
-  core.exportVariable(
-    EnvVar.CODEQL_VERSION_INFO,
+  fs.writeFileSync(
+    getPathToCodeQLVersionCacheFile(env),
     JSON.stringify({ cmd, version }),
+    "utf8",
   );
 }
 
-export function getCachedCodeQlVersion(cmd?: string): undefined | VersionInfo {
+/**
+ * Returns the cached CodeQL CLI version, if any. If not cached,
+ * attempts to read and parse it from disk.
+ * @param cmd The path to the CodeQL CLI.
+ * @param env The environment variables to use—only necessary for testing.
+ */
+export function getCachedCodeQlVersion(
+  cmd?: string,
+  env: Env = getEnv(),
+): undefined | VersionInfo {
   if (cachedCodeQlVersion !== undefined) {
     return cachedCodeQlVersion;
   }
   // Fall back to the value persisted by an earlier Actions step, if any. This is
   // best-effort: any malformed or mismatched value is ignored so that the caller
   // invokes `codeql version` instead.
-  const serialized = process.env[EnvVar.CODEQL_VERSION_INFO];
-  if (!serialized) {
-    return undefined;
-  }
+  const serialized = fs.readFileSync(
+    getPathToCodeQLVersionCacheFile(env),
+    "utf8",
+  );
   let persisted: unknown;
   try {
     persisted = JSON.parse(serialized);

--- a/src/util.ts
+++ b/src/util.ts
@@ -689,10 +689,12 @@ export function getCachedCodeQlVersion(
   // Fall back to the value persisted by an earlier Actions step, if any. This is
   // best-effort: any malformed or mismatched value is ignored so that the caller
   // invokes `codeql version` instead.
-  const serialized = fs.readFileSync(
-    getPathToCodeQLVersionCacheFile(env),
-    "utf8",
-  );
+  let serialized: string;
+  try {
+    serialized = fs.readFileSync(getPathToCodeQLVersionCacheFile(env), "utf8");
+  } catch {
+    return undefined;
+  }
   let persisted: unknown;
   try {
     persisted = JSON.parse(serialized);

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,12 +9,11 @@ import getFolderSize from "get-folder-size";
 import * as yaml from "js-yaml";
 import * as semver from "semver";
 
-import { getTemporaryDirectory } from "./actions-util";
 import * as apiCompatibility from "./api-compatibility.json";
 import type { CodeQL, VersionInfo } from "./codeql";
 import type { Pack } from "./config/db-config";
 import type { Config } from "./config-utils";
-import { Env, EnvVar, getEnv, getRequiredEnvParam } from "./environment";
+import { EnvVar, getRequiredEnvParam } from "./environment";
 import * as json from "./json";
 import { Language } from "./languages";
 import { Logger } from "./logging";
@@ -599,16 +598,6 @@ export function asHTTPError(arg: any): HTTPError | undefined {
   return undefined;
 }
 
-let cachedCodeQlVersion: undefined | VersionInfo = undefined;
-
-/**
- * Resets the in-process cache of the CodeQL CLI version. Only for use in tests,
- * which exercise multiple "steps" within a single process.
- */
-export function resetCachedCodeQlVersion(): void {
-  cachedCodeQlVersion = undefined;
-}
-
 /** The persisted version together with the CLI path it was obtained from. */
 interface PersistedVersionInfo {
   cmd: string;
@@ -629,7 +618,7 @@ function isVersionInfo(x: unknown): x is VersionInfo {
   );
 }
 
-function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
+export function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
   const candidate = x as Partial<PersistedVersionInfo> | null;
   return (
     typeof candidate === "object" &&
@@ -637,79 +626,6 @@ function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
     typeof candidate.cmd === "string" &&
     isVersionInfo(candidate.version)
   );
-}
-
-/**
- * Returns the file path to the `codeql version` output cache.
- * @param env The environment variables to use.
- */
-function getPathToCodeQLVersionCacheFile(env: Env): string {
-  return path.join(getTemporaryDirectory(env), "version.json");
-}
-
-/**
- * Caches the CodeQL CLI version both in-memory and on disk.
- * @param cmd The path to the CodeQL CLI.
- * @param version The version information to cache.
- * @param env The environment variables to use.
- */
-export function cacheCodeQlVersion(
-  cmd: string,
-  version: VersionInfo,
-  env: Env = getEnv(),
-): void {
-  if (cachedCodeQlVersion !== undefined) {
-    throw new Error("cacheCodeQlVersion() should be called only once");
-  }
-  cachedCodeQlVersion = version;
-  // Persist the version so that subsequent Actions steps, which run in separate
-  // processes, can reuse it rather than invoking `codeql version` again. We
-  // record the CLI path so that a different step using a different CodeQL bundle
-  // doesn't pick up a stale version.
-  fs.writeFileSync(
-    getPathToCodeQLVersionCacheFile(env),
-    JSON.stringify({ cmd, version }),
-    "utf8",
-  );
-}
-
-/**
- * Returns the cached CodeQL CLI version, if any.
- * @param cmd The path to the CodeQL CLI.
- * @param env The environment variables to use.
- */
-export function getCachedCodeQlVersion(
-  cmd?: string,
-  env: Env = getEnv(),
-): undefined | VersionInfo {
-  if (cachedCodeQlVersion !== undefined) {
-    return cachedCodeQlVersion;
-  }
-  // Fall back to the value persisted by an earlier Actions step, if any. This is
-  // best-effort: any malformed or mismatched value is ignored so that the caller
-  // invokes `codeql version` instead.
-  let serialized: string;
-  try {
-    serialized = fs.readFileSync(getPathToCodeQLVersionCacheFile(env), "utf8");
-  } catch {
-    return undefined;
-  }
-  let persisted: unknown;
-  try {
-    persisted = JSON.parse(serialized);
-  } catch {
-    return undefined;
-  }
-  if (
-    !isPersistedVersionInfo(persisted) ||
-    (cmd !== undefined && persisted.cmd !== cmd)
-  ) {
-    return undefined;
-  }
-  // Memoize the parsed value so that subsequent calls in this process don't
-  // re-parse the environment variable.
-  cachedCodeQlVersion = persisted.version;
-  return cachedCodeQlVersion;
 }
 
 export async function codeQlVersionAtLeast(

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,6 @@ import * as yaml from "js-yaml";
 import * as semver from "semver";
 
 import * as apiCompatibility from "./api-compatibility.json";
-import type { VersionInfo } from "./cli/types";
 import type { CodeQL } from "./codeql";
 import type { Pack } from "./config/db-config";
 import type { Config } from "./config-utils";
@@ -597,36 +596,6 @@ export function asHTTPError(arg: any): HTTPError | undefined {
     return new HTTPError(arg.message, arg.httpStatusCode as number);
   }
   return undefined;
-}
-
-/** The persisted version together with the CLI path it was obtained from. */
-interface PersistedVersionInfo {
-  cmd: string;
-  version: VersionInfo;
-}
-
-function isVersionInfo(x: unknown): x is VersionInfo {
-  const candidate = x as Partial<VersionInfo> | null;
-  return (
-    typeof candidate === "object" &&
-    candidate !== null &&
-    typeof candidate.version === "string" &&
-    (candidate.features === undefined ||
-      (typeof candidate.features === "object" &&
-        candidate.features !== null)) &&
-    (candidate.overlayVersion === undefined ||
-      typeof candidate.overlayVersion === "number")
-  );
-}
-
-export function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
-  const candidate = x as Partial<PersistedVersionInfo> | null;
-  return (
-    typeof candidate === "object" &&
-    candidate !== null &&
-    typeof candidate.cmd === "string" &&
-    isVersionInfo(candidate.version)
-  );
 }
 
 export async function codeQlVersionAtLeast(

--- a/src/util.ts
+++ b/src/util.ts
@@ -674,8 +674,7 @@ export function cacheCodeQlVersion(
 }
 
 /**
- * Returns the cached CodeQL CLI version, if any. If not cached,
- * attempts to read and parse it from disk.
+ * Returns the cached CodeQL CLI version, if any.
  * @param cmd The path to the CodeQL CLI.
  * @param env The environment variables to use—only necessary for testing.
  */

--- a/src/util.ts
+++ b/src/util.ts
@@ -641,7 +641,7 @@ function isPersistedVersionInfo(x: unknown): x is PersistedVersionInfo {
 
 /**
  * Returns the file path to the `codeql version` output cache.
- * @param env The environment variables to use—only necessary for testing.
+ * @param env The environment variables to use.
  */
 function getPathToCodeQLVersionCacheFile(env: Env): string {
   return path.join(getTemporaryDirectory(env), "version.json");
@@ -651,7 +651,7 @@ function getPathToCodeQLVersionCacheFile(env: Env): string {
  * Caches the CodeQL CLI version both in-memory and on disk.
  * @param cmd The path to the CodeQL CLI.
  * @param version The version information to cache.
- * @param env The environment variables to use—only necessary for testing.
+ * @param env The environment variables to use.
  */
 export function cacheCodeQlVersion(
   cmd: string,
@@ -676,7 +676,7 @@ export function cacheCodeQlVersion(
 /**
  * Returns the cached CodeQL CLI version, if any.
  * @param cmd The path to the CodeQL CLI.
- * @param env The environment variables to use—only necessary for testing.
+ * @param env The environment variables to use.
  */
 export function getCachedCodeQlVersion(
   cmd?: string,

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,8 @@ import * as yaml from "js-yaml";
 import * as semver from "semver";
 
 import * as apiCompatibility from "./api-compatibility.json";
-import type { CodeQL, VersionInfo } from "./codeql";
+import type { VersionInfo } from "./cli/types";
+import type { CodeQL } from "./codeql";
 import type { Pack } from "./config/db-config";
 import type { Config } from "./config-utils";
 import { EnvVar, getRequiredEnvParam } from "./environment";


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

Currently, the output of `codeql version` is cached and persisted between steps as an environment variable. This is fine, for now, but, as we begin to cache more of the CLI, we should persist that output to a file instead because:

1. There is a limit to the size of a process' environment. On GitHub Actions, the runners already have a populated environment. And, the output of these CLI commands may be verbose.
2. There is data to suggest that a larger environment has performance implications (more environment variables -> more memory for the kernel to copy during `execve(2)`).

To that end, and as a precaution, this PR replaces `$CODEQL_ACTION_CLI_VERSION_INFO` with `$CODEQL_ACTION_TEMP/version.json`, a file-backed cache for `codeql version`.


**Changes**

* Moved the CodeQL CLI version caching logic from `util.ts` (which used environment variables) into a new module `src/cli/output-cache.ts`, which now uses a temporary on-disk file (`codeql-action-command-cache.json`) for cross-step persistence. This includes new functions for caching, retrieving, and resetting the cached version, as well as improved validation of persisted data.
* Moved the `VersionInfo` type definition from `codeql.ts` to a new shared file `src/cli/types.ts`, and updated all references to use the new location. This centralizes type definitions to avoid cyclic dependencies.
* Removed the now-obsolete `CODEQL_VERSION_INFO` environment variable from `EnvVar` in `environment.ts`.

---

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
