### PR TITLE
Improve CodeQL tools download time telemetry

### DIFF
--- a/lib/entry-points.js
+++ b/lib/entry-points.js
@@ -151503,10 +151503,10 @@ async function downloadAndExtract(codeqlURL, compressionMethod, dest, authorizat
   logger.info(
     `Downloading CodeQL tools from ${codeqlURL} . This may take a while.`
   );
+  const startTime = import_perf_hooks2.performance.now();
   try {
     if (compressionMethod === "zstd" && process.platform === "linux") {
       logger.info(`Streaming the extraction of the CodeQL bundle.`);
-      const toolsInstallStart = import_perf_hooks2.performance.now();
       await downloadAndExtractZstdWithStreaming(
         codeqlURL,
         dest,
@@ -151515,15 +151515,13 @@ async function downloadAndExtract(codeqlURL, compressionMethod, dest, authorizat
         tarVersion,
         logger
       );
-      const combinedDurationMs = Math.round(
-        import_perf_hooks2.performance.now() - toolsInstallStart
-      );
+      const totalDurationMs = Math.round(import_perf_hooks2.performance.now() - startTime);
       logger.info(
         `Finished downloading and extracting CodeQL bundle to ${dest} (${formatDuration(
-          combinedDurationMs
+          totalDurationMs
         )}).`
       );
-      return {};
+      return { totalDurationMs };
     }
   } catch (e) {
     core11.warning(
@@ -151565,7 +151563,11 @@ async function downloadAndExtract(codeqlURL, compressionMethod, dest, authorizat
   } finally {
     await cleanUpPath(archivedBundlePath, "CodeQL bundle archive", logger);
   }
-  return { downloadDurationMs };
+  return {
+    downloadDurationMs,
+    extractionDurationMs,
+    totalDurationMs: Math.round(import_perf_hooks2.performance.now() - startTime)
+  };
 }
 async function downloadAndExtractZstdWithStreaming(codeqlURL, dest, authorization, headers, tarVersion, logger) {
   fs13.mkdirSync(dest, { recursive: true });
@@ -161677,6 +161679,12 @@ async function sendCompletedStatusReport2(startedAt, config, configFile, toolsIn
   if (toolsDownloadStatusReport?.downloadDurationMs !== void 0) {
     initToolsDownloadFields.tools_download_duration_ms = toolsDownloadStatusReport.downloadDurationMs;
   }
+  if (toolsDownloadStatusReport?.extractionDurationMs !== void 0) {
+    initToolsDownloadFields.tools_extraction_duration_ms = toolsDownloadStatusReport.extractionDurationMs;
+  }
+  if (toolsDownloadStatusReport?.totalDurationMs !== void 0) {
+    initToolsDownloadFields.tools_total_duration_ms = toolsDownloadStatusReport.totalDurationMs;
+  }
   if (toolsFeatureFlagsValid !== void 0) {
     initToolsDownloadFields.tools_feature_flags_valid = toolsFeatureFlagsValid;
   }
@@ -162696,6 +162704,12 @@ async function sendCompletedStatusReport3(startedAt, toolsInput, toolsDownloadSt
   const initToolsDownloadFields = {};
   if (toolsDownloadStatusReport?.downloadDurationMs !== void 0) {
     initToolsDownloadFields.tools_download_duration_ms = toolsDownloadStatusReport.downloadDurationMs;
+  }
+  if (toolsDownloadStatusReport?.extractionDurationMs !== void 0) {
+    initToolsDownloadFields.tools_extraction_duration_ms = toolsDownloadStatusReport.extractionDurationMs;
+  }
+  if (toolsDownloadStatusReport?.totalDurationMs !== void 0) {
+    initToolsDownloadFields.tools_total_duration_ms = toolsDownloadStatusReport.totalDurationMs;
   }
   if (toolsFeatureFlagsValid !== void 0) {
     initToolsDownloadFields.tools_feature_flags_valid = toolsFeatureFlagsValid;

--- a/src/init-action.ts
+++ b/src/init-action.ts
@@ -174,6 +174,14 @@ async function sendCompletedStatusReport(
     initToolsDownloadFields.tools_download_duration_ms =
       toolsDownloadStatusReport.downloadDurationMs;
   }
+  if (toolsDownloadStatusReport?.extractionDurationMs !== undefined) {
+    initToolsDownloadFields.tools_extraction_duration_ms =
+      toolsDownloadStatusReport.extractionDurationMs;
+  }
+  if (toolsDownloadStatusReport?.totalDurationMs !== undefined) {
+    initToolsDownloadFields.tools_total_duration_ms =
+      toolsDownloadStatusReport.totalDurationMs;
+  }
   if (toolsFeatureFlagsValid !== undefined) {
     initToolsDownloadFields.tools_feature_flags_valid = toolsFeatureFlagsValid;
   }

--- a/src/setup-codeql-action.ts
+++ b/src/setup-codeql-action.ts
@@ -85,6 +85,14 @@ async function sendCompletedStatusReport(
     initToolsDownloadFields.tools_download_duration_ms =
       toolsDownloadStatusReport.downloadDurationMs;
   }
+  if (toolsDownloadStatusReport?.extractionDurationMs !== undefined) {
+    initToolsDownloadFields.tools_extraction_duration_ms =
+      toolsDownloadStatusReport.extractionDurationMs;
+  }
+  if (toolsDownloadStatusReport?.totalDurationMs !== undefined) {
+    initToolsDownloadFields.tools_total_duration_ms =
+      toolsDownloadStatusReport.totalDurationMs;
+  }
   if (toolsFeatureFlagsValid !== undefined) {
     initToolsDownloadFields.tools_feature_flags_valid = toolsFeatureFlagsValid;
   }

--- a/src/setup-codeql.test.ts
+++ b/src/setup-codeql.test.ts
@@ -234,6 +234,7 @@ test.serial(
       codeqlFolder: "codeql",
       statusReport: {
         downloadDurationMs: 200,
+        totalDurationMs: 300,
       },
       toolsVersion: LINKED_CLI_VERSION.cliVersion,
     });
@@ -286,6 +287,7 @@ test.serial(
       codeqlFolder: "codeql",
       statusReport: {
         downloadDurationMs: 200,
+        totalDurationMs: 300,
       },
       toolsVersion: expectedVersion,
     });

--- a/src/status-report.ts
+++ b/src/status-report.ts
@@ -620,8 +620,21 @@ export interface InitWithConfigStatusReport extends InitStatusReport {
 
 /** Fields of the init status report populated when the tools source is `download`. */
 export interface InitToolsDownloadFields {
-  /** Time taken to download the bundle, in milliseconds. */
+  /**
+   * Time taken to download the bundle, in milliseconds. Not populated when the bundle is downloaded
+   * and extracted concurrently.
+   */
   tools_download_duration_ms?: number;
+  /**
+   * Time taken to extract the bundle, in milliseconds. Not populated when the bundle is downloaded
+   * and extracted concurrently.
+   */
+  tools_extraction_duration_ms?: number;
+  /**
+   * Total time taken to make the bundle available on disk, in milliseconds. This includes any time
+   * spent on a streaming attempt that failed and fell back to downloading before extracting.
+   */
+  tools_total_duration_ms?: number;
   /**
    * Whether the relevant tools dotcom feature flags have been misconfigured.
    * Only populated if we attempt to determine the default version based on the dotcom feature flags. */

--- a/src/tools-download.test.ts
+++ b/src/tools-download.test.ts
@@ -15,7 +15,7 @@ import { withTmpDir } from "./util";
 setupTests(test);
 
 test.serial(
-  "downloadAndExtract reports the duration when downloading before extracting",
+  "downloadAndExtract reports the durations when downloading before extracting",
   async (t) => {
     await withTmpDir(async (tmpDir) => {
       const archivePath = path.join(tmpDir, "codeql-bundle.tar.gz");
@@ -34,6 +34,8 @@ test.serial(
       );
 
       t.assert(Number.isInteger(statusReport.downloadDurationMs));
+      t.assert(Number.isInteger(statusReport.extractionDurationMs));
+      t.assert(Number.isInteger(statusReport.totalDurationMs));
     });
   },
 );
@@ -67,6 +69,7 @@ test.serial(
       );
 
       t.assert(Number.isInteger(statusReport.downloadDurationMs));
+      t.assert(Number.isInteger(statusReport.totalDurationMs));
       t.true(request.isDone());
       t.false(extractTarZst.called);
       t.true(downloadTool.calledOnce);
@@ -76,7 +79,7 @@ test.serial(
 );
 
 test.serial(
-  "downloadAndExtract omits the download duration when streaming extraction",
+  "downloadAndExtract reports only the total duration when streaming extraction",
   async (t) => {
     await withTmpDir(async (tmpDir) => {
       sinon.stub(process, "platform").value("linux");
@@ -106,7 +109,9 @@ test.serial(
         getRunnerLogger(true),
       );
 
-      t.deepEqual(statusReport, {});
+      t.assert(Number.isInteger(statusReport.totalDurationMs));
+      t.is(statusReport.downloadDurationMs, undefined);
+      t.is(statusReport.extractionDurationMs, undefined);
       t.false(downloadTool.called);
       t.true(extractTarZst.calledOnce);
       t.true(request.isDone());

--- a/src/tools-download.ts
+++ b/src/tools-download.ts
@@ -31,7 +31,21 @@ const STREAMING_STALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const TOOLCACHE_TOOL_NAME = "CodeQL";
 
 export type ToolsDownloadStatusReport = {
+  /**
+   * Time spent downloading the bundle, in milliseconds. Not populated when the bundle is downloaded
+   * and extracted concurrently, since the two cannot be told apart.
+   */
   downloadDurationMs?: number;
+  /**
+   * Time spent extracting the bundle, in milliseconds. Not populated when the bundle is downloaded
+   * and extracted concurrently, since the two cannot be told apart.
+   */
+  extractionDurationMs?: number;
+  /**
+   * Total time taken to make the bundle available on disk, in milliseconds. This includes any time
+   * spent on a streaming attempt that failed and fell back to downloading before extracting.
+   */
+  totalDurationMs: number;
 };
 
 export async function downloadAndExtract(
@@ -47,11 +61,12 @@ export async function downloadAndExtract(
     `Downloading CodeQL tools from ${codeqlURL} . This may take a while.`,
   );
 
+  const startTime = performance.now();
+
   try {
     if (compressionMethod === "zstd" && process.platform === "linux") {
       logger.info(`Streaming the extraction of the CodeQL bundle.`);
 
-      const toolsInstallStart = performance.now();
       await downloadAndExtractZstdWithStreaming(
         codeqlURL,
         dest,
@@ -61,16 +76,14 @@ export async function downloadAndExtract(
         logger,
       );
 
-      const combinedDurationMs = Math.round(
-        performance.now() - toolsInstallStart,
-      );
+      const totalDurationMs = Math.round(performance.now() - startTime);
       logger.info(
         `Finished downloading and extracting CodeQL bundle to ${dest} (${formatDuration(
-          combinedDurationMs,
+          totalDurationMs,
         )}).`,
       );
 
-      return {};
+      return { totalDurationMs };
     }
   } catch (e) {
     core.warning(
@@ -98,7 +111,7 @@ export async function downloadAndExtract(
     )}).`,
   );
 
-  let extractionDurationMs: number;
+  let extractionDurationMs: number | undefined;
 
   try {
     logger.info("Extracting CodeQL bundle.");
@@ -120,7 +133,11 @@ export async function downloadAndExtract(
     await cleanUpPath(archivedBundlePath, "CodeQL bundle archive", logger);
   }
 
-  return { downloadDurationMs };
+  return {
+    downloadDurationMs,
+    extractionDurationMs,
+    totalDurationMs: Math.round(performance.now() - startTime),
+  };
 }
 
 async function downloadAndExtractZstdWithStreaming(


### PR DESCRIPTION
We are considering shipping trimmed CodeQL bundles containing the CLI and a single language, as an alternative to today's combined per-platform bundle. This PR establishes a baseline for how long the current bundle takes, so the effect can be measured.

`downloadAndExtract` has two paths. The streaming path (Zstandard on Linux, which most hosted runners take) downloads and extracts concurrently, and returned an empty status report — so the dominant path reported no timings at all. The download-then-extract path reported the download duration and only logged the extraction duration.

| Field | When populated | Meaning |
| --- | --- | --- |
| `tools_download_duration_ms` | Download-then-extract only | Time spent downloading. Unchanged. |
| `tools_extraction_duration_ms` | Download-then-extract only | Time spent extracting. |
| `tools_total_duration_ms` | Always | Wall-clock for the whole operation. |

`tools_total_duration_ms` is the field to compare across the change, being the only one populated on both paths. The component fields are left unpopulated on the streaming path, where downloading and extracting overlap and cannot be told apart. `tools_download_duration_ms` keeps its existing meaning so earlier data remains comparable.

The total is wall-clock across the whole call, so where streaming fails it includes the failed attempt and its cleanup. Those runs stay identifiable: on Linux, a report containing `tools_download_duration_ms` is one where streaming failed.

Compressed bundle size is deliberately not reported. For the common case it is a function of CLI version and platform, so it is already knowable from the release assets — and the size saving is the part of this that can be predicted, whereas the durations are not.

No changelog entry, as there is no user-facing change.

### Risk assessment

- **Low risk:** telemetry only. No change to what is downloaded, from where, or in what order, and no new failure modes on the download path.

#### Which use cases does this change impact?

Workflow types:

- **Advanced setup** - Impacts users who have custom CodeQL workflows.
- **Managed** - Impacts users with `dynamic` workflows (Default Setup, Code Quality, ...).

Products:

- **Code Scanning** - The changes impact analyses when `analysis-kinds: code-scanning`.
- **Code Quality** - The changes impact analyses when `analysis-kinds: code-quality`.
- **Other first-party** - The changes impact other first-party analyses.

Environments:

- **Dotcom** - Impacts CodeQL workflows on `github.com` and/or GitHub Enterprise Cloud with Data Residency.
- **GHES** - Impacts CodeQL workflows on GitHub Enterprise Server.

#### How did/will you validate this change?

- **Unit tests** - `src/tools-download.test.ts` covers both paths and the fallback from streaming to download-then-extract.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Rollback** - Change can only be disabled by rolling back the release or releasing a new version with a fix.

#### How will you know if something goes wrong after this change is released?

- **Telemetry** - This change is itself a telemetry change; the new fields appearing with plausible values is the signal that it works.

#### Are there any special considerations for merging or releasing this change?

- **Special considerations** - This change is only useful if it is released before any change to how the bundle is packaged, since its purpose is to establish a baseline.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
