### PR TITLE
Don't upload the ESLint SARIF from merge queue refs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -67,7 +67,12 @@ jobs:
 
       - name: Upload sarif
         uses: ./upload-sarif
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 24
+        # The merge queue deletes its `gh-readonly-queue` ref as soon as the queue entry resolves,
+        # so uploading against it races with that deletion. Both the `merge_group` run and the
+        # paired `push` run that the queue branch creates use that ref, so gate on the ref itself
+        # rather than the event. The same results are uploaded by the `pull_request` run and again
+        # by the `push` run on `main`.
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 24 && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
         with:
           sarif_file: eslint.sarif
           category: eslint


### PR DESCRIPTION
The `Unit Tests` job uploads its ESLint SARIF via `upload-sarif`, gated only on OS and Node version. `PR Checks` runs on `merge_group`, and also on `push` for the `gh-readonly-queue` branch that the merge queue creates, so in both cases the upload targets a ref that GitHub deletes as soon as the queue entry resolves. When the upload loses that race the code scanning API returns 404 and the step fails.

This accounts for every merge queue failure of `PR Checks` in the visible run history — five of them, going back to May.

Gate the step on the ref rather than the event, since both the `merge_group` run and the paired `push` run use the ephemeral ref. Nothing is lost: alerts on a queue ref are never surfaced, and the same results are uploaded by the `pull_request` run and again by the `push` run on `main`.

`codeql.yml` already skips its uploads for merge queue runs. It only needs the event check because its `push` trigger is limited to `main` and `releases/v*`.

Lint enforcement is unaffected — `lint-ci` still fails the job on any lint error. Only the alert upload is skipped.