### PR TITLE
Run slow macOS checks on larger runners

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -56,7 +56,7 @@ jobs:
         include:
           - os: ubuntu-latest
             version: nightly-latest
-          - os: macos-latest
+          - os: macos-latest-xlarge
             version: nightly-latest
           - os: windows-latest
             version: nightly-latest

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -54,11 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-latest-xlarge
             version: linked
-          - os: macos-latest
+          - os: macos-latest-xlarge
             version: default
-          - os: macos-latest
+          - os: macos-latest-xlarge
             version: nightly-latest
     name: Swift analysis using a custom build command
     if: github.triggering_actor != 'dependabot[bot]'

--- a/pr-checks/checks/all-platform-bundle.yml
+++ b/pr-checks/checks/all-platform-bundle.yml
@@ -2,7 +2,8 @@ name: "All-platform bundle"
 description: "Tests using an all-platform CodeQL Bundle"
 operatingSystems:
   - ubuntu
-  - macos
+  - os: macos
+    runner-image: macos-latest-xlarge
   - windows
 versions:
   - nightly-latest

--- a/pr-checks/checks/swift-custom-build.yml
+++ b/pr-checks/checks/swift-custom-build.yml
@@ -5,7 +5,8 @@ versions:
   - default
   - nightly-latest
 operatingSystems:
-  - macos
+  - os: macos
+    runner-image: macos-latest-xlarge
 installGo: true
 installDotNet: true
 env:


### PR DESCRIPTION
Move the all-platform bundle and Swift custom-build macOS checks to `macos-latest-xlarge`. These jobs are currently on the critical path for PR checks and the merge queue.

The four affected required check names need updating.