### PR TITLE
Use `json` module for JSON validation in `output-cache`

### DIFF
--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146744,6 +146744,10 @@ var versionInfoBaseSchema = {
 };
 
 // src/cli/output-cache.ts
+var outputCacheSchema = {
+  cmd: string,
+  entries: object({})
+};
 var COMMAND_CACHE_FILENAME = "codeql-action-command-cache.json";
 var cachedCodeQlVersion = void 0;
 function getCommandCacheFilePath(env) {
@@ -146794,13 +146798,7 @@ function isVersionInfo(x) {
   return isObject(x) && validateSchema(versionInfoBaseSchema, x);
 }
 function isOutputCache(x) {
-  return isObject(x) && validateSchema(
-    {
-      cmd: string,
-      entries: object({})
-    },
-    x
-  ) && isObject(x.entries) && isVersionInfo(x.entries.version);
+  return isObject(x) && validateSchema(outputCacheSchema, x) && isObject(x.entries) && isVersionInfo(x.entries.version);
 }
 
 // src/config/pack-registries.ts

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146774,12 +146774,23 @@ function getCachedCodeQlVersion(logger, env, cmd) {
   return cachedCodeQlVersion;
 }
 function isVersionInfo(x) {
-  const candidate = x;
-  return typeof candidate === "object" && candidate !== null && typeof candidate.version === "string" && (candidate.features === void 0 || typeof candidate.features === "object" && candidate.features !== null) && (candidate.overlayVersion === void 0 || typeof candidate.overlayVersion === "number");
+  return isObject(x) && validateSchema(
+    {
+      version: string,
+      features: optional(object({})),
+      overlayVersion: optional(number)
+    },
+    x
+  );
 }
 function isOutputCache(x) {
-  const candidate = x;
-  return typeof candidate === "object" && candidate !== null && typeof candidate.cmd === "string" && candidate.entries !== void 0 && isVersionInfo(candidate.entries.version);
+  return isObject(x) && validateSchema(
+    {
+      cmd: string,
+      entries: object({})
+    },
+    x
+  ) && isObject(x.entries) && isVersionInfo(x.entries.version);
 }
 
 // src/config/pack-registries.ts

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146753,7 +146753,7 @@ var cachedCodeQlVersion = void 0;
 function getCommandCacheFilePath(env) {
   return import_path.default.join(getTemporaryDirectory(env), COMMAND_CACHE_FILENAME);
 }
-function cacheCodeQlVersion(env, cmd, version) {
+function cacheCodeQlVersion(cacheFilePath, cmd, version) {
   if (cachedCodeQlVersion !== void 0) {
     throw new Error("cacheCodeQlVersion() should be called only once");
   }
@@ -146762,23 +146762,17 @@ function cacheCodeQlVersion(env, cmd, version) {
     cmd,
     entries: { version }
   };
-  fs3.writeFileSync(
-    getCommandCacheFilePath(env),
-    JSON.stringify(outputCache),
-    "utf8"
-  );
+  fs3.writeFileSync(cacheFilePath, JSON.stringify(outputCache), "utf8");
 }
-function getCachedCodeQlVersion(logger, env, cmd) {
+function getCachedCodeQlVersion(logger, cacheFilePath, cmd) {
   if (cachedCodeQlVersion !== void 0) {
     return cachedCodeQlVersion;
   }
   let serialized;
   try {
-    serialized = fs3.readFileSync(getCommandCacheFilePath(env), "utf8");
+    serialized = fs3.readFileSync(cacheFilePath, "utf8");
   } catch (e) {
-    logger.debug(
-      `Cannot read CLI-cache file ${getCommandCacheFilePath(env)}: ${e}`
-    );
+    logger.debug(`Cannot read CLI-cache file ${cacheFilePath}: ${e}`);
     return void 0;
   }
   let persisted;
@@ -147342,7 +147336,10 @@ async function createStatusReportBase(actionName, status, actionStartedAt, confi
       core7.exportVariable("CODEQL_WORKFLOW_STARTED_AT" /* WORKFLOW_STARTED_AT */, workflowStartedAt);
     }
     const runnerOs = getRequiredEnvParam("RUNNER_OS");
-    const codeQlCliVersion = getCachedCodeQlVersion(logger, getEnv());
+    const codeQlCliVersion = getCachedCodeQlVersion(
+      logger,
+      getCommandCacheFilePath(getEnv())
+    );
     const actionRef = process.env["GITHUB_ACTION_REF"] || "";
     const testingEnvironment = getTestingEnvironment();
     if (testingEnvironment) {
@@ -152362,7 +152359,12 @@ async function getCodeQLForCmd(logger, cmd, checkVersion) {
       return cmd;
     },
     async getVersion() {
-      let result = getCachedCodeQlVersion(logger, getEnv(), cmd);
+      const cacheFilePath = getCommandCacheFilePath(getEnv());
+      let result = getCachedCodeQlVersion(
+        logger,
+        cacheFilePath,
+        cmd
+      );
       if (result === void 0) {
         result = await runCliJson(
           cmd,
@@ -152371,7 +152373,7 @@ async function getCodeQLForCmd(logger, cmd, checkVersion) {
             noStreamStdout: true
           }
         );
-        cacheCodeQlVersion(getEnv(), cmd, result);
+        cacheCodeQlVersion(cacheFilePath, cmd, result);
       }
       return result;
     },

--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -146727,6 +146727,23 @@ function wrapApiConfigurationError(e) {
 // src/cli/output-cache.ts
 var fs3 = __toESM(require("fs"));
 var import_path = __toESM(require("path"));
+
+// src/cli/types.ts
+var versionInfoBaseSchema = {
+  version: string,
+  features: optional(object({})),
+  /**
+   * The overlay version helps deal with backward incompatible changes for
+   * overlay analysis. When a precompiled query pack reports the same overlay
+   * version as the CodeQL CLI, we can use the CodeQL CLI to perform overlay
+   * analysis with that pack. Otherwise, if the overlay versions are different,
+   * or if either the pack or the CLI does not report an overlay version,
+   * we need to revert to non-overlay analysis.
+   */
+  overlayVersion: optional(number)
+};
+
+// src/cli/output-cache.ts
 var COMMAND_CACHE_FILENAME = "codeql-action-command-cache.json";
 var cachedCodeQlVersion = void 0;
 function getCommandCacheFilePath(env) {
@@ -146774,14 +146791,7 @@ function getCachedCodeQlVersion(logger, env, cmd) {
   return cachedCodeQlVersion;
 }
 function isVersionInfo(x) {
-  return isObject(x) && validateSchema(
-    {
-      version: string,
-      features: optional(object({})),
-      overlayVersion: optional(number)
-    },
-    x
-  );
+  return isObject(x) && validateSchema(versionInfoBaseSchema, x);
 }
 function isOutputCache(x) {
   return isObject(x) && validateSchema(

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -7,7 +7,10 @@ import { getRunnerLogger } from "../logging";
 import { getTestEnv, setupTests } from "../testing-utils";
 import * as util from "../util";
 
-import * as outputCache from "./output-cache";
+import {
+  getCachedCodeQlVersion,
+  getCommandCacheFilePath,
+} from "./output-cache";
 
 setupTests(test);
 
@@ -18,7 +21,7 @@ test.serial(
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = outputCache.getCommandCacheFilePath(env);
+      const cacheFile = getCommandCacheFilePath(env);
       fs.writeFileSync(
         cacheFile,
         JSON.stringify({
@@ -27,12 +30,9 @@ test.serial(
         }),
         "utf8",
       );
-      t.deepEqual(
-        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
-        {
-          version: "2.20.0",
-        },
-      );
+      t.deepEqual(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), {
+        version: "2.20.0",
+      });
     });
   },
 );
@@ -42,7 +42,7 @@ test.serial(
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = outputCache.getCommandCacheFilePath(env);
+      const cacheFile = getCommandCacheFilePath(env);
       fs.writeFileSync(
         cacheFile,
         JSON.stringify({
@@ -51,10 +51,7 @@ test.serial(
         }),
         "utf8",
       );
-      t.is(
-        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
-        undefined,
-      );
+      t.is(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), undefined);
     });
   },
 );
@@ -64,12 +61,9 @@ test.serial(
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = outputCache.getCommandCacheFilePath(env);
+      const cacheFile = getCommandCacheFilePath(env);
       fs.writeFileSync(cacheFile, "not valid json", "utf8");
-      t.is(
-        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
-        undefined,
-      );
+      t.is(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), undefined);
     });
   },
 );
