### PR TITLE
Improve workflow dispatch for Dependabot PRs

### DIFF
--- a/.github/workflows/__all-platform-bundle.yml
+++ b/.github/workflows/__all-platform-bundle.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -61,7 +66,9 @@ jobs:
           - os: windows-latest
             version: nightly-latest
     name: All-platform bundle
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__analysis-kinds.yml
+++ b/.github/workflows/__analysis-kinds.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -59,7 +64,9 @@ jobs:
             version: nightly-latest
             analysis-kinds: risk-assessment
     name: Analysis kinds
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -57,7 +62,9 @@ jobs:
           - os: ubuntu-latest
             version: default
     name: "Analyze: 'ref' and 'sha' from inputs"
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__autobuild-action.yml
+++ b/.github/workflows/__autobuild-action.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -51,7 +56,9 @@ jobs:
           - os: windows-latest
             version: linked
     name: autobuild-action
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
+++ b/.github/workflows/__autobuild-direct-tracing-with-working-dir.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -53,7 +58,9 @@ jobs:
           - os: windows-latest
             version: nightly-latest
     name: Autobuild direct tracing (custom working directory)
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__autobuild-working-dir.yml
+++ b/.github/workflows/__autobuild-working-dir.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: Autobuild working directory
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__build-mode-autobuild.yml
+++ b/.github/workflows/__build-mode-autobuild.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -53,7 +58,9 @@ jobs:
           - os: windows-latest
             version: nightly-latest
     name: Build mode autobuild
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__build-mode-manual.yml
+++ b/.github/workflows/__build-mode-manual.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -57,7 +62,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Build mode manual
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__build-mode-none.yml
+++ b/.github/workflows/__build-mode-none.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -39,7 +44,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Build mode none
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__build-mode-rollback.yml
+++ b/.github/workflows/__build-mode-rollback.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Build mode rollback
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__bundle-from-nightly.yml
+++ b/.github/workflows/__bundle-from-nightly.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: 'Bundle: From nightly'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__bundle-from-toolcache.yml
+++ b/.github/workflows/__bundle-from-toolcache.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: toolcache
     name: 'Bundle: From toolcache'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__bundle-toolcache.yml
+++ b/.github/workflows/__bundle-toolcache.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: windows-latest
             version: linked
     name: 'Bundle: Caching checks'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__cleanup-db-cluster-dir.yml
+++ b/.github/workflows/__cleanup-db-cluster-dir.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: Clean up database cluster directory
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__config-export.yml
+++ b/.github/workflows/__config-export.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -39,7 +44,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Config export
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__config-input.yml
+++ b/.github/workflows/__config-input.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: Config input
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__cpp-deptrace-disabled.yml
+++ b/.github/workflows/__cpp-deptrace-disabled.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'C/C++: disabling autoinstalling dependencies (Linux)'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
+++ b/.github/workflows/__cpp-deptrace-enabled-on-macos.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -39,7 +44,9 @@ jobs:
           - os: macos-latest
             version: nightly-latest
     name: 'C/C++: autoinstalling dependencies is skipped (macOS)'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__cpp-deptrace-enabled.yml
+++ b/.github/workflows/__cpp-deptrace-enabled.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'C/C++: autoinstalling dependencies (Linux)'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__diagnostics-export.yml
+++ b/.github/workflows/__diagnostics-export.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -39,7 +44,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Diagnostic export
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__export-file-baseline-information.yml
+++ b/.github/workflows/__export-file-baseline-information.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -61,7 +66,9 @@ jobs:
           - os: windows-latest
             version: nightly-latest
     name: Export file baseline information
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: Extractor ram and threads options test
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__global-proxy.yml
+++ b/.github/workflows/__global-proxy.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -39,7 +44,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Proxy test
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -59,7 +64,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'Go: Custom queries'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-diagnostic.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -47,7 +52,9 @@ jobs:
           - os: ubuntu-latest
             version: default
     name: 'Go: diagnostic when Go is changed after init step'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround-no-file-program.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -47,7 +52,9 @@ jobs:
           - os: ubuntu-latest
             version: default
     name: 'Go: diagnostic when `file` is not installed'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__go-indirect-tracing-workaround.yml
+++ b/.github/workflows/__go-indirect-tracing-workaround.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -47,7 +52,9 @@ jobs:
           - os: ubuntu-latest
             version: default
     name: 'Go: workaround for indirect tracing'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__go-tracing-autobuilder.yml
