### PR TITLE
Make a `Logger` available to `getCodeQLForCmd`

### DIFF
--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -151830,7 +151830,7 @@ async function setupCodeQL(toolsInput, apiDetails, tempDir, variant, defaultCliV
         `Unsupported platform: ${process.platform}`
       );
     }
-    cachedCodeQL = await getCodeQLForCmd(codeqlCmd, checkVersion);
+    cachedCodeQL = await getCodeQLForCmd(logger, codeqlCmd, checkVersion);
     return {
       codeql: cachedCodeQL,
       toolsDownloadStatusReport,
@@ -151847,13 +151847,13 @@ Details: ${e.stack}` : ""}`
     );
   }
 }
-async function getCodeQL(cmd) {
+async function getCodeQL(logger, cmd) {
   if (cachedCodeQL === void 0) {
-    cachedCodeQL = await getCodeQLForCmd(cmd, true);
+    cachedCodeQL = await getCodeQLForCmd(logger, cmd, true);
   }
   return cachedCodeQL;
 }
-async function getCodeQLForCmd(cmd, checkVersion) {
+async function getCodeQLForCmd(logger, cmd, checkVersion) {
   const codeql = {
     getPath() {
       return cmd;
@@ -151890,7 +151890,7 @@ async function getCodeQLForCmd(cmd, checkVersion) {
     async isScannedLanguage(language) {
       return !await this.isTracedLanguage(language);
     },
-    async databaseInitCluster(config, sourceRoot, processName, qlconfigFile, logger) {
+    async databaseInitCluster(config, sourceRoot, processName, qlconfigFile) {
       const extraArgs = config.languages.map(
         (language) => `--language=${language}`
       );
@@ -152446,7 +152446,7 @@ async function setupCppAutobuild(codeql, logger) {
 }
 async function runAutobuild(config, language, logger) {
   logger.startGroup(`Attempting to automatically build ${language} code`);
-  const codeQL = await getCodeQL(config.codeQLCmd);
+  const codeQL = await getCodeQL(logger, config.codeQLCmd);
   if (language === "cpp" /* cpp */) {
     await setupCppAutobuild(codeQL, logger);
   }
@@ -154786,7 +154786,7 @@ async function combineSarifFilesUsingCLI(sarifFiles, gitHubVersion, features, lo
   let tempDir = getTemporaryDirectory();
   const config = await getConfig(tempDir, logger);
   if (config !== void 0) {
-    codeQL = await getCodeQL(config.codeQLCmd);
+    codeQL = await getCodeQL(logger, config.codeQLCmd);
     tempDir = config.tempDir;
   } else {
     logger.info(
@@ -155523,7 +155523,7 @@ async function run({ startedAt, logger }) {
         "Config file could not be found at expected location. Has the 'init' action been called?"
       );
     }
-    const codeql = await getCodeQL(config.codeQLCmd);
+    const codeql = await getCodeQL(logger, config.codeQLCmd);
     if (hasBadExpectErrorInput()) {
       throw new ConfigurationError(
         "`expect-error` input parameter is for internal use only. It should only be set by codeql-action or a fork."
@@ -160646,7 +160646,7 @@ async function runWrapper2() {
         logger
       );
       if (config !== void 0) {
-        const codeql = await getCodeQL(config.codeQLCmd);
+        const codeql = await getCodeQL(logger, config.codeQLCmd);
         const version = await codeql.getVersion();
         await uploadCombinedSarifArtifacts(
           logger,
@@ -160726,7 +160726,7 @@ async function run2({ startedAt, logger }) {
         "Config file could not be found at expected location. Has the 'init' action been called?"
       );
     }
-    const codeql = await getCodeQL(config.codeQLCmd);
+    const codeql = await getCodeQL(logger, config.codeQLCmd);
     languages = await determineAutobuildLanguages(codeql, config, logger);
     if (languages !== void 0) {
       const workingDirectory = getOptionalInput("working-directory");
@@ -161616,6 +161616,7 @@ async function prepareFailedSarif(logger, features, config) {
     const category = `/language:${language}`;
     const checkoutPath = ".";
     const result = await generateFailedSarif(
+      logger,
       features,
       config,
       category,
@@ -161636,6 +161637,7 @@ async function prepareFailedSarif(logger, features, config) {
     const category = getCategoryInputOrThrow(workflow, jobName, matrix);
     const checkoutPath = getCheckoutPathInputOrThrow(workflow, jobName, matrix);
     const result = await generateFailedSarif(
+      logger,
       features,
       config,
       category,
@@ -161644,9 +161646,9 @@ async function prepareFailedSarif(logger, features, config) {
     return new Success(result);
   }
 }
-async function generateFailedSarif(features, config, category, checkoutPath, sarifFile) {
+async function generateFailedSarif(logger, features, config, category, checkoutPath, sarifFile) {
   const databasePath = config.dbLocation;
-  const codeql = await getCodeQL(config.codeQLCmd);
+  const codeql = await getCodeQL(logger, config.codeQLCmd);
   if (sarifFile === void 0) {
     sarifFile = "../codeql-failed-run.sarif";
   }
@@ -161912,7 +161914,7 @@ async function run4(startedAt) {
         "Debugging artifacts are unavailable since the 'init' Action failed before it could produce any."
       );
     } else {
-      const codeql = await getCodeQL(config.codeQLCmd);
+      const codeql = await getCodeQL(logger, config.codeQLCmd);
       uploadFailedSarifResult = await uploadFailureInfo(
         tryUploadAllAvailableDebugArtifacts,
         printDebugLogs,
@@ -162015,7 +162017,7 @@ var core23 = __toESM(require_core());
 // src/resolve-environment.ts
 async function runResolveBuildEnvironment(cmd, logger, workingDir, language) {
   logger.startGroup(`Attempting to resolve build environment for ${language}`);
-  const codeql = await getCodeQL(cmd);
+  const codeql = await getCodeQL(logger, cmd);
   if (workingDir !== void 0) {
     logger.info(`Using ${workingDir} as the working directory.`);
   }

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -154473,7 +154473,7 @@ async function initConfig2(actionState, inputs) {
     return await initConfig(actionState, inputs);
   });
 }
-async function runDatabaseInitCluster(databaseInitEnvironment, codeql, config, sourceRoot, processName, qlconfigFile, logger) {
+async function runDatabaseInitCluster(databaseInitEnvironment, codeql, config, sourceRoot, processName, qlconfigFile) {
   fs19.mkdirSync(config.dbLocation, { recursive: true });
   await wrapEnvironment(
     databaseInitEnvironment,
@@ -154481,8 +154481,7 @@ async function runDatabaseInitCluster(databaseInitEnvironment, codeql, config, s
       config,
       sourceRoot,
       processName,
-      qlconfigFile,
-      logger
+      qlconfigFile
     )
   );
 }
@@ -161496,8 +161495,7 @@ exec ${goBinaryPath} "$@"`
       config,
       sourceRoot,
       "Runner.Worker.exe",
-      qlconfigFile,
-      logger
+      qlconfigFile
     );
     if (config.overlayDatabaseMode !== "none" /* None */ && !await checkPacksForOverlayCompatibility(codeql, config, logger)) {
       logger.info(
@@ -161513,8 +161511,7 @@ exec ${goBinaryPath} "$@"`
         config,
         sourceRoot,
         "Runner.Worker.exe",
-        qlconfigFile,
-        logger
+        qlconfigFile
       );
     }
     const tracerConfig = await getCombinedTracerConfig(codeql, config);

--- a/src/analyze-action-post.ts
+++ b/src/analyze-action-post.ts
@@ -38,7 +38,7 @@ export async function runWrapper() {
         logger,
       );
       if (config !== undefined) {
-        const codeql = await getCodeQL(config.codeQLCmd);
+        const codeql = await getCodeQL(logger, config.codeQLCmd);
         const version = await codeql.getVersion();
         await debugArtifacts.uploadCombinedSarifArtifacts(
           logger,

--- a/src/analyze-action.ts
+++ b/src/analyze-action.ts
@@ -255,7 +255,7 @@ async function run({ startedAt, logger }: ActionState<["Base", "Logger"]>) {
       );
     }
 
-    const codeql = await getCodeQL(config.codeQLCmd);
+    const codeql = await getCodeQL(logger, config.codeQLCmd);
 
     if (hasBadExpectErrorInput()) {
       throw new util.ConfigurationError(

--- a/src/autobuild-action.ts
+++ b/src/autobuild-action.ts
@@ -99,7 +99,7 @@ async function run({ startedAt, logger }: ActionState<["Base", "Logger"]>) {
       );
     }
 
-    const codeql = await getCodeQL(config.codeQLCmd);
+    const codeql = await getCodeQL(logger, config.codeQLCmd);
 
     languages = await determineAutobuildLanguages(codeql, config, logger);
     if (languages !== undefined) {

--- a/src/autobuild.ts
+++ b/src/autobuild.ts
@@ -155,7 +155,7 @@ export async function runAutobuild(
   logger: Logger,
 ) {
   logger.startGroup(`Attempting to automatically build ${language} code`);
-  const codeQL = await getCodeQL(config.codeQLCmd);
+  const codeQL = await getCodeQL(logger, config.codeQLCmd);
   if (language === BuiltInLanguage.cpp) {
     await setupCppAutobuild(codeQL, logger);
   }

--- a/src/codeql.test.ts
+++ b/src/codeql.test.ts
@@ -580,7 +580,6 @@ const injectedConfigMacro = makeMacro({
         "",
         undefined,
         undefined,
-        getRunnerLogger(true),
       );
 
       const args = runnerConstructorStub.firstCall.args[1] as string[];
@@ -856,7 +855,6 @@ test.serial(
         "",
         undefined,
         "/path/to/qlconfig.yml",
-        getRunnerLogger(true),
       );
 
       const args = runnerConstructorStub.firstCall.args[1] as string[];
@@ -887,7 +885,6 @@ test.serial(
         "",
         undefined,
         undefined, // undefined qlconfigFile
-        getRunnerLogger(true),
       );
 
       const args = runnerConstructorStub.firstCall.args[1] as any[];
@@ -1066,7 +1063,6 @@ test.serial(
       "sourceRoot",
       undefined,
       undefined,
-      getRunnerLogger(false),
     );
 
     t.true(runnerConstructorStub.calledOnce);

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -23,7 +23,7 @@ import {
 } from "./feature-flags";
 import { isAnalyzingDefaultBranch } from "./git-utils";
 import { Language } from "./languages";
-import { Logger } from "./logging";
+import { getRunnerLogger, Logger } from "./logging";
 import { writeBaseDatabaseOidsFile, writeOverlayChangesFile } from "./overlay";
 import { OverlayDatabaseMode } from "./overlay/overlay-database-mode";
 import * as setupCodeql from "./setup-codeql";
@@ -346,7 +346,7 @@ export async function setupCodeQL(
       );
     }
 
-    cachedCodeQL = await getCodeQLForCmd(codeqlCmd, checkVersion);
+    cachedCodeQL = await getCodeQLForCmd(logger, codeqlCmd, checkVersion);
     return {
       codeql: cachedCodeQL,
       toolsDownloadStatusReport,
@@ -372,9 +372,9 @@ export async function setupCodeQL(
 /**
  * Use the CodeQL executable located at the given path.
  */
-export async function getCodeQL(cmd: string): Promise<CodeQL> {
+export async function getCodeQL(logger: Logger, cmd: string): Promise<CodeQL> {
   if (cachedCodeQL === undefined) {
-    cachedCodeQL = await getCodeQLForCmd(cmd, true);
+    cachedCodeQL = await getCodeQLForCmd(logger, cmd, true);
   }
   return cachedCodeQL;
 }
@@ -481,8 +481,9 @@ export function createStubCodeQL(partialCodeql: Partial<CodeQL>): CodeQL {
  */
 export async function getCodeQLForTesting(
   cmd = "codeql-for-testing",
+  logger: Logger = getRunnerLogger(true),
 ): Promise<CodeQL> {
-  return getCodeQLForCmd(cmd, false);
+  return getCodeQLForCmd(logger, cmd, false);
 }
 
 /**
@@ -494,6 +495,7 @@ export async function getCodeQLForTesting(
  * @returns A new CodeQL object
  */
 async function getCodeQLForCmd(
+  logger: Logger,
   cmd: string,
   checkVersion: boolean,
 ): Promise<CodeQL> {
@@ -539,7 +541,6 @@ async function getCodeQLForCmd(
       sourceRoot: string,
       processName: string | undefined,
       qlconfigFile: string | undefined,
-      logger: Logger,
     ) {
       const extraArgs = config.languages.map(
         (language) => `--language=${language}`,

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -91,7 +91,6 @@ export interface CodeQL {
     sourceRoot: string,
     processName: string | undefined,
     qlconfigFile: string | undefined,
-    logger: Logger,
   ): Promise<void>;
   /**
    * Runs the autobuilder for the given language.

--- a/src/init-action-post-helper.ts
+++ b/src/init-action-post-helper.ts
@@ -123,6 +123,7 @@ async function prepareFailedSarif(
     const category = `/language:${language}`;
     const checkoutPath = ".";
     const result = await generateFailedSarif(
+      logger,
       features,
       config,
       category,
@@ -146,6 +147,7 @@ async function prepareFailedSarif(
     const checkoutPath = getCheckoutPathInputOrThrow(workflow, jobName, matrix);
 
     const result = await generateFailedSarif(
+      logger,
       features,
       config,
       category,
@@ -156,6 +158,7 @@ async function prepareFailedSarif(
 }
 
 async function generateFailedSarif(
+  logger: Logger,
   features: FeatureEnablement,
   config: Config,
   category: string | undefined,
@@ -163,7 +166,7 @@ async function generateFailedSarif(
   sarifFile?: string,
 ) {
   const databasePath = config.dbLocation;
-  const codeql = await getCodeQL(config.codeQLCmd);
+  const codeql = await getCodeQL(logger, config.codeQLCmd);
 
   // Set the filename for the SARIF file if not already set.
   if (sarifFile === undefined) {

--- a/src/init-action-post.ts
+++ b/src/init-action-post.ts
@@ -75,7 +75,7 @@ async function run(startedAt: Date) {
         "Debugging artifacts are unavailable since the 'init' Action failed before it could produce any.",
       );
     } else {
-      const codeql = await getCodeQL(config.codeQLCmd);
+      const codeql = await getCodeQL(logger, config.codeQLCmd);
 
       uploadFailedSarifResult = await initActionPostHelper.uploadFailureInfo(
         debugArtifacts.tryUploadAllAvailableDebugArtifacts,

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -689,7 +689,6 @@ async function run(
       sourceRoot,
       "Runner.Worker.exe",
       qlconfigFile,
-      logger,
     );
 
     // To check custom query packs for compatibility with overlay analysis, we
@@ -718,7 +717,6 @@ async function run(
         sourceRoot,
         "Runner.Worker.exe",
         qlconfigFile,
-        logger,
       );
     }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -89,7 +89,6 @@ export async function runDatabaseInitCluster(
   sourceRoot: string,
   processName: string | undefined,
   qlconfigFile: string | undefined,
-  logger: Logger,
 ): Promise<void> {
   fs.mkdirSync(config.dbLocation, { recursive: true });
   await configUtils.wrapEnvironment(
@@ -100,7 +99,6 @@ export async function runDatabaseInitCluster(
         sourceRoot,
         processName,
         qlconfigFile,
-        logger,
       ),
   );
 }

--- a/src/resolve-environment.ts
+++ b/src/resolve-environment.ts
@@ -9,7 +9,7 @@ export async function runResolveBuildEnvironment(
 ) {
   logger.startGroup(`Attempting to resolve build environment for ${language}`);
 
-  const codeql = await getCodeQL(cmd);
+  const codeql = await getCodeQL(logger, cmd);
 
   if (workingDir !== undefined) {
     logger.info(`Using ${workingDir} as the working directory.`);

--- a/src/upload-lib.ts
+++ b/src/upload-lib.ts
@@ -140,7 +140,7 @@ async function combineSarifFilesUsingCLI(
 
   const config = await getConfig(tempDir, logger);
   if (config !== undefined) {
-    codeQL = await getCodeQL(config.codeQLCmd);
+    codeQL = await getCodeQL(logger, config.codeQLCmd);
     tempDir = config.tempDir;
   } else {
     logger.info(


### PR DESCRIPTION
Makes a `Logger` available to `getCodeQLForCmd`.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.
- **Third-party analyses** - The changes affect the `upload-sarif` action.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Dashboards** - I will watch relevant dashboards for issues after the release. Consider whether this requires this change to be released at a particular time rather than as part of a regular release.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