@@ -79,7 +73,7 @@ test.serial(
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = outputCache.getCommandCacheFilePath(env);
+      const cacheFile = getCommandCacheFilePath(env);
       const testValues = [
         { cmd: "/path/to/codeql" },
         { entries: { version: { version: "2.20.0" } } },
@@ -104,7 +98,7 @@ test.serial(
       for (const value of testValues) {
         fs.writeFileSync(cacheFile, value, "utf8");
         t.is(
-          outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
+          getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
           undefined,
           value,
         );
@@ -117,10 +111,7 @@ test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
   await util.withTmpDir(async (tmpDir: string) => {
     const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
     t.notThrows(() => {
-      t.is(
-        outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
-        undefined,
-      );
+      t.is(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), undefined);
     });
   });
 });

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs";
-import path from "path";
 
 import test from "ava";
 
@@ -18,7 +17,8 @@ test.serial(
   "getCachedCodeQlVersion reuses a version persisted by an earlier step",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "codeql-action-command-cache.json");
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      const cacheFile = outputCache.getCommandCacheFilePath(env);
       fs.writeFileSync(
         cacheFile,
         JSON.stringify({
@@ -27,7 +27,6 @@ test.serial(
         }),
         "utf8",
       );
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
       t.deepEqual(
         outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
         {
@@ -42,16 +41,16 @@ test.serial(
   "getCachedCodeQlVersion ignores a persisted version from a different CLI",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "version.json");
+      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      const cacheFile = outputCache.getCommandCacheFilePath(env);
       fs.writeFileSync(
         cacheFile,
         JSON.stringify({
           cmd: "/path/to/other-codeql",
-          version: { version: "2.20.0" },
+          entries: { version: { version: "2.20.0" } },
         }),
         "utf8",
       );
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
       t.is(
         outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
         undefined,
@@ -64,9 +63,9 @@ test.serial(
   "getCachedCodeQlVersion ignores a malformed persisted value",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "version.json");
-      fs.writeFileSync(cacheFile, "not valid json", "utf8");
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+      const cacheFile = outputCache.getCommandCacheFilePath(env);
+      fs.writeFileSync(cacheFile, "not valid json", "utf8");
       t.is(
         outputCache.getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
         undefined,
@@ -79,9 +78,8 @@ test.serial(
   "getCachedCodeQlVersion ignores a persisted value with the wrong structure",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const cacheFile = path.join(tmpDir, "version.json");
       const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-
+      const cacheFile = outputCache.getCommandCacheFilePath(env);
       const testValues = [
         { cmd: "/path/to/codeql" },
         { entries: { version: { version: "2.20.0" } } },

--- a/src/cli/output-cache.test.ts
+++ b/src/cli/output-cache.test.ts
@@ -1,16 +1,13 @@
 import * as fs from "fs";
+import path from "path";
 
 import test from "ava";
 
-import { EnvVar } from "../environment";
 import { getRunnerLogger } from "../logging";
-import { getTestEnv, setupTests } from "../testing-utils";
+import { setupTests } from "../testing-utils";
 import * as util from "../util";
 
-import {
-  getCachedCodeQlVersion,
-  getCommandCacheFilePath,
-} from "./output-cache";
+import { getCachedCodeQlVersion } from "./output-cache";
 
 setupTests(test);
 
@@ -20,19 +17,22 @@ test.serial(
   "getCachedCodeQlVersion reuses a version persisted by an earlier step",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = getCommandCacheFilePath(env);
+      const cacheFilePath = path.join(tmpDir, "cache.json");
+
       fs.writeFileSync(
-        cacheFile,
+        cacheFilePath,
         JSON.stringify({
           cmd: "/path/to/codeql",
           entries: { version: { version: "2.20.0" } },
         }),
         "utf8",
       );
-      t.deepEqual(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), {
-        version: "2.20.0",
-      });
+      t.deepEqual(
+        getCachedCodeQlVersion(logger, cacheFilePath, "/path/to/codeql"),
+        {
+          version: "2.20.0",
+        },
+      );
     });
   },
 );
@@ -41,17 +41,19 @@ test.serial(
   "getCachedCodeQlVersion ignores a persisted version from a different CLI",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = getCommandCacheFilePath(env);
+      const cacheFilePath = path.join(tmpDir, "cache.json");
       fs.writeFileSync(
-        cacheFile,
+        cacheFilePath,
         JSON.stringify({
           cmd: "/path/to/other-codeql",
           entries: { version: { version: "2.20.0" } },
         }),
         "utf8",
       );
-      t.is(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), undefined);
+      t.is(
+        getCachedCodeQlVersion(logger, cacheFilePath, "/path/to/codeql"),
+        undefined,
+      );
     });
   },
 );
