### PR TITLE
Analyze all supported languages in the Linux Arm64 check

### DIFF
--- a/.github/workflows/__linux-arm64.yml
+++ b/.github/workflows/__linux-arm64.yml
@@ -20,6 +20,11 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
+      dotnet-version:
+        type: string
+        description: The version of .NET to install
+        required: false
+        default: 9.x
       go-version:
         type: string
         description: The version of Go to install
@@ -27,6 +32,11 @@ on:
         default: '>=1.21.0'
   workflow_call:
     inputs:
+      dotnet-version:
+        type: string
+        description: The version of .NET to install
+        required: false
+        default: 9.x
       go-version:
         type: string
         description: The version of Go to install
@@ -37,7 +47,7 @@ defaults:
     shell: bash
 concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || false }}
-  group: linux-arm64-${{github.ref}}-${{inputs.go-version}}
+  group: linux-arm64-${{github.ref}}-${{inputs.dotnet-version}}-${{inputs.go-version}}
 jobs:
   linux-arm64:
     strategy:
@@ -56,6 +66,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: ${{ inputs.dotnet-version || '9.x' }}
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -70,21 +84,22 @@ jobs:
           setup-kotlin: 'true'
       - uses: ./../action/init
         with:
-          languages: javascript,python,go
+          languages: ${{ env.LANGUAGES }}
           tools: ${{ steps.prepare-test.outputs.tools-url }}
-      - name: Build Go code
-        run: go build main.go
+      - name: Build code
+        run: ./build.sh
       - uses: ./../action/analyze
         with:
           upload-database: false
       - name: Assert databases exist
         run: |
           cd "$RUNNER_TEMP/codeql_databases"
-          for lang in javascript python go; do
+          for lang in ${LANGUAGES//,/ }; do
             if [[ ! -d "$lang" ]]; then
               echo "Did not find a database for $lang"
               exit 1
             fi
           done
     env:
+      LANGUAGES: cpp,csharp,go,java,javascript,python,ruby
       CODEQL_ACTION_TEST_MODE: true

--- a/.github/workflows/__linux-arm64.yml
+++ b/.github/workflows/__linux-arm64.yml
@@ -99,6 +99,7 @@ jobs:
               echo "Did not find a database for $lang"
               exit 1
             fi
+            echo "Found database for $lang"
           done
     env:
       LANGUAGES: cpp,csharp,go,java,javascript,python,ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ See the [releases page](https://github.com/github/codeql-action/releases) for th
 
 ## [UNRELEASED]
 
-- The CodeQL Action now supports CodeQL releases that are compatible with Linux Arm64 and download the native `linux-arm64` CodeQL bundle when available. [#4072](https://github.com/github/codeql-action/pull/4072)
+- The CodeQL Action now supports CodeQL releases that are compatible with Linux Arm64 and downloads the native `linux-arm64` CodeQL bundle when available. [#4072](https://github.com/github/codeql-action/pull/4072)
 
 ## 4.37.9 - 26 Aug 2026
 

--- a/pr-checks/checks/linux-arm64.yml
+++ b/pr-checks/checks/linux-arm64.yml
@@ -31,4 +31,5 @@ steps:
           echo "Did not find a database for $lang"
           exit 1
         fi
+        echo "Found database for $lang"
       done

--- a/pr-checks/checks/linux-arm64.yml
+++ b/pr-checks/checks/linux-arm64.yml
@@ -9,20 +9,24 @@ operatingSystems:
 versions:
   - nightly-latest
 installGo: true
+installDotNet: true
+# The set of languages CodeQL supports on this platform, excluding Swift (macOS only).
+env:
+  LANGUAGES: cpp,csharp,go,java,javascript,python,ruby
 steps:
   - uses: ./../action/init
     with:
-      languages: javascript,python,go
+      languages: ${{ env.LANGUAGES }}
       tools: ${{ steps.prepare-test.outputs.tools-url }}
-  - name: Build Go code
-    run: go build main.go
+  - name: Build code
+    run: ./build.sh
   - uses: ./../action/analyze
     with:
       upload-database: false
   - name: Assert databases exist
     run: |
       cd "$RUNNER_TEMP/codeql_databases"
-      for lang in javascript python go; do
+      for lang in ${LANGUAGES//,/ }; do
         if [[ ! -d "$lang" ]]; then
           echo "Did not find a database for $lang"
           exit 1


### PR DESCRIPTION
Follow-up to #4072 (now merged), addressing @mbg's review comments on the Linux Arm64 end-to-end check.

- Analyze all languages CodeQL supports on Linux Arm64, excluding Swift (macOS only). The check previously only covered `javascript,python,go`; it now covers `cpp,csharp,go,java,javascript,python,ruby`, matching the "all languages excluding Swift" set already used by the multi-language autodetect check. Compiled languages are built via the shared `multi-language-repo` `build.sh` (which `prepare-test` swaps into the workspace), and `.NET` setup was added alongside the existing Go setup.
- De-duplicate the check's language list. It previously appeared twice (the `init` `languages:` input and the assert loop); both now read from a single `LANGUAGES` env var.
- Fix a CHANGELOG tense inconsistency: `download` -> `downloads`.

`pr-checks/checks/linux-arm64.yml` is a template, so `__linux-arm64.yml` was regenerated via `pr-checks/sync.sh` (only that generated workflow changed).

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Test only.

#### Which use cases does this change impact?

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **End-to-end tests** - The Linux Arm64 PR check exercises the changed template.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

- **Other** - The Linux Arm64 PR check would fail if a language failed to analyze on arm64.

#### Are there any special considerations for merging or releasing this change?

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
