### PR TITLE
Document merge-commit requirement for release PRs

### DIFF
--- a/.github/instructions/release-merge.instructions.md
+++ b/.github/instructions/release-merge.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "CHANGELOG.md,src/defaults.json,lib/defaults.json,src/api-compatibility.json"
+---
+
+# Merging release, mergeback, and backport PRs
+
+The release process creates a cascade of PRs (`main` → `releases/vN`, then
+`releases/vN` → `main` mergeback, then `releases/vN` → `releases/v(N-1)`
+backport). These PRs reliably touch `CHANGELOG.md`, `src/defaults.json` /
+`lib/defaults.json` (bundle/CLI version bump), and `src/api-compatibility.json`.
+
+Such PRs **must be merged with a merge commit**. Never squash or rebase, as
+that breaks the branch linkage the release automation relies on.
+
+When arming auto-merge on these PRs, use `--merge` (e.g. `gh pr merge --merge`),
+not `--squash` or `--rebase`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,13 @@ Here are a few things you can do that will increase the likelihood of your pull 
     This workflow goes through the pull requests that have been merged to `main` since the last release, creates a changelog, then opens a pull request to merge the changes since the last release into the `releases/v3` release branch.
 
     You can start a release by triggering this workflow via [workflow dispatch](https://github.com/github/codeql-action/actions/workflows/update-release-branch.yml).
-1. The workflow run will open a pull request titled "Merge main into releases/v3". Follow the steps on the checklist in the pull request. Once you've checked off all but the last two of these, approve the PR and automerge it.
+1. The workflow run will open a pull request titled "Merge main into releases/v3". Follow the steps on the checklist in the pull request. Once you've checked off all but the last two of these, approve the PR and automerge it **with a merge commit** (`gh pr merge --merge`).
 1. When the "Merge main into releases/v3" pull request is merged into the `releases/v3` branch, a mergeback pull request to `main` will be automatically created. This mergeback pull request incorporates the changelog updates into `main`, tags the release using the merge commit of the "Merge main into releases/v3" pull request, and bumps the patch version of the CodeQL Action.
 1. If a backport to an older major version is required, a pull request targeting that version's branch will also be automatically created.
-1. Approve the mergeback and backport pull request (if applicable) and automerge them.
+1. Approve the mergeback and backport pull request (if applicable) and automerge them **with a merge commit** (`gh pr merge --merge`).
+
+    > [!NOTE]
+    > The release, mergeback, and backport pull requests must always be merged with a merge commit — **never squash or rebase**. The mergeback tags the release using the merge commit of the "Merge main into releases/v3" pull request, so squashing or rebasing breaks tagging and the branch linkage the release automation relies on.
 
 Once the mergeback and backport pull request have been merged, the release is complete.
 


### PR DESCRIPTION
<!--
    For GitHub staff: Remember that this is a public repository. Do not link to internal resources.
-->

The release process creates a cascade of PRs (`main` -> `releases/vN`, then the `releases/vN` -> `main` mergeback, then a `releases/vN` -> `releases/v(N-1)` backport). These must be merged with a **merge commit**: the mergeback tags the release using the merge commit of the "Merge main into releases/vN" PR, so squashing or rebasing breaks tagging and the branch linkage the release automation relies on. Today nothing in the repo states this, so it depends on whoever clicks merge remembering the right strategy.

This PR bakes the rule into two places:

- **`.github/instructions/release-merge.instructions.md`** (new) - a path-scoped Copilot instructions file with an `applyTo` glob targeting the files that reliably change in release/mergeback/backport PRs (`CHANGELOG.md`, `src/defaults.json`, `lib/defaults.json`, `src/api-compatibility.json`). It tells the agent to merge with a merge commit and arm auto-merge with `--merge`.
- **`CONTRIBUTING.md`** - the human-facing Releasing runbook. Both automerge steps now say to merge "with a merge commit (`gh pr merge --merge`)", plus a `> [!NOTE]` explaining why squash/rebase would break tagging.

Docs-only change; no behavior or code paths are affected.

### Risk assessment

- **Low risk:** Documentation only.

#### Which use cases does this change impact?

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **None** - Documentation-only change; no runtime behavior is affected.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

- **Other** - N/A, documentation-only change.

#### Are there any special considerations for merging or releasing this change?

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.