### PR TITLE
Delete CLI output-cache file during `init`

### DIFF
--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -161696,6 +161696,15 @@ async function run3(actionState) {
         `The 'init' action should not be run in the same workflow as 'setup-codeql'.`
       );
     }
+    try {
+      fs29.unlinkSync(getCommandCacheFilePath(actionState.env));
+    } catch (e) {
+      if (e?.code !== "ENOENT") {
+        logger.warning(
+          `Cannot delete CLI-cache file ${getCommandCacheFilePath(actionState.env)}: ${e}`
+        );
+      }
+    }
     toolsInput = await getToolsInput(
       actionStateWithFeatures,
       repositoryProperties

--- a/src/cli/output-cache.ts
+++ b/src/cli/output-cache.ts
@@ -43,7 +43,7 @@ export function resetCachedCodeQlVersion(): void {
  * Returns the path to the temporary file that backs the
  * on-disk cache of CLI responses between workflow steps.
  */
-function getCommandCacheFilePath(env: Env): string {
+export function getCommandCacheFilePath(env: Env): string {
   return path.join(getTemporaryDirectory(env), COMMAND_CACHE_FILENAME);
 }
 

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -22,6 +22,7 @@ import {
   getTotalCacheSize,
   shouldRestoreCache,
 } from "./caching-utils";
+import { getCommandCacheFilePath } from "./cli/output-cache";
 import { CodeQL } from "./codeql";
 import { getConfigFileInput } from "./config/file";
 import { ComputedInput, getToolsInput } from "./config/inputs";
@@ -294,6 +295,18 @@ async function run(
       throw new ConfigurationError(
         `The 'init' action should not be run in the same workflow as 'setup-codeql'.`,
       );
+    }
+
+    // Delete the CLI output-cache file if it exists, to avoid
+    // accidentally reusing a stale version from a previous run.
+    try {
+      fs.unlinkSync(getCommandCacheFilePath(actionState.env));
+    } catch (e: any) {
+      if (e?.code !== "ENOENT") {
+        logger.warning(
+          `Cannot delete CLI-cache file ${getCommandCacheFilePath(actionState.env)}: ${e}`,
+        );
+      }
     }
 
     // Get the computed `tools` input.


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
                      If necessary, link to this PR from an internal issue and include further details there.

    Everyone: Include a summary of the context of this change, what it aims to accomplish, and why you
              chose the approach you did if applicable. Indicate any open questions you want to answer
              during the review process and anything you want reviewers to pay particular attention to.

    See https://github.com/github/codeql-action/blob/main/CONTRIBUTING.md for additional information.
-->

The CLI output-cache file, which was introduced in #4081, is not meant to be used between runs—only steps. On non-ephemeral (i.e. self-hosted) runners, if the temp directories are not cleared between runs, the Action may load a previous ("stale") cache file, which may lead to unexpected results if the CLI has changed.

To prevent that from happening, with this PR, the Action will proactively delete the cache file at the expected location early in the `init` step, if one exists.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

<!-- Delete options that don't apply. -->

- **Test repository** - This change will be tested on a test repository before merging.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

<!-- Delete strategies that don't apply. -->

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

<!-- Delete options that don't apply. -->

- **Telemetry** - I rely on existing telemetry or have made changes to the telemetry.
    - **Alerts** - New or existing monitors will trip if something goes wrong with this change.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