@@ -60,10 +62,12 @@ test.serial(
   "getCachedCodeQlVersion ignores a malformed persisted value",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = getCommandCacheFilePath(env);
-      fs.writeFileSync(cacheFile, "not valid json", "utf8");
-      t.is(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), undefined);
+      const cacheFilePath = path.join(tmpDir, "cache.json");
+      fs.writeFileSync(cacheFilePath, "not valid json", "utf8");
+      t.is(
+        getCachedCodeQlVersion(logger, cacheFilePath, "/path/to/codeql"),
+        undefined,
+      );
     });
   },
 );
@@ -72,8 +76,7 @@ test.serial(
   "getCachedCodeQlVersion ignores a persisted value with the wrong structure",
   async (t) => {
     await util.withTmpDir(async (tmpDir: string) => {
-      const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
-      const cacheFile = getCommandCacheFilePath(env);
+      const cacheFilePath = path.join(tmpDir, "cache.json");
       const testValues = [
         { cmd: "/path/to/codeql" },
         { entries: { version: { version: "2.20.0" } } },
@@ -96,9 +99,9 @@ test.serial(
       ].map((v) => JSON.stringify(v));
 
       for (const value of testValues) {
-        fs.writeFileSync(cacheFile, value, "utf8");
+        fs.writeFileSync(cacheFilePath, value, "utf8");
         t.is(
-          getCachedCodeQlVersion(logger, env, "/path/to/codeql"),
+          getCachedCodeQlVersion(logger, cacheFilePath, "/path/to/codeql"),
           undefined,
           value,
         );
@@ -109,9 +112,12 @@ test.serial(
 
 test.serial("getCachedCodeQlVersion ignores non-existent file", async (t) => {
   await util.withTmpDir(async (tmpDir: string) => {
-    const env = getTestEnv({ [EnvVar.TEMP]: tmpDir });
+    const cacheFilePath = path.join(tmpDir, "cache.json");
     t.notThrows(() => {
-      t.is(getCachedCodeQlVersion(logger, env, "/path/to/codeql"), undefined);
+      t.is(
+        getCachedCodeQlVersion(logger, cacheFilePath, "/path/to/codeql"),
+        undefined,
+      );
     });
   });
 });

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -57,12 +57,12 @@ export function getCommandCacheFilePath(env: Env): string {
 
 /**
  * Caches the CodeQL CLI version both in-memory and on disk.
- * @param env The environment variables to use.
+ * @param cacheFilePath The path to the cache file.
  * @param cmd The path to the CodeQL CLI.
  * @param version The version information to cache.
  */
 export function cacheCodeQlVersion(
-  env: Env,
+  cacheFilePath: string,
   cmd: string,
   version: VersionInfo,
 ): void {
@@ -78,22 +78,18 @@ export function cacheCodeQlVersion(
   // processes, can reuse it rather than invoking `codeql version` again. We
   // record the CLI path so that a different step using a different CodeQL bundle
   // doesn't pick up a stale version.
-  fs.writeFileSync(
-    getCommandCacheFilePath(env),
-    JSON.stringify(outputCache),
-    "utf8",
-  );
+  fs.writeFileSync(cacheFilePath, JSON.stringify(outputCache), "utf8");
 }
 
 /**
  * Returns the cached CodeQL CLI version, if any.
  * @param logger The logger to use for logging messages.
- * @param env The environment variables to use.
+ * @param cacheFilePath The path to the cache file.
  * @param cmd The path to the CodeQL CLI.
  */
 export function getCachedCodeQlVersion(
   logger: Logger,
-  env: Env,
+  cacheFilePath: string,
   cmd?: string,
 ): undefined | VersionInfo {
   if (cachedCodeQlVersion !== undefined) {
@@ -104,11 +100,9 @@ export function getCachedCodeQlVersion(
   // invokes `codeql version` instead.
   let serialized: string;
   try {
-    serialized = fs.readFileSync(getCommandCacheFilePath(env), "utf8");
+    serialized = fs.readFileSync(cacheFilePath, "utf8");
   } catch (e) {
-    logger.debug(
-      `Cannot read CLI-cache file ${getCommandCacheFilePath(env)}: ${e}`,
-    );
+    logger.debug(`Cannot read CLI-cache file ${cacheFilePath}: ${e}`);
     return undefined;
   }
   let persisted: unknown;

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -3,6 +3,7 @@ import path from "path";
 
 import { getTemporaryDirectory } from "../actions-util";
 import { Env } from "../environment";
+import * as json from "../json";
 import { Logger } from "../logging";
 
 import type { VersionInfo } from "./types";
@@ -127,16 +128,16 @@ export function getCachedCodeQlVersion(
  * @param x The value to test
  */
 function isVersionInfo(x: unknown): x is VersionInfo {
-  const candidate = x as Partial<VersionInfo> | null;
   return (
-    typeof candidate === "object" &&
-    candidate !== null &&
-    typeof candidate.version === "string" &&
-    (candidate.features === undefined ||
-      (typeof candidate.features === "object" &&
-        candidate.features !== null)) &&
-    (candidate.overlayVersion === undefined ||
-      typeof candidate.overlayVersion === "number")
+    json.isObject(x) &&
+    json.validateSchema(
+      {
+        version: json.string,
+        features: json.optional(json.object({})),
+        overlayVersion: json.optional(json.number),
+      } as const satisfies json.Schema,
+      x,
+    )
   );
 }
 
@@ -145,12 +146,16 @@ function isVersionInfo(x: unknown): x is VersionInfo {
  * @param x The value to test
  */
 function isOutputCache(x: unknown): x is OutputCache {
-  const candidate = x as Partial<OutputCache> | null;
   return (
-    typeof candidate === "object" &&
-    candidate !== null &&
-    typeof candidate.cmd === "string" &&
-    candidate.entries !== undefined &&
-    isVersionInfo(candidate.entries.version)
+    json.isObject(x) &&
+    json.validateSchema(
+      {
+        cmd: json.string,
+        entries: json.object({}),
+      } as const satisfies json.Schema,
+      x,
+    ) &&
+    json.isObject<{ version: unknown }>(x.entries) &&
+    isVersionInfo(x.entries.version)
   );
 }

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -14,12 +14,20 @@ import { VersionInfo, versionInfoBaseSchema } from "./types";
 export type CommandCacheKey = string;
 
 /**
- * The type of the command cache that is persisted to disk.
+ * The JSON schema of the command cache that is persisted to disk.
  */
-export interface OutputCache {
-  cmd: string;
-  entries: Record<CommandCacheKey, unknown>;
-}
+const outputCacheSchema = {
+  cmd: json.string,
+  entries: json.object({}),
+} as const satisfies json.Schema;
+
+/**
+ * The type that describes the command cache that is persisted to disk. This type
+ * is partially derived from {@link outputCacheSchema}.
+ */
+export type OutputCache = json.FromSchema<typeof outputCacheSchema> & {
+  entries: { version: VersionInfo };
+};
 
 /**
  * The name of the temporary file that backs the on-disk cache of
@@ -138,13 +146,7 @@ function isVersionInfo(x: unknown): x is VersionInfo {
 function isOutputCache(x: unknown): x is OutputCache {
   return (
     json.isObject(x) &&
-    json.validateSchema(
-      {
-        cmd: json.string,
-        entries: json.object({}),
-      } as const satisfies json.Schema,
-      x,
-    ) &&
+    json.validateSchema(outputCacheSchema, x) &&
     json.isObject<{ version: unknown }>(x.entries) &&
     isVersionInfo(x.entries.version)
   );

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -6,7 +6,7 @@ import { Env } from "../environment";
 import * as json from "../json";
 import { Logger } from "../logging";
 
-import type { VersionInfo } from "./types";
+import { VersionInfo, versionInfoBaseSchema } from "./types";
 
 /**
  * The keys of the command cache. Each key corresponds to a command whose output we cache.
@@ -128,17 +128,7 @@ export function getCachedCodeQlVersion(
  * @param x The value to test
  */
 function isVersionInfo(x: unknown): x is VersionInfo {
-  return (
-    json.isObject(x) &&
-    json.validateSchema(
-      {
-        version: json.string,
-        features: json.optional(json.object({})),
-        overlayVersion: json.optional(json.number),
-      } as const satisfies json.Schema,
-      x,
-    )
-  );
+  return json.isObject(x) && json.validateSchema(versionInfoBaseSchema, x);
 }
 
 /**

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -44,7 +44,7 @@ export function resetCachedCodeQlVersion(): void {
  * Returns the path to the temporary file that backs the
  * on-disk cache of CLI responses between workflow steps.
  */
-function getCommandCacheFilePath(env: Env): string {
+export function getCommandCacheFilePath(env: Env): string {
   return path.join(getTemporaryDirectory(env), COMMAND_CACHE_FILENAME);
 }
 

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -22,8 +22,7 @@ const outputCacheSchema = {
 } as const satisfies json.Schema;
 
 /**
- * The type that describes the command cache that is persisted to disk. This type
- * is partially derived from {@link outputCacheSchema}.
+ * The type that describes the command cache that is persisted to disk.
  */
 export type OutputCache = json.FromSchema<typeof outputCacheSchema> & {
   entries: { version: VersionInfo };

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -25,8 +25,6 @@ export type VersionInfoBase = json.FromSchema<typeof versionInfoBaseSchema>;
 /**
  * The full type that describes the expected output of the `codeql version` command.
  */
-export type VersionInfo = VersionInfoBase & {
-  // `features` remains optional, but the more specific type takes precedence
-  // over the `any` type derived by `FromSchema`.
+export type VersionInfo = Omit<VersionInfoBase, "features"> & {
   features?: { [name: string]: boolean };
 };

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -19,13 +19,11 @@ export const versionInfoBaseSchema = {
 
 /**
  * The base type that describes the expected output of the `codeql version` command.
- * This type is partially derived from {@link versionInfoBaseSchema}.
  */
 export type VersionInfoBase = json.FromSchema<typeof versionInfoBaseSchema>;
 
 /**
  * The full type that describes the expected output of the `codeql version` command.
- * This type is partially derived from {@link VersionInfoBase}.
  */
 export type VersionInfo = VersionInfoBase & {
   // `features` remains optional, but the more specific type takes precedence

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,6 +1,11 @@
-export interface VersionInfo {
-  version: string;
-  features?: { [name: string]: boolean };
+import * as json from "../json";
+
+/**
+ * The JSON schema of the expected output of the `codeql version` command.
+ */
+export const versionInfoBaseSchema = {
+  version: json.string,
+  features: json.optional(json.object({})),
   /**
    * The overlay version helps deal with backward incompatible changes for
    * overlay analysis. When a precompiled query pack reports the same overlay
@@ -9,5 +14,21 @@ export interface VersionInfo {
    * or if either the pack or the CLI does not report an overlay version,
    * we need to revert to non-overlay analysis.
    */
-  overlayVersion?: number;
-}
+  overlayVersion: json.optional(json.number),
+} as const satisfies json.Schema;
+
+/**
+ * The base type that describes the expected output of the `codeql version` command.
+ * This type is partially derived from {@link versionInfoBaseSchema}.
+ */
+export type VersionInfoBase = json.FromSchema<typeof versionInfoBaseSchema>;
+
+/**
+ * The full type that describes the expected output of the `codeql version` command.
+ * This type is partially derived from {@link VersionInfoBase}.
+ */
+export type VersionInfo = VersionInfoBase & {
+  // `features` remains optional, but the more specific type takes precedence
+  // over the `any` type derived by `FromSchema`.
+  features?: { [name: string]: boolean };
+};

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -491,7 +491,12 @@ async function getCodeQLForCmd(
       return cmd;
     },
     async getVersion() {
-      let result = outputCache.getCachedCodeQlVersion(logger, getEnv(), cmd);
+      const cacheFilePath = outputCache.getCommandCacheFilePath(getEnv());
+      let result = outputCache.getCachedCodeQlVersion(
+        logger,
+        cacheFilePath,
+        cmd,
+      );
       if (result === undefined) {
         result = await runCliJson<VersionInfo>(
           cmd,
@@ -500,7 +505,7 @@ async function getCodeQLForCmd(
             noStreamStdout: true,
           },
         );
-        outputCache.cacheCodeQlVersion(getEnv(), cmd, result);
+        outputCache.cacheCodeQlVersion(cacheFilePath, cmd, result);
       }
       return result;
     },

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -14,7 +14,10 @@ import {
   isSelfHostedRunner,
 } from "./actions-util";
 import { getAnalysisKey, getApiClient } from "./api-client";
-import { getCachedCodeQlVersion } from "./cli/output-cache";
+import {
+  getCachedCodeQlVersion,
+  getCommandCacheFilePath,
+} from "./cli/output-cache";
 import type { Config } from "./config/action-config";
 import type { ComputedInput, InputName } from "./config/inputs";
 import { parseRegistriesWithoutCredentials } from "./config/pack-registries";
@@ -376,7 +379,10 @@ export async function createStatusReportBase(
       core.exportVariable(EnvVar.WORKFLOW_STARTED_AT, workflowStartedAt);
     }
     const runnerOs = getRequiredEnvParam("RUNNER_OS");
-    const codeQlCliVersion = getCachedCodeQlVersion(logger, getEnv());
+    const codeQlCliVersion = getCachedCodeQlVersion(
+      logger,
+      getCommandCacheFilePath(getEnv()),
+    );
     const actionRef = process.env["GITHUB_ACTION_REF"] || "";
     const testingEnvironment = getTestingEnvironment();
     // re-export the testing environment variable so that it is available to subsequent steps,


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

- Use the included `json` module to improve (make more readable) the validation of the output of `codeql version`.
- Refactor `getCachedCodeQlVersion` and `cacheCodeQlVersion` to accept the cache-file-path as an argument, rather than construct it; this makes it easier to test.
- Change the `VersionInfo` type to be derived from its JSON schema.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Unit tests** - I am depending on unit test coverage (i.e. tests in `.test.ts` files).
- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