+++ b/.github/workflows/__go-tracing-autobuilder.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -67,7 +72,9 @@ jobs:
           - os: macos-latest
             version: nightly-latest
     name: 'Go: tracing with autobuilder step'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__go-tracing-custom-build-steps.yml
+++ b/.github/workflows/__go-tracing-custom-build-steps.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -67,7 +72,9 @@ jobs:
           - os: macos-latest
             version: nightly-latest
     name: 'Go: tracing with custom build steps'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__go-tracing-legacy-workflow.yml
+++ b/.github/workflows/__go-tracing-legacy-workflow.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -67,7 +72,9 @@ jobs:
           - os: macos-latest
             version: nightly-latest
     name: 'Go: tracing with legacy workflow'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__init-with-registries.yml
+++ b/.github/workflows/__init-with-registries.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'Packaging: Download using registries'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Custom source root
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__job-run-uuid-sarif.yml
+++ b/.github/workflows/__job-run-uuid-sarif.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Job run UUID added to SARIF
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__language-aliases.yml
+++ b/.github/workflows/__language-aliases.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: Language aliases
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__linux-arm64.yml
+++ b/.github/workflows/__linux-arm64.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -57,7 +62,9 @@ jobs:
           - os: ubuntu-24.04-arm
             version: nightly-latest
     name: Linux Arm64
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__local-bundle.yml
+++ b/.github/workflows/__local-bundle.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -57,7 +62,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: Local CodeQL bundle
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -91,7 +96,9 @@ jobs:
           - os: macos-latest-xlarge
             version: nightly-latest
     name: Multi-language repository
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__overlay-init-fallback.yml
+++ b/.github/workflows/__overlay-init-fallback.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -39,7 +44,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Overlay database init fallback
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__packaging-codescanning-config-inputs-js.yml
+++ b/.github/workflows/__packaging-codescanning-config-inputs-js.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -61,7 +66,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'Packaging: Config and input passed to the CLI'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -61,7 +66,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'Packaging: Config and input'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -61,7 +66,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'Packaging: Config file'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -61,7 +66,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: 'Packaging: Action input'
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -59,7 +64,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Remote config file
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__resolve-environment-action.yml
+++ b/.github/workflows/__resolve-environment-action.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Resolve environment
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: ubuntu-latest
             version: default
     name: RuboCop multi-language
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__ruby.yml
+++ b/.github/workflows/__ruby.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -47,7 +52,9 @@ jobs:
           - os: macos-latest
             version: nightly-latest
     name: Ruby analysis
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__rust.yml
+++ b/.github/workflows/__rust.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -45,7 +50,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Rust analysis
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -67,7 +72,9 @@ jobs:
           - os: macos-latest
             version: nightly-latest
     name: Split workflow
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__start-proxy.yml
+++ b/.github/workflows/__start-proxy.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: windows-latest
             version: linked
     name: Start proxy
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__submit-sarif-failure.yml
+++ b/.github/workflows/__submit-sarif-failure.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -41,7 +46,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Submit SARIF after failure
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/__swift-autobuild.yml
+++ b/.github/workflows/__swift-autobuild.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -37,7 +42,9 @@ jobs:
           - os: macos-latest-xlarge
             version: nightly-latest
     name: Swift analysis using autobuild
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__swift-custom-build.yml
+++ b/.github/workflows/__swift-custom-build.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -61,7 +66,9 @@ jobs:
           - os: macos-latest-xlarge
             version: nightly-latest
     name: Swift analysis using a custom build command
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -59,7 +64,9 @@ jobs:
           - os: ubuntu-latest
             version: nightly-latest
     name: Test unsetting environment variables
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -57,7 +62,9 @@ jobs:
           - os: ubuntu-latest
             version: default
     name: "Upload-sarif: 'ref' and 'sha' from inputs"
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__upload-sarif.yml
+++ b/.github/workflows/__upload-sarif.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -64,7 +69,9 @@ jobs:
             version: default
             analysis-kinds: code-scanning,code-quality
     name: Test different uses of `upload-sarif`
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -12,7 +12,12 @@ on:
     branches:
       - main
       - releases/v*
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -57,7 +62,9 @@ jobs:
           - os: ubuntu-latest
             version: linked
     name: Use a custom `checkout_path`
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: |-
+      (github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||
+      github.event.label.name == 'Rebuild: Unchanged'
     permissions:
       contents: read
       security-events: read

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
 
       - name: Remove label
         if: github.event_name == 'pull_request'
@@ -145,3 +145,14 @@ jobs:
           echo "Pushed a commit to rebuild the Action." \
             "Please approve running the PR checks." |
             gh pr comment --body-file - --repo github/codeql-action "$PR_NUMBER"
+
+      - name: "Add 'Rebuild: Unchanged' label"
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.push.outputs.changes != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit --repo github/codeql-action "$PR_NUMBER" \
+            --add-label "Rebuild: Unchanged"

--- a/pr-checks/sync.ts
+++ b/pr-checks/sync.ts
@@ -500,6 +500,13 @@ function getSetupSteps(checkSpecification: JobSpecification): {
 }
 
 /**
+ * Condition used to prevent jobs from running for Dependabot PRs
+ * to avoid unnecessary runs if the "Rebuild" workflow ends up
+ * changing the JavaScript bundles.
+ */
+const dependabotCheck = "github.triggering_actor != 'dependabot[bot]'";
+
+/**
  * Generates an Actions job from the `checkSpecification`.
  *
  * @param specDocument
@@ -572,7 +579,7 @@ function generateJob(
       },
     },
     name: checkSpecification.name,
-    if: "github.triggering_actor != 'dependabot[bot]'",
+    if: dependabotCheck,
     permissions: {
       contents: "read",
       "security-events": "read",
@@ -622,7 +629,7 @@ function generateValidationJob(
 
   const validationJob: Record<string, any> = {
     name: jobSpecification.name,
-    if: "github.triggering_actor != 'dependabot[bot]'",
+    if: dependabotCheck,
     needs: [checkName],
     permissions: {
       contents: "read",

--- a/pr-checks/sync.ts
+++ b/pr-checks/sync.ts
@@ -503,8 +503,12 @@ function getSetupSteps(checkSpecification: JobSpecification): {
  * Condition used to prevent jobs from running for Dependabot PRs
  * to avoid unnecessary runs if the "Rebuild" workflow ends up
  * changing the JavaScript bundles.
+ *
+ * Also allows jobs to run if a PR was labelled with "Rebuild: Unchanged".
  */
-const dependabotCheck = "github.triggering_actor != 'dependabot[bot]'";
+const jobRunCheck = new yaml.Scalar(
+  "(github.event.action != 'labeled' && github.triggering_actor != 'dependabot[bot]') ||\ngithub.event.label.name == 'Rebuild: Unchanged'",
+);
 
 /**
  * Generates an Actions job from the `checkSpecification`.
@@ -579,7 +583,7 @@ function generateJob(
       },
     },
     name: checkSpecification.name,
-    if: dependabotCheck,
+    if: jobRunCheck,
     permissions: {
       contents: "read",
       "security-events": "read",
@@ -629,7 +633,7 @@ function generateValidationJob(
 
   const validationJob: Record<string, any> = {
     name: jobSpecification.name,
-    if: dependabotCheck,
+    if: jobRunCheck,
     needs: [checkName],
     permissions: {
       contents: "read",
@@ -772,7 +776,9 @@ function main(): void {
         push: {
           branches: ["main", "releases/v*"],
         },
-        pull_request: {},
+        pull_request: {
+          types: ["opened", "synchronize", "reopened", "labeled"],
+        },
         merge_group: {
           types: ["checks_requested"],
         },


### PR DESCRIPTION
This is an experiment to improve workflow runs for Dependabot PRs in cases where the `Rebuild` workflow doesn't make any changes. The central idea is that the `Rebuild` workflow applies a label (`Rebuild: Unchanged`) to a PR it ran for, but where it made no changes. The label is then used as a trigger for the required workflows.

### Risk assessment

For internal use only. Please select the risk level of this change:

- **Low risk:** Changes are fully under feature flags, or have been fully tested and validated in pre-production environments and are highly observable, or are documentation or test only.

#### Which use cases does this change impact?

<!-- Delete options that don't apply. If in doubt, do not delete an option. -->

Environments:

- **Testing/None** - This change does not impact any CodeQL workflows in production.

#### How did/will you validate this change?

- **End-to-end tests** - I am depending on PR checks (i.e. tests in `pr-checks`).
- **Other** - Please provide details.

#### If something goes wrong after this change is released, what are the mitigation and rollback strategies?

- **Development/testing only** - This change cannot cause any failures in production.

#### How will you know if something goes wrong after this change is released?

- **Other** - Please provide details.

#### Are there any special considerations for merging or releasing this change?

<!--
    Consider whether this change depends on a different change in another repository that should be released first.
-->

- **No special considerations** - This change can be merged at any time.

### Merge / deployment checklist

- Confirm this change is backwards compatible with existing workflows.
- Consider adding a [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) entry for this change.
- Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) and docs have been updated if necessary.
